### PR TITLE
docs: modify and fix 3 points

### DIFF
--- a/docs/source/zh-cn/intro/quickstart.md
+++ b/docs/source/zh-cn/intro/quickstart.md
@@ -217,14 +217,14 @@ exports.list = function* newsList() {
   yield this.render('news/list.tpl', { list: newsList });
 };
 ```
-还需增加app/service/news.js中读取到的配置：
+还需增加 `app/service/news.js` 中读取到的配置：
 
 ```js
 // config/config.default.js
 config.news = {
-    pageSize: 5,
-    serverUrl: 'https://hacker-news.firebaseio.com/v0',
-  };
+  pageSize: 5,
+  serverUrl: 'https://hacker-news.firebaseio.com/v0',
+};
 ```
 
 ### 编写扩展

--- a/docs/source/zh-cn/intro/quickstart.md
+++ b/docs/source/zh-cn/intro/quickstart.md
@@ -23,7 +23,7 @@ $ npm i
 
 ```bash
 $ npm run dev
-$ open localhost:7001
+$ open localhost:7001/home
 ```
 
 ## 逐步搭建
@@ -196,9 +196,9 @@ module.exports = app => {
       // parallel GET detail, see `yield {}` from co
       const newsList = yield Object.keys(idList).map(key => {
         const url = `${serverUrl}/item/${idList[key]}.json`;
-        return this.ctx.curl(url, { dataType: 'json' }).then(res => res.data);
+        return this.ctx.curl(url, { dataType: 'json' });
       });
-      return newsList;
+      return newsList.map(res => res.data);
     }
   }
   return NewsService;
@@ -216,6 +216,15 @@ exports.list = function* newsList() {
   const newsList = yield this.service.news.list(page);
   yield this.render('news/list.tpl', { list: newsList });
 };
+```
+还需增加app/service/news.js中读取到的配置：
+
+```js
+// config/config.default.js
+config.news = {
+    pageSize: 5,
+    serverUrl: 'https://hacker-news.firebaseio.com/v0',
+  };
 ```
 
 ### 编写扩展


### PR DESCRIPTION
1）默认脚手架生成的工程「egg-init egg-init egg-example --type=simple」中路由写到的/home了
2）this.ctx.curl(url, { dataType: 'json' })的返回值非promise对象，使用.then()会报错
3）需config中增加serverUrl、pageSize的值

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
