### PR TITLE
feat(application): emit startTimeout event

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -200,5 +200,11 @@ module.exports = appInfo => {
     limit: 50,
   };
 
+  /**
+   * emit `startTimeout` if worker don't ready after `workerStartTimeout` ms
+   * @member {Number} Config.workerStartTimeout
+   */
+  exports.workerStartTimeout = 10 * 60 * 1000;
+
   return exports;
 };

--- a/lib/egg.js
+++ b/lib/egg.js
@@ -32,6 +32,7 @@ class EggApplication extends EggCore {
     this.messenger = new Messenger();
 
     this.dumpConfig();
+    this._setupTimeoutTimer();
 
     // 开始启动
     this.console.info('[egg:core] App root: %s', this.baseDir);
@@ -215,6 +216,15 @@ class EggApplication extends EggCore {
   get [EGG_PATH]() {
     return path.join(__dirname, '..');
   }
+
+  _setupTimeoutTimer() {
+    const startTimeoutTimer = setTimeout(() => {
+      this.logger.error(`${this.type} still doesn't ready after ${this.config.workerStartTimeout} ms.`);
+      this.emit('startTimeout');
+    }, this.config.workerStartTimeout);
+    this.ready(() => clearTimeout(startTimeoutTimer));
+  }
+
 
   /**
    * 关闭 app 上的所有事件监听

--- a/test/fixtures/apps/app-start-timeout/app.js
+++ b/test/fixtures/apps/app-start-timeout/app.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function(app) {
+  const done = app.readyCallback('app-timeout');
+  setTimeout(done, 30000);
+};

--- a/test/fixtures/apps/app-start-timeout/config/config.default.js
+++ b/test/fixtures/apps/app-start-timeout/config/config.default.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.workerStartTimeout = 1000;

--- a/test/fixtures/apps/app-start-timeout/package.json
+++ b/test/fixtures/apps/app-start-timeout/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "app-start-timeout"
+}

--- a/test/lib/application.test.js
+++ b/test/lib/application.test.js
@@ -84,6 +84,16 @@ describe('test/lib/application.test.js', () => {
       called.should.equal(true);
     });
   });
+
+  describe('app start timeout', function() {
+    it('should emit `startTimeout` event', function(done) {
+      const baseDir = path.join(__dirname, '../fixtures/apps/app-start-timeout');
+      const application = new Application({
+        baseDir,
+      });
+      application.once('startTimeout', done);
+    });
+  });
 });
 
 function createApplication(options) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

emit startTimeout event if app don't ready after `config.workerStartTimeout` ms.