### PR TITLE
docs: 修正Controller文档中关于jsonp配置的错误

### DIFF
--- a/docs/source/zh-cn/basics/controller.md
+++ b/docs/source/zh-cn/basics/controller.md
@@ -780,7 +780,7 @@ exports.show = function* (ctx) {
 
 ```js
 // config/config.default.js
-module.exports = {
+exports.jsonp = {
   callback: 'callback', // 识别 query 中的 `callback` 参数
   limit: 100, // 函数名最长为 100 个字符
 }


### PR DESCRIPTION
原文档中 https://eggjs.org/zh-cn/basics/controller.html#jsonp-配置 的配置说明是

```
module.exports = {
  callback: 'callback', // 识别 query 中的 `callback` 参数
  limit: 100, // 函数名最长为 100 个字符
}
```

实际上应为

```
exports.jsonp = {...}
```