### PR TITLE
feat: add 400 response for broken client request to instead of empty response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/plugins.png
 package-lock.json
 yarn.lock
 !test/fixtures/apps/loader-plugin/node_modules
+.editorconfig

--- a/lib/application.js
+++ b/lib/application.js
@@ -14,7 +14,6 @@ const KEYS = Symbol('Application#keys');
 const HELPER = Symbol('Application#Helper');
 const LOCALS = Symbol('Application#locals');
 const BIND_EVENTS = Symbol('Application#bindEvents');
-const ON_CLIENT_ERROR = Symbol('Application#onClientError');
 const WARN_CONFUSED_CONFIG = Symbol('Application#warnConfusedConfig');
 const EGG_LOADER = Symbol.for('egg#loader');
 const EGG_PATH = Symbol.for('egg#eggPath');
@@ -70,7 +69,7 @@ class Application extends EggApplication {
     return path.join(__dirname, '..');
   }
 
-  [ON_CLIENT_ERROR](err, socket) {
+  onClientError(err, socket) {
     this.logger.error('A client (%s:%d) error [%s] occurred: %s',
       socket.remoteAddress,
       socket.remotePort,
@@ -94,7 +93,7 @@ class Application extends EggApplication {
       },
     });
 
-    server.on('clientError', this[ON_CLIENT_ERROR].bind(this));
+    server.on('clientError', (err, socket) => this.onClientError(err, socket));
   }
 
   /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -22,13 +22,13 @@ const CLUSTER_CLIENTS = Symbol.for('egg#clusterClients');
 
 // client error => 400 Bad Request
 // Refs: https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_event_clienterror
-const DEFAULT_BAD_REQUEST_HTML = '<html>' +
-  '<head><title>400 Bad Request</title></head>' +
-  '<body bgcolor="white">' +
-  '<center><h1>400 Bad Request</h1></center>' +
-  '<hr><center>❤</center>' +
-  '</body>' +
-  '</html>';
+const DEFAULT_BAD_REQUEST_HTML = `<html>
+  <head><title>400 Bad Request</title></head>
+  <body bgcolor="white">
+  <center><h1>400 Bad Request</h1></center>
+  <hr><center>❤</center>
+  </body>
+  </html>`;
 const DEFAULT_BAD_REQUEST_HTML_LENGTH = Buffer.byteLength(DEFAULT_BAD_REQUEST_HTML);
 const DEFAULT_BAD_REQUEST_RESPONSE =
   `HTTP/1.1 400 Bad Request\r\nContent-Length: ${DEFAULT_BAD_REQUEST_HTML_LENGTH}` +
@@ -71,7 +71,11 @@ class Application extends EggApplication {
   }
 
   [ON_CLIENT_ERROR](err, socket) {
-    this.logger.warn('A client error [%s] occurred: %s', err.code, err.message);
+    this.logger.error('A client (%s:%d) error [%s] occurred: %s',
+      socket.remoteAddress,
+      socket.remotePort,
+      err.code,
+      err.message);
 
     // because it's a raw socket object, we should return the raw HTTP response
     // packet.

--- a/lib/application.js
+++ b/lib/application.js
@@ -14,10 +14,25 @@ const KEYS = Symbol('Application#keys');
 const HELPER = Symbol('Application#Helper');
 const LOCALS = Symbol('Application#locals');
 const BIND_EVENTS = Symbol('Application#bindEvents');
+const ON_CLIENT_ERROR = Symbol('Application#onClientError');
 const WARN_CONFUSED_CONFIG = Symbol('Application#warnConfusedConfig');
 const EGG_LOADER = Symbol.for('egg#loader');
 const EGG_PATH = Symbol.for('egg#eggPath');
 const CLUSTER_CLIENTS = Symbol.for('egg#clusterClients');
+
+// client error => 400 Bad Request
+// Refs: https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_event_clienterror
+const DEFAULT_BAD_REQUEST_HTML = '<html>' +
+  '<head><title>400 Bad Request</title></head>' +
+  '<body bgcolor="white">' +
+  '<center><h1>400 Bad Request</h1></center>' +
+  '<hr><center>❤</center>' +
+  '</body>' +
+  '</html>';
+const DEFAULT_BAD_REQUEST_HTML_LENGTH = Buffer.byteLength(DEFAULT_BAD_REQUEST_HTML);
+const DEFAULT_BAD_REQUEST_RESPONSE =
+  `HTTP/1.1 400 Bad Request\r\nContent-Length: ${DEFAULT_BAD_REQUEST_HTML_LENGTH}` +
+  `\r\n\r\n${DEFAULT_BAD_REQUEST_HTML}`;
 
 /**
  * Singleton instance in App Worker, extend {@link EggApplication}
@@ -55,6 +70,14 @@ class Application extends EggApplication {
     return path.join(__dirname, '..');
   }
 
+  [ON_CLIENT_ERROR](err, socket) {
+    this.logger.warn('A client error [%s] occurred: %s', err.code, err.message);
+
+    // because it's a raw socket object, we should return the raw HTTP response
+    // packet.
+    socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+  }
+
   onServer(server) {
     /* istanbul ignore next */
     graceful({
@@ -66,6 +89,8 @@ class Application extends EggApplication {
         this.coreLogger.error(err);
       },
     });
+
+    server.on('clientError', this[ON_CLIENT_ERROR].bind(this));
   }
 
   /**
@@ -247,7 +272,7 @@ class Application extends EggApplication {
       ctx.coreLogger.error(err);
     });
     // expose server to support websocket
-    this.on('server', server => this.onServer(server));
+    this.once('server', server => this.onServer(server));
   }
 
   /**

--- a/test/lib/cluster/app_worker.test.js
+++ b/test/lib/cluster/app_worker.test.js
@@ -62,7 +62,6 @@ describe('test/lib/cluster/app_worker.test.js', () => {
     ]);
   });
 
-
   describe('listen hostname', () => {
     let app;
     before(() => {

--- a/test/lib/cluster/app_worker.test.js
+++ b/test/lib/cluster/app_worker.test.js
@@ -47,9 +47,13 @@ describe('test/lib/cluster/app_worker.test.js', () => {
     test.request().path = '/foo bar';
 
     return test
-      // .expect(
-      //  '<html><head><title>400 Bad Request</title></head><body bgcolor="white">' +
-      //  '<center><h1>400 Bad Request</h1></center><hr><center>❤</center></body></html>')
+      .expect(`<html>
+  <head><title>400 Bad Request</title></head>
+  <body bgcolor="white">
+  <center><h1>400 Bad Request</h1></center>
+  <hr><center>❤</center>
+  </body>
+  </html>`)
       .expect(400);
   });
 

--- a/test/lib/cluster/app_worker.test.js
+++ b/test/lib/cluster/app_worker.test.js
@@ -19,14 +19,14 @@ describe('test/lib/cluster/app_worker.test.js', () => {
       .expect('true');
   });
 
-  it('should response 400 bad request when HTTP request packet broken', function* () {
+  it('should response 400 bad request when HTTP request packet broken', async () => {
     const test1 = app.httpRequest()
       // Node.js (http-parser) will occur an error while the raw URI in HTTP
       // request packet containing space.
       //
       // Refs: https://zhuanlan.zhihu.com/p/31966196
       .get('/foo bar');
-    const test2 = app.httpRequest().get('/foo baz')
+    const test2 = app.httpRequest().get('/foo baz');
 
     // app.httpRequest().expect() will encode the uri so that we cannot
     // request the server with raw `/foo bar` to emit 400 status code.
@@ -56,10 +56,10 @@ describe('test/lib/cluster/app_worker.test.js', () => {
   </body>
   </html>`;
 
-    yield [
+    await Promise.all([
       test1.expect(html).expect(400),
-      test2.expect(html).expect(400)
-    ];
+      test2.expect(html).expect(400),
+    ]);
   });
 
 


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
application

##### Description of change
<!-- Provide a description of the change below this comment. -->
Egg.js will do no response while client error. This PR makes server response a 400 Bad Request instead.

+ Refs: https://zhuanlan.zhihu.com/p/31966196
+ Refs: https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_event_clienterror