### PR TITLE
refactor: use logger.close, .end is deprecated

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -240,7 +240,7 @@ class EggApplication extends EggCore {
    */
   close() {
     for (const logger of this.loggers.values()) {
-      logger.end();
+      logger.close();
     }
     this.messenger.close();
     process.removeListener('unhandledRejection', this._unhandledRejectionHandler);

--- a/test/app/extend/context.test.js
+++ b/test/app/extend/context.test.js
@@ -18,7 +18,7 @@ describe('test/app/extend/context.test.js', () => {
 
     it('env=local: level => debug', function* () {
       mm.env('local');
-      mm(process.env, 'EGG_LOG', 'none');
+      mm.consoleLevel('NONE');
       app = utils.app('apps/demo', { cache: false });
       yield app.ready();
       const logdir = app.config.logger.dir;
@@ -46,6 +46,7 @@ describe('test/app/extend/context.test.js', () => {
 
     it('env=unittest: level => info', function* () {
       mm.env('unittest');
+      mm.consoleLevel('NONE');
       app = utils.app('apps/demo', { cache: false });
       yield app.ready();
       const logdir = app.config.logger.dir;
@@ -81,6 +82,7 @@ describe('test/app/extend/context.test.js', () => {
 
     it('env=prod: level => info', function* () {
       mm.env('unittest');
+      mm.consoleLevel('NONE');
       app = utils.app('apps/demo', { cache: false });
       yield app.ready();
       const logdir = app.config.logger.dir;
@@ -375,6 +377,7 @@ describe('test/app/extend/context.test.js', () => {
     });
 
     it('should run background task error', function* () {
+      mm.consoleLevel('NONE');
       yield request(app.callback())
         .get('/error')
         .expect(200)

--- a/test/fixtures/apps/agent-app/plugins/mock-client/mock_client.js
+++ b/test/fixtures/apps/agent-app/plugins/mock-client/mock_client.js
@@ -51,7 +51,7 @@ class MockClient extends EventEmitter {
   }
 
   * getTimeout() {
-    yield sleep(5000);
+    yield sleep(6000);
     return 'timeout';
   }
 

--- a/test/lib/agent.test.js
+++ b/test/lib/agent.test.js
@@ -65,7 +65,6 @@ describe('test/lib/agent.test.js', () => {
     let app;
     before(() => {
       app = utils.cluster('apps/agent-throw');
-      app.debug();
       return app.ready();
     });
     after(() => app.close());


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

logger

##### Description of change
<!-- Provide a description of the change below this comment. -->
