### PR TITLE
feat: support app.httpclient and agent.httpclient auto set tracer

### DIFF
--- a/lib/core/httpclient.js
+++ b/lib/core/httpclient.js
@@ -18,6 +18,22 @@ class HttpClient extends urllib.HttpClient {
     });
     this.app = app;
   }
+
+  request(url, args, callback) {
+    if (args && typeof args !== 'function') {
+      if (!(args.ctx && args.ctx.tracer) && !args.tracer) {
+        args.tracer = this.app.tracer;
+      }
+    }
+
+    if (!args) {
+      args = {
+        tracer: this.app.tracer,
+      };
+    }
+
+    return super.request(url, args, callback);
+  }
 }
 
 function normalizeConfig(app) {

--- a/lib/core/httpclient.js
+++ b/lib/core/httpclient.js
@@ -20,16 +20,15 @@ class HttpClient extends urllib.HttpClient {
   }
 
   request(url, args, callback) {
-    if (args && typeof args !== 'function') {
-      if (!(args.ctx && args.ctx.tracer) && !args.tracer) {
-        args.tracer = this.app.tracer;
-      }
+    if (typeof args === 'function') {
+      callback = args;
+      args = null;
     }
 
-    if (!args) {
-      args = {
-        tracer: this.app.tracer,
-      };
+    args = args || {};
+
+    if (!args.ctx && !args.tracer) {
+      args.tracer = this.app.tracer;
     }
 
     return super.request(url, args, callback);

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "egg-doctools": "^2.0.1",
     "egg-mock": "^3.8.0",
     "egg-plugin-puml": "^2.4.0",
+    "egg-tracer": "^1.1.0",
     "egg-view-nunjucks": "^2.1.3",
     "eslint": "^4.1.1",
     "eslint-config-egg": "^5.0.0",

--- a/test/fixtures/apps/httpclient-tracer/app.js
+++ b/test/fixtures/apps/httpclient-tracer/app.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = app => {
+  const done = app.readyCallback('ready');
+  setTimeout(done, 5000);
+};

--- a/test/fixtures/apps/httpclient-tracer/config/plugin.js
+++ b/test/fixtures/apps/httpclient-tracer/config/plugin.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  tracer: {
+    enable: true,
+    package: 'egg-tracer',
+  },
+}

--- a/test/fixtures/apps/httpclient-tracer/package.json
+++ b/test/fixtures/apps/httpclient-tracer/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "httpclient-tracer"
+}

--- a/test/lib/core/httpclient.test.js
+++ b/test/lib/core/httpclient.test.js
@@ -177,4 +177,216 @@ describe('test/lib/core/httpclient.test.js', () => {
         });
     });
   });
+
+  describe('httpclient tracer', () => {
+    let app;
+    before(() => {
+      app = utils.app('apps/httpclient-tracer');
+      return app.ready();
+    });
+
+    after(() => app.close());
+
+    it('should app request auto set tracer', function* () {
+      const httpclient = app.httpclient;
+
+      let reqTracer;
+      let resTracer;
+
+      httpclient.on('request', function(options) {
+        reqTracer = options.args.tracer;
+      });
+
+      httpclient.on('response', function(options) {
+        resTracer = options.req.args.tracer;
+      });
+
+      let res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+      });
+
+      assert(res.status === 200);
+      assert(reqTracer === resTracer);
+
+      assert(reqTracer.traceId);
+      assert(reqTracer.traceId === resTracer.traceId);
+
+      reqTracer = null;
+      resTracer = null;
+
+      res = yield httpclient.request('https://www.alipay.com');
+
+      assert(res.status === 200);
+      assert(reqTracer === resTracer);
+
+      assert(reqTracer.traceId);
+      assert(reqTracer.traceId === resTracer.traceId);
+    });
+
+    it('should agent request auto set tracer', function* () {
+      const httpclient = app.agent.httpclient;
+
+      let reqTracer;
+      let resTracer;
+
+      httpclient.on('request', function(options) {
+        reqTracer = options.args.tracer;
+      });
+
+      httpclient.on('response', function(options) {
+        resTracer = options.req.args.tracer;
+      });
+
+      const res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+      });
+
+      assert(res.status === 200);
+      assert(reqTracer === resTracer);
+
+      assert(reqTracer.traceId);
+      assert(reqTracer.traceId === resTracer.traceId);
+    });
+
+    it('should app request with ctx and tracer', function* () {
+      const httpclient = app.httpclient;
+
+      let reqTracer;
+      let resTracer;
+
+      httpclient.on('request', function(options) {
+        reqTracer = options.args.tracer || options.ctx.tracer;
+      });
+
+      httpclient.on('response', function(options) {
+        resTracer = options.req.args.tracer || options.ctx.tracer;
+      });
+
+      let res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+        ctx: {},
+      });
+
+      assert(res.status === 200);
+
+      assert(reqTracer.traceId);
+      assert(reqTracer.traceId === resTracer.traceId);
+
+      reqTracer = null;
+      resTracer = null;
+      res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+        ctx: {},
+        tracer: {
+          id: '1234',
+        },
+      });
+
+      assert(res.status === 200);
+      assert(reqTracer.id === resTracer.id);
+      assert(reqTracer.id === '1234');
+
+      reqTracer = null;
+      resTracer = null;
+      res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+        ctx: {
+          tracer: {
+            id: '5678',
+          },
+        },
+      });
+
+      assert(res.status === 200);
+      assert(reqTracer.id === resTracer.id);
+      assert(reqTracer.id === '5678');
+    });
+  });
+
+  describe('before app ready multi httpclient request tracer', () => {
+    let app;
+    before(() => {
+      app = utils.app('apps/httpclient-tracer');
+    });
+
+    after(() => app.close());
+
+    it('should app request before ready use same tracer', function* () {
+      const httpclient = app.httpclient;
+
+      let reqTracers = [];
+      let resTracers = [];
+
+      httpclient.on('request', function(options) {
+        reqTracers.push(options.args.tracer);
+      });
+
+      httpclient.on('response', function(options) {
+        resTracers.push(options.req.args.tracer);
+      });
+
+      let res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+      });
+      assert(res.status === 200);
+
+
+      res = yield httpclient.request('https://github.com', {
+        method: 'GET',
+      });
+
+      assert(res.status === 200);
+
+      res = yield httpclient.request('https://www.npmjs.com', {
+        method: 'GET',
+      });
+      assert(res.status === 200);
+
+      assert(reqTracers.length === 3);
+      assert(resTracers.length === 3);
+
+      assert(reqTracers[0] === reqTracers[1]);
+      assert(reqTracers[1] === reqTracers[2]);
+
+      assert(resTracers[0] === reqTracers[2]);
+      assert(resTracers[1] === resTracers[0]);
+      assert(resTracers[2] === resTracers[1]);
+
+      assert(reqTracers[0].traceId);
+
+      reqTracers = [];
+      resTracers = [];
+
+      yield app.ready();
+
+      res = yield httpclient.request('https://www.alipay.com', {
+        method: 'GET',
+      });
+      assert(res.status === 200);
+
+
+      res = yield httpclient.request('https://github.com', {
+        method: 'GET',
+      });
+      assert(res.status === 200);
+
+      res = yield httpclient.request('https://www.npmjs.com', {
+        method: 'GET',
+      });
+      assert(res.status === 200);
+
+      assert(reqTracers.length === 3);
+      assert(resTracers.length === 3);
+
+      assert(reqTracers[0] !== reqTracers[1]);
+      assert(reqTracers[1] !== reqTracers[2]);
+
+      assert(resTracers[0] !== reqTracers[2]);
+      assert(resTracers[1] !== resTracers[0]);
+      assert(resTracers[2] !== resTracers[1]);
+
+      assert(reqTracers[0].traceId);
+    });
+  });
+
 });

--- a/test/lib/core/httpclient.test.js
+++ b/test/lib/core/httpclient.test.js
@@ -264,7 +264,6 @@ describe('test/lib/core/httpclient.test.js', () => {
 
       let res = yield httpclient.request('https://www.alipay.com', {
         method: 'GET',
-        ctx: {},
       });
 
       assert(res.status === 200);


### PR DESCRIPTION
如果 httpclient.request 的时候, 没有 ctx, 自动在 args 中设置 tracer.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
