### PR TITLE
docs: add egg-security config to router docs

### DIFF
--- a/docs/source/zh-cn/basics/router.md
+++ b/docs/source/zh-cn/basics/router.md
@@ -204,7 +204,7 @@ module.exports = function* () {
 
 >「除非清楚的确认后果，否则不建议擅自关闭安全插件提供的功能。」
 
-> 这里在写例子的话可临时在 config/config.default.js 中设置
+> 这里在写例子的话可临时在 `config/config.default.js` 中设置
 ```
 exports.security = {
   csrf: false

--- a/docs/source/zh-cn/basics/router.md
+++ b/docs/source/zh-cn/basics/router.md
@@ -196,17 +196,18 @@ module.exports = function* () {
 
 > 附：
 
-> 这里直接发起post请求会报错，框架内部针对表单 POST 请求均会验证 CSRF 的值，会把用户提交的 CSRF key 与当前上下文中的 CSRF key 进行对比，因此我们在表单提交时，请带上 CSRF key 进行提交。
+> 这里直接发起 POST 请求会**报错**：'secret is missing'。错误信息来自 [koa-csrf/index.js#L69](https://github.com/koajs/csrf/blob/2.5.0/index.js#L69) 。
 
-> 注意：上面的校验是因为框架中内置了安全插件 [egg-security](https://github.com/eggjs/egg-security)，提供了一些默认的安全实践，并且框架的安全插件是默认开启的，如果需要关闭其中一些安全防范，直接设置该项的 enable 属性为 false 即可。
+> **原因**：框架内部针对表单 POST 请求均会验证 CSRF 的值，因此我们在表单提交时，请带上 CSRF key 进行提交。
+
+> **注意**：上面的校验是因为框架中内置了安全插件 [egg-security](https://github.com/eggjs/egg-security)，提供了一些默认的安全实践，并且框架的安全插件是默认开启的，如果需要关闭其中一些安全防范，直接设置该项的 enable 属性为 false 即可。
 
 >「除非清楚的确认后果，否则不建议擅自关闭安全插件提供的功能。」
 
 > 这里在写例子的话可临时在 config/config.default.js 中设置
 ```
 exports.security = {
-  csrf: false,
-  ctoken: false,
+  csrf: false
 };
 ```
 

--- a/docs/source/zh-cn/basics/router.md
+++ b/docs/source/zh-cn/basics/router.md
@@ -154,7 +154,7 @@ exports.info = function* () {
   this.body = `user: ${this.params.id}, ${this.params.name}`;
 };
 
-// curl http://127.0.0.1:7001/user/123
+// curl http://127.0.0.1:7001/user/123/xiaoming
 ```
 
 #### 复杂参数的获取
@@ -192,6 +192,22 @@ module.exports = function* () {
 
 // 模拟发起 post 请求。
 // curl -X POST http://127.0.0.1:7001/form --data '{"name":"controller"}' --header 'Content-Type:application/json'
+```
+
+> 附：
+
+> 这里直接发起post请求会报错，框架内部针对表单 POST 请求均会验证 CSRF 的值，会把用户提交的 CSRF key 与当前上下文中的 CSRF key 进行对比，因此我们在表单提交时，请带上 CSRF key 进行提交。
+
+> 注意：上面的校验是因为框架中内置了安全插件 [egg-security](https://github.com/eggjs/egg-security)，提供了一些默认的安全实践，并且框架的安全插件是默认开启的，如果需要关闭其中一些安全防范，直接设置该项的 enable 属性为 false 即可。
+
+>「除非清楚的确认后果，否则不建议擅自关闭安全插件提供的功能。」
+
+> 这里在写例子的话可临时在 config/config.default.js 中设置
+```
+exports.security = {
+  csrf: false,
+  ctoken: false,
+};
 ```
 
 ### 表单校验

--- a/docs/source/zh-cn/basics/router.md
+++ b/docs/source/zh-cn/basics/router.md
@@ -198,7 +198,7 @@ module.exports = function* () {
 
 > 这里直接发起 POST 请求会**报错**：'secret is missing'。错误信息来自 [koa-csrf/index.js#L69](https://github.com/koajs/csrf/blob/2.5.0/index.js#L69) 。
 
-> **原因**：框架内部针对表单 POST 请求均会验证 CSRF 的值，因此我们在表单提交时，请带上 CSRF key 进行提交。
+> **原因**：框架内部针对表单 POST 请求均会验证 CSRF 的值，因此我们在表单提交时，请带上 CSRF key 进行提交，可参考[安全威胁csrf的防范](https://eggjs.org/zh-cn/core/security.html#安全威胁csrf的防范)
 
 > **注意**：上面的校验是因为框架中内置了安全插件 [egg-security](https://github.com/eggjs/egg-security)，提供了一些默认的安全实践，并且框架的安全插件是默认开启的，如果需要关闭其中一些安全防范，直接设置该项的 enable 属性为 false 即可。
 


### PR DESCRIPTION
1）curl地址没带name参数值，会路由不到
2）没有设置csrf的post请求，直接curl模拟post会经过egg-security执行验证时报错‘secret is missing’

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
