### PR TITLE
refactor: set consoleLevel WARN of coreLogger in local

### DIFF
--- a/config/config.local.js
+++ b/config/config.local.js
@@ -1,0 +1,7 @@
+'use strict';
+
+exports.logger = {
+  coreLogger: {
+    consoleLevel: 'WARN',
+  },
+};

--- a/test/lib/core/logger.test.js
+++ b/test/lib/core/logger.test.js
@@ -30,7 +30,7 @@ describe('test/lib/core/logger.test.js', () => {
     assert(app.coreLogger.get('console').options.level === Logger.INFO);
   });
 
-  it('should got right level on local env', function* () {
+  it.only('should got right level on local env', function* () {
     mm.env('local');
     mm(process.env, 'EGG_LOG', '');
     app = utils.app('apps/mock-dev-app');
@@ -39,7 +39,7 @@ describe('test/lib/core/logger.test.js', () => {
     assert(app.logger.get('file').options.level === Logger.INFO);
     assert(app.logger.get('console').options.level === Logger.INFO);
     assert(app.coreLogger.get('file').options.level === Logger.INFO);
-    assert(app.coreLogger.get('console').options.level === Logger.INFO);
+    assert(app.coreLogger.get('console').options.level === Logger.WARN);
   });
 
   it('should set EGG_LOG level on local env', function* () {

--- a/test/lib/core/logger.test.js
+++ b/test/lib/core/logger.test.js
@@ -30,7 +30,7 @@ describe('test/lib/core/logger.test.js', () => {
     assert(app.coreLogger.get('console').options.level === Logger.INFO);
   });
 
-  it.only('should got right level on local env', function* () {
+  it('should got right level on local env', function* () {
     mm.env('local');
     mm(process.env, 'EGG_LOG', '');
     app = utils.app('apps/mock-dev-app');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

This config is removed by PR #695,
but the infomation of coreLogger is not useful for app developer,
and this config won't changed by app developer

