### PR TITLE
feat: print error to console on unittest env

### DIFF
--- a/config/config.local.js
+++ b/config/config.local.js
@@ -2,13 +2,11 @@
 
 module.exports = {
   logger: {
-    // 开发环境，将 INFO 以上级别的应用日志和 WARN 以上级别的系统日志输出到 stdout
     level: 'DEBUG',
     consoleLevel: 'INFO',
     coreLogger: {
       consoleLevel: 'WARN',
     },
-    // 在 local 或者 unittest 环境下，默认不缓存日志，直接写入磁盘
     buffer: false,
   },
 };

--- a/config/config.unittest.js
+++ b/config/config.unittest.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   logger: {
-    // 默认不缓存日志，直接写入磁盘
     consoleLevel: 'WARN',
     buffer: false,
   },

--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -6,16 +6,18 @@ module.exports = function createLoggers(app) {
   const loggerConfig = app.config.logger;
   loggerConfig.type = app.type;
 
-  // prod 环境强制配置 INFO
   if (app.config.env === 'prod' && loggerConfig.level === 'DEBUG') {
     loggerConfig.level = 'INFO';
   }
 
   const loggers = new Loggers(app.config);
 
-  // 启动成功了，所有日志不输出到终端，
-  // 除本地环境，本地环境还是可以根据 consoleLevel 控制日志
-  app.ready(() => app.config.env !== 'local' && loggers.disableConsole());
+  // won't print to console after started, except for local and unittest
+  app.ready(() => {
+    if (app.config.env !== 'local' && app.config.env !== 'unittest') {
+      loggers.disableConsole();
+    }
+  });
   loggers.coreLogger.info('[egg:logger] init all loggers with options: %j', loggerConfig);
 
   return loggers;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

logger

##### Description of change
<!-- Provide a description of the change below this comment. -->

consoleLevel on unittest is WARN, so it should be print,
but egg disable console after app ready.

so enable console on unittest env

Closes eggjs/egg#127