### PR TITLE
fix: deprecate warning when inspect & toJSON

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -87,7 +87,9 @@ class EggApplication extends EggCore {
    * ```
    */
   inspect() {
-    const res = {};
+    const res = {
+      env: this.config.env,
+    };
 
     function delegate(res, app, keys) {
       for (const key of keys) {
@@ -110,7 +112,6 @@ class EggApplication extends EggCore {
     delegate(res, this, [
       'name',
       'baseDir',
-      'env',
       'subdomainOffset',
     ]);
 
@@ -122,7 +123,12 @@ class EggApplication extends EggCore {
       'httpclient',
       'loggers',
     ]);
+
     return res;
+  }
+
+  toJSON() {
+    return this.inspect();
   }
 
   /**

--- a/test/lib/application.test.js
+++ b/test/lib/application.test.js
@@ -147,6 +147,15 @@ describe('test/lib/application.test.js', () => {
       });
     });
 
+    describe('inspect && toJSON', () => {
+      it('should override koa method', function() {
+        const inspectResult = app.inspect();
+        const jsonResult = app.toJSON();
+        assert.deepEqual(inspectResult, jsonResult);
+        assert(inspectResult.env === app.config.env);
+      });
+    });
+
     describe('class style controller', () => {
       it('should work with class style controller', () => {
         return request(app.callback())


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
