### PR TITLE
docs: Uniform the standards that we should acquire this parsed parame…

### DIFF
--- a/docs/source/en/basics/router.md
+++ b/docs/source/en/basics/router.md
@@ -133,7 +133,7 @@ module.exports = app => {
 
 // app/controller/search.js
 module.exports = function* (ctx) {
-  ctx.body = `search: ${this.query.name}`;
+  ctx.body = `search: ${ctx.query.name}`;
 };
 
 // curl http://127.0.0.1:7001/search?name=egg
@@ -265,9 +265,9 @@ module.exports = app => {
 };
 
 // app/controller/search.js
-module.exports = function* () {
-  const type = this.query.type;
-  const q = this.query.q || 'nodejs';
+module.exports = function* (ctx) {
+  const type = ctx.query.type;
+  const q = ctx.query.q || 'nodejs';
 
   if (type === 'bing') {
     this.redirect(`http://cn.bing.com/search?q=${q}`);
@@ -288,7 +288,7 @@ Here we just briefly explain how to use the middleware, and refer to [Middleware
 ```js
 // app/controller/search.js
 module.exports = function* (ctx) {
-  ctx.body = `search: ${this.query.name}`;
+  ctx.body = `search: ${ctx.query.name}`;
 };
 
 // app/middleware/uppercase.js

--- a/docs/source/zh-cn/basics/router.md
+++ b/docs/source/zh-cn/basics/router.md
@@ -138,7 +138,7 @@ module.exports = app => {
 
 // app/controller/search.js
 module.exports = function* (ctx) {
-  ctx.body = `search: ${this.query.name}`;
+  ctx.body = `search: ${ctx.query.name}`;
 };
 
 // curl http://127.0.0.1:7001/search?name=egg
@@ -270,9 +270,9 @@ module.exports = app => {
 };
 
 // app/controller/search.js
-module.exports = function* () {
-  const type = this.query.type;
-  const q = this.query.q || 'nodejs';
+module.exports = function* (ctx) {
+  const type = ctx.query.type;
+  const q = ctx.query.q || 'nodejs';
 
   if (type === 'bing') {
     this.redirect(`http://cn.bing.com/search?q=${q}`);
@@ -293,7 +293,7 @@ module.exports = function* () {
 ```js
 // app/controller/search.js
 module.exports = function* (ctx) {
-  ctx.body = `search: ${this.query.name}`;
+  ctx.body = `search: ${ctx.query.name}`;
 };
 
 // app/middleware/uppercase.js


### PR DESCRIPTION
Uniform the standards that we should acquire this parsed parameter body through context.query ,  thus we can avoid confusion and easier to understand the api of docs.

before:
// app/controller/search.js
``` javascript
module.exports = function* (ctx) {
  ctx.body = `search: ${this.query.name}`;
};
```

after:
// app/controller/search.js
``` javascript
module.exports = function* (ctx) {
  ctx.body = `search: ${ctx.query.name}`;
};
```

In addition, when we write a Controller by defining a Controller class, it is invalid that we acquire this parsed parameter body through this.query.

// it is invalid.
// app/controller/post.js
``` javascript
module.exports = app => {
  class PostController extends app.Controller {
    * create() {
       // it is invalid. Cannot read property 'name' of undefined
       this.ctx.body = `search: ${this.query.name}`;      
    }
  }
  return PostController;
}
```
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
