### PR TITLE
docs(development): change `exports` to `config`

### DIFF
--- a/docs/source/zh-cn/core/development.md
+++ b/docs/source/zh-cn/core/development.md
@@ -309,7 +309,7 @@ exports.proxyworker = {
 
 // config/config.default.js
 // 如果10086被占用，你可以通过这个配置指定其他的端口号
-exports.proxyworker = {
+config.proxyworker = {
   port: 10086,
 };
 ```


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change


the  [debug docs](https://eggjs.org/zh-cn/core/development.html#2-启动插件) is 

```
exports.proxyworker = {
  port: 10086,
};
```

but I init the project using `egg-init` , in `config.default.js` , I'd like to config like this:

// config/config.default.js 
```js
'use strict';

module.exports = appInfo => {
  const config = {};

  // should change to your own
  config.keys = appInfo.name + '_1500736672654_5027';

  // add your config here
 +  config.proxyworker = {
 +   port: 10086,
 + };

  return config;
};
```

