### PR TITLE
refactor: remove ctx.getCookie, ctx.setCookie and ctx.deleteCookie

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -149,47 +149,6 @@ const proto = module.exports = {
   },
 
   /**
-   * 写 Cookie
-   * @method Cookie#setCookie
-   * @param {String} name  cookie name
-   * @param {String} value cookie value
-   * @param {Object} opts  cookie options
-   * - {String}  domain    cookie domain, default is `ctx.hostname`
-   * - {String}  path      cookie path, default is '/'
-   * - {Boolean} encrypt   encrypt cookie or not, default is false
-   * - {Boolean} httpOnly  http only cookie or not, default is true
-   * - {Date}    expires   cookie's expiration date, default is expires at the end of session.
-   * @return {Context} koa context
-   */
-  setCookie(name, value, opts) {
-    this.cookies.set(name, value, opts);
-    return this;
-  },
-
-  /**
-   * 读取 Cookie
-   * @method Cookie#getCookie
-   * @param {String} name - Cookie key
-   * @param {Object} opts  cookie options
-   * @return {String} cookie value
-   */
-  getCookie(name, opts) {
-    return this.cookies.get(name, opts);
-  },
-
-  /**
-   * 删除 Cookie
-   * @method Cookie#deleteCookie
-   * @param {String} name - Cookie key
-   * @param {Object} opts  cookie options
-   * @return {Context} koa context
-   */
-  deleteCookie(name, opts) {
-    this.setCookie(name, null, opts);
-    return this;
-  },
-
-  /**
    * Wrap app.loggers with context infomation,
    * if a custom logger is defined by naming aLogger, then you can `ctx.getLogger('aLogger')`
    * @param {String} name - logger name

--- a/examples/cookie/app/controller/forget.js
+++ b/examples/cookie/app/controller/forget.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = function* () {
-  this.deleteCookie('remember');
+  this.cookies.set('remember', null);
   this.redirect('/');
 };

--- a/examples/cookie/app/controller/home.js
+++ b/examples/cookie/app/controller/home.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function* () {
-  if (this.getCookie('remember')) {
+  if (this.cookies.get('remember')) {
     this.body = '<p>Remembered :). Click to <a href="/forget">forget</a>!.</p>';
     return;
   }

--- a/examples/cookie/app/controller/remember.js
+++ b/examples/cookie/app/controller/remember.js
@@ -2,6 +2,6 @@
 
 module.exports = function* () {
   const minute = 60000;
-  if (this.request.body.remember) this.setCookie('remember', 1, { maxAge: minute });
+  if (this.request.body.remember) this.cookies.set('remember', 1, { maxAge: minute });
   this.redirect('/');
 };

--- a/test/fixtures/apps/demo/app/controller/hello.js
+++ b/test/fixtures/apps/demo/app/controller/hello.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = function*() {
-  this.setCookie('hi', 'foo');
+  this.cookies.set('hi', 'foo');
   this.body = 'hello';
 };

--- a/test/fixtures/apps/encrypt-cookies/app/controller/home.js
+++ b/test/fixtures/apps/encrypt-cookies/app/controller/home.js
@@ -1,13 +1,13 @@
 module.exports = function* () {
-  var encrypt = this.getCookie('foo', {
+  var encrypt = this.cookies.get('foo', {
     encrypt: true
   });
-  var encryptWrong = this.getCookie('foo', { signed: false });
-  var plain = this.getCookie('plain', { signed: false });
-  this.setCookie('foo', 'bar 中文', {
+  var encryptWrong = this.cookies.get('foo', { signed: false });
+  var plain = this.cookies.get('plain', { signed: false });
+  this.cookies.set('foo', 'bar 中文', {
     encrypt: true
   });
-  this.setCookie('plain', 'text ok', { signed: false });
+  this.cookies.set('plain', 'text ok', { signed: false });
   this.body = {
     set: 'bar 中文',
     encrypt: encrypt,

--- a/test/fixtures/apps/secure-app/app/controller/index.js
+++ b/test/fixtures/apps/secure-app/app/controller/index.js
@@ -1,17 +1,17 @@
 exports.home = function*() {
   if (this.query.cookiedel) {
     if (!this.query.opts) {
-      this.deleteCookie('cookiedel');
+      this.cookies.set('cookiedel', null);
     } else {
       const options = {
         path: '/hello',
         domain: 'eggjs.org',
       };
-      this.deleteCookie('cookiedel', options);
+      this.cookies.set('cookiedel', null, options);
     }
   }
   if (this.query.setCookieValue) {
-    this.setCookie('foo-cookie', this.query.setCookieValue);
+    this.cookies.set('foo-cookie', this.query.setCookieValue);
   }
 
   if (this.query.hasOwnProperty('cookiepath')) {
@@ -21,10 +21,10 @@ exports.home = function*() {
     if (this.query.cookiedomain) {
       opts.domain = this.query.cookiedomain;
     }
-    this.setCookie('cookiepath', this.query.cookiepath, opts);
+    this.cookies.set('cookiepath', this.query.cookiepath, opts);
   }
   if (this.query.notSetPath) {
-    this.setCookie('notSetPath', this.query.notSetPath, {
+    this.cookies.set('notSetPath', this.query.notSetPath, {
       path: null,
       domain: null,
     });

--- a/test/lib/core/cookies.test.js
+++ b/test/lib/core/cookies.test.js
@@ -5,7 +5,7 @@ const mm = require('egg-mock');
 const request = require('supertest');
 const utils = require('../../utils');
 
-describe('test/lib/core/cookies.test.js', () => {
+describe.only('test/lib/core/cookies.test.js', () => {
   afterEach(mm.restore);
 
   describe('secure = true', () => {
@@ -19,14 +19,14 @@ describe('test/lib/core/cookies.test.js', () => {
     it('should throw TypeError when set secure on not secure request', () => {
       const ctx = app.mockContext();
       (function() {
-        ctx.setCookie('foo', 'bar', { secure: true });
+        ctx.cookies.set('foo', 'bar', { secure: true });
       }).should.throw('Cannot send secure cookie over unencrypted connection');
     });
 
     it('should set cookie twice and not set domain when ctx.hostname=localhost', () => {
       const ctx = app.mockContext();
       ctx.set('Set-Cookie', 'foo=bar');
-      ctx.setCookie('foo1', 'bar1');
+      ctx.cookies.set('foo1', 'bar1');
       ctx.response.get('set-cookie').should.eql([
         'foo=bar',
         'foo1=bar1; path=/; httponly',
@@ -38,7 +38,7 @@ describe('test/lib/core/cookies.test.js', () => {
       mm(app, 'keys', null);
       const ctx = app.mockContext();
       (function() {
-        ctx.setCookie('foo', 'bar', {
+        ctx.cookies.set('foo', 'bar', {
           encrypt: true,
         });
       }).should.throw('.keys required for encrypt/sign cookies');
@@ -49,7 +49,7 @@ describe('test/lib/core/cookies.test.js', () => {
       const ctx = app.mockContext();
       ctx.header.cookie = 'foo=bar';
       (function() {
-        ctx.getCookie('foo', {
+        ctx.cookies.get('foo', {
           encrypt: true,
         });
       }).should.throw('.keys required for encrypt/sign cookies');

--- a/test/lib/core/cookies.test.js
+++ b/test/lib/core/cookies.test.js
@@ -5,7 +5,7 @@ const mm = require('egg-mock');
 const request = require('supertest');
 const utils = require('../../utils');
 
-describe.only('test/lib/core/cookies.test.js', () => {
+describe('test/lib/core/cookies.test.js', () => {
   afterEach(mm.restore);
 
   describe('secure = true', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

cookie


##### Description of change

去除无意义的封装，保持和 koa 接口一致。

closes #181 
