### PR TITLE
fix: don't allow x-forwarded-host header

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -72,7 +72,7 @@ module.exports = appInfo => {
      * @default
      * @since 1.0.0
      */
-    hostHeaders: 'x-forwarded-host',
+    hostHeaders: '',
 
     /**
      * package.json

--- a/test/app/extend/request.test.js
+++ b/test/app/extend/request.test.js
@@ -32,10 +32,12 @@ describe('test/app/extend/request.test.js', () => {
         assert(req.host === '');
       });
 
-      it('should return host from X-Forwarded-Host header', () => {
+      it('should not allow X-Forwarded-Host header', () => {
+        mm(app.config, 'proxy', true);
         mm(req.header, 'x-forwarded-host', 'foo.com');
+        mm(req.header, 'host', 'bar.com');
         assert(typeof req.host === 'string');
-        assert(req.host === 'foo.com');
+        assert(req.host === 'bar.com');
       });
 
       it('should return host from Host header when proxy=false', () => {
@@ -44,6 +46,15 @@ describe('test/app/extend/request.test.js', () => {
         mm(req.header, 'host', 'bar.com');
         assert(typeof req.host === 'string');
         assert(req.host === 'bar.com');
+      });
+
+      it('should custom hostHeaders', () => {
+        mm(app.config, 'proxy', true);
+        mm(app.config, 'hostHeaders', 'x-forwarded-host');
+        mm(req.header, 'x-forwarded-host', 'foo.com');
+        mm(req.header, 'host', 'bar.com');
+        assert(typeof req.host === 'string');
+        assert(req.host === 'foo.com');
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

It's a security issue, x-forwarded-host can be retreived
from ctx.host when app.config.proxy is true, and be injected
to cookie domain.

