### PR TITLE
chore: use Buffer.alloc, Buffer.from.

### DIFF
--- a/test/app/extend/response.test.js
+++ b/test/app/extend/response.test.js
@@ -33,7 +33,7 @@ describe('test/app/extend/response.test.js', () => {
       ctx.body = '1';
       ctx.response.remove('content-length');
       assert(ctx.response.length === 1);
-      ctx.body = new Buffer(2);
+      ctx.body = Buffer.alloc(2);
       ctx.response.remove('content-length');
       assert(ctx.response.length === 2);
       ctx.body = {};

--- a/test/lib/core/cookies.test.js
+++ b/test/lib/core/cookies.test.js
@@ -37,7 +37,7 @@ describe('test/lib/core/cookies.test.js', () => {
 
     it('should log CookieLimitExceed error when cookie value too long', done => {
       const ctx = app.mockContext();
-      const value = new Buffer(4094).fill(49).toString();
+      const value = Buffer.alloc(4094).fill(49).toString();
       ctx.cookies.set('foo', value);
       setTimeout(() => {
         const logPath = path.join(utils.getFilepath('apps/secure-app'), 'logs/secure-app/common-error.log');

--- a/test/lib/core/utils.test.js
+++ b/test/lib/core/utils.test.js
@@ -88,7 +88,7 @@ describe('test/lib/core/utils.test.js', () => {
     const obj = {
       bufferClass$: Buffer,
       bufferClassExtend$: SlowBuffer,
-      buffer$: new Buffer('123'),
+      buffer$: Buffer.from('123'),
       bufferExtend$: new SlowBuffer('123'),
     };
     utils.convertObject(obj);


### PR DESCRIPTION
Since new Buffer() was deprecated since Node.js v6. (https://nodejs.org/dist/latest-v8.x/docs/api/buffer.html#buffer_class_buffer)

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
