### PR TITLE
fix: try to use custom function name first

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -195,8 +195,9 @@ const proto = module.exports = {
   runInBackground(scope) {
     const ctx = this;
     const start = Date.now();
+    // try to use custom function name first
     /* istanbul ignore next */
-    const taskName = scope.name || '-';
+    const taskName = scope._name || scope.name || '-';
     co(function* () {
       yield scope(ctx);
       ctx.coreLogger.info('[egg:background] task:%s success (%dms)', taskName, Date.now() - start);

--- a/test/app/extend/context.test.js
+++ b/test/app/extend/context.test.js
@@ -246,6 +246,20 @@ describe('test/app/extend/context.test.js', () => {
       );
     });
 
+    it('should use custom task name first', function* () {
+      yield app.httpRequest()
+        .get('/custom')
+        .expect(200)
+        .expect('hello');
+      yield sleep(5000);
+      const logdir = app.config.logger.dir;
+      const log = fs.readFileSync(path.join(logdir, 'ctx-background-web.log'), 'utf8');
+      assert(/background run result file size: \d+/.test(log));
+      assert(
+        /\[egg:background] task:customTaskName success \(\d+ms\)/.test(fs.readFileSync(path.join(logdir, 'egg-web.log'), 'utf8'))
+      );
+    });
+
     it('should run background task error', function* () {
       mm.consoleLevel('NONE');
       yield app.httpRequest()

--- a/test/fixtures/apps/ctx-background/app/controller/custom.js
+++ b/test/fixtures/apps/ctx-background/app/controller/custom.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const fs = require('mz/fs');
+
+module.exports = function* () {
+  this.body = 'hello';
+  const fn = function* saveUserInfo(ctx) {
+    const buf = yield fs.readFile(__filename);
+    ctx.logger.warn('background run result file size: %s', buf.length);
+  };
+  fn._name = 'customTaskName';
+  this.runInBackground(fn);
+};

--- a/test/fixtures/apps/ctx-background/app/router.js
+++ b/test/fixtures/apps/ctx-background/app/router.js
@@ -2,6 +2,7 @@
 
 module.exports = app => {
   app.get('/', app.controller.home);
+  app.get('/custom', app.controller.custom);
   app.get('/app_background', app.controller.app);
   app.get('/error', app.controller.error);
 };


### PR DESCRIPTION
common use case like:

```js
const fn = function* (ctx) {}

fn.name = `some_${var}_${now)`;
```

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
