### PR TITLE
docs: shorthand for httpRequest

### DIFF
--- a/docs/source/en/advanced/framework.md
+++ b/docs/source/en/advanced/framework.md
@@ -1,11 +1,11 @@
 title: Framework Development
 ---
 
-During maintaining a number of projects, are your familiar with situations below: 
+During maintaining a number of projects, are your familiar with situations below:
 
 - Each project contains the same configuration files that need to be copied every time, such as `gulpfile.js`, `webpack.config.js`.
 - Each project has similiar dependancies.
-- It's difficult to synchronize those projects based on the same configurations like those mentioned above once they have changed? 
+- It's difficult to synchronize those projects based on the same configurations like those mentioned above once they have changed?
 
 Have your team got:
 
@@ -264,6 +264,8 @@ Here are some differences between initiation of frameworks.
 
 ```js
 const mock = require('egg-mock');
+const assert = require('assert');
+
 describe('test/index.test.js', () => {
   let app;
   before(() => {
@@ -279,10 +281,9 @@ describe('test/index.test.js', () => {
   after(() => app.close());
   afterEach(mock.restore);
 
-  it('should success', () => {
-    return app.httpRequest()
-    .get('/')
-    .expect(200);
+  it('should success', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 200);
   });
 });
 ```
@@ -332,6 +333,8 @@ The option of `mock.cluster` have no difference with `mm.app` while their APIs a
 
 ```js
 const mock = require('egg-mock');
+const assert = require('assert');
+
 describe('/test/index.test.js', () => {
   let app;
   before(() => {
@@ -343,10 +346,9 @@ describe('/test/index.test.js', () => {
   });
   after(() => app.close());
   afterEach(mock.restore);
-  it('should success', () => {
-    return app.httpRequest()
-    .get('/')
-    .expect(200);
+  it('should success', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 200);
   });
 });
 ```

--- a/docs/source/en/core/unittest.md
+++ b/docs/source/en/core/unittest.md
@@ -14,7 +14,7 @@ Let us start with a few questions:
 If you are not sure, you probably need unit testing.
 
 Actually, it brings us tremendous benefits:
-- guarantee the quality of maintaining code 
+- guarantee the quality of maintaining code
 - guarantee the correctness of reconstruction
 - enhance confidence
 - automation
@@ -192,15 +192,14 @@ Common Error:
 
 ```js
 // Bad
-const { app } = require('egg-mock/bootstrap');
+const { app, assert } = require('egg-mock/bootstrap');
 
 describe('bad test', () => {
   doSomethingBefore();
 
-  it('should redirect', () => {
-    return app.httpRequest()
-      .get('/')
-      .expect(302);
+  it('should redirect', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 302);
   });
 });
 ```
@@ -211,15 +210,14 @@ It's supposed to locate in a `before` hook in the suite of a particular test cas
 
 ```js
 // Good
-const { app } = require('egg-mock/bootstrap');
+const { app, assert } = require('egg-mock/bootstrap');
 
 describe('good test', () => {
   before(() => doSomethingBefore());
 
-  it('should redirect', () => {
-    return app.httpRequest()
-      .get('/')
-      .expect(302);
+  it('should redirect', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 302);
   });
 });
 ```
@@ -244,15 +242,13 @@ egg-bin supports asynchronous test:
 ```js
 // using Promise
 it('should redirect', () => {
-  return app.httpRequest()
-    .get('/')
+  return app.httpRequest('/')
     .expect(302);
 });
 
 // using callback
 it('should redirect', done => {
-  app.httpRequest()
-    .get('/')
+  app.httpRequest('/')
     .expect(302, done);
 });
 
@@ -261,6 +257,13 @@ it('should redirect', async () => {
   await app.httpRequest()
     .get('/')
     .expect(302);
+});
+
+// using async + assert
+it('should GET /', async () => {
+  const { res, status } = await app.httpRequest('/');
+  assert(status === 200);
+  assert(res.text === 'some text');
 });
 ```
 
@@ -295,23 +298,20 @@ const { app, mock, assert } = require('egg-mock/bootstrap');
 
 describe('test/controller/home.test.js', () => {
   describe('GET /', () => {
-    it('should status 200 and get the body', () => {
+  it('should status 200 and get the body', async () => {
       // load `GET /` request
-      return app.httpRequest()
-        .get('/')
-        .expect(200) // set expectation of status to 200
-        .expect('hello world'); // set expectation of body to 'hello world'
+      const { res, status } = await app.httpRequest('/');
+      assert(status === 200); // set expectation of status to 200
+      assert(res.text === 'hello world'); // set expectation of body to 'hello world'
     });
 
     it('should send multi requests', async () => {
-      await app.httpRequest()
-        .get('/')
+      await app.httpRequest('/')
         .expect(200) v
         .expect('hello world'); // set expectation of body to 'hello world'
 
       // once more
-      const result = await app.httpRequest()
-        .get('/')
+      const result = await app.httpRequest('/')
         .expect(200)
         .expect('hello world');
 

--- a/docs/source/en/intro/quickstart.md
+++ b/docs/source/en/intro/quickstart.md
@@ -437,11 +437,11 @@ All the test files should be placed at `{app_root}/test/**/*.test.js`.
 const { app, mock, assert } = require('egg-mock/bootstrap');
 
 describe('test/app/middleware/robot.test.js', () => {
-  it('should block robot', () => {
-    return app.httpRequest()
-      .get('/')
-      .set('User-Agent', "Baiduspider")
-      .expect(403);
+  it('should block robot', async () => {
+    const { status } = await app.httpRequest('/')
+      .set('User-Agent', "Baiduspider");
+
+    assert(status === 403);
   });
 });
 ```

--- a/docs/source/zh-cn/advanced/framework.md
+++ b/docs/source/zh-cn/advanced/framework.md
@@ -268,6 +268,8 @@ AgentWorkerLoader 扩展也类似，这里不再举例。AgentWorkerLoader 加�
 
 ```js
 const mock = require('egg-mock');
+const assert = require('assert');
+
 describe('test/index.test.js', () => {
   let app;
   before(() => {
@@ -283,10 +285,9 @@ describe('test/index.test.js', () => {
   after(() => app.close());
   afterEach(mock.restore);
 
-  it('should success', () => {
-    return app.httpRequest()
-      .get('/')
-      .expect(200);
+  it('should success', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 200);
   });
 });
 ```
@@ -336,6 +337,8 @@ describe('/test/index.test.js', () => {
 
 ```js
 const mock = require('egg-mock');
+const assert = require('assert');
+
 describe('/test/index.test.js', () => {
   let app;
   before(() => {
@@ -347,10 +350,9 @@ describe('/test/index.test.js', () => {
   });
   after(() => app.close());
   afterEach(mock.restore);
-  it('should success', () => {
-    return app.httpRequest()
-      .get('/')
-      .expect(200);
+  it('should success', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 200);
   });
 });
 ```

--- a/docs/source/zh-cn/core/unittest.md
+++ b/docs/source/zh-cn/core/unittest.md
@@ -215,15 +215,14 @@ it('should mock ctx.user', () => {
 
 ```js
 // Bad
-const { app } = require('egg-mock/bootstrap');
+const { app, assert } = require('egg-mock/bootstrap');
 
 describe('bad test', () => {
   doSomethingBefore();
 
-  it('should redirect', () => {
-    return app.httpRequest()
-      .get('/')
-      .expect(302);
+  it('should redirect', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 302);
   });
 });
 ```
@@ -235,15 +234,14 @@ Mocha 刚开始运行的时候会载入所有用例，这时 describe 方法就�
 
 ```js
 // Good
-const { app } = require('egg-mock/bootstrap');
+const { app, assert } = require('egg-mock/bootstrap');
 
 describe('good test', () => {
   before(() => doSomethingBefore());
 
-  it('should redirect', () => {
-    return app.httpRequest()
-      .get('/')
-      .expect(302);
+  it('should redirect', async () => {
+    const { status } = await app.httpRequest('/');
+    assert(status === 302);
   });
 });
 ```
@@ -269,15 +267,13 @@ egg-bin 支持测试异步调用，它支持多种写法：
 ```js
 // 使用返回 Promise 的方式
 it('should redirect', () => {
-  return app.httpRequest()
-    .get('/')
+  return app.httpRequest('/')
     .expect(302);
 });
 
 // 使用 callback 的方式
 it('should redirect', done => {
-  app.httpRequest()
-    .get('/')
+  app.httpRequest('/')
     .expect(302, done);
 });
 
@@ -286,6 +282,13 @@ it('should redirect', async () => {
   await app.httpRequest()
     .get('/')
     .expect(302);
+});
+
+// 使用 async + assert
+it('should GET /', async () => {
+  const { res, status } = await app.httpRequest('/');
+  assert(status === 200);
+  assert(res.text === 'some text');
 });
 ```
 
@@ -322,24 +325,21 @@ const { app, mock, assert } = require('egg-mock/bootstrap');
 
 describe('test/controller/home.test.js', () => {
   describe('GET /', () => {
-    it('should status 200 and get the body', () => {
+    it('should status 200 and get the body', async () => {
       // 对 app 发起 `GET /` 请求
-      return app.httpRequest()
-        .get('/')
-        .expect(200) // 期望返回 status 200
-        .expect('hello world'); // 期望 body 是 hello world
+      const { res, status } = await app.httpRequest('/');
+      assert(status === 200); // 期望返回 status 200
+      assert(res.text === 'hello world'); // 期望 body 是 hello world
     });
 
     it('should send multi requests', async () => {
-      // 使用 generator function 方式写测试用例，可以在一个用例中串行发起多次请求
-      await app.httpRequest()
-        .get('/')
+      // 使用 async function 方式写测试用例，可以在一个用例中串行发起多次请求
+      await app.httpRequest('/')
         .expect(200) // 期望返回 status 200
         .expect('hello world'); // 期望 body 是 hello world
 
       // 再请求一次
-      const result = await app.httpRequest()
-        .get('/')
+      const result = await app.httpRequest('/')
         .expect(200)
         .expect('hello world');
 

--- a/docs/source/zh-cn/intro/quickstart.md
+++ b/docs/source/zh-cn/intro/quickstart.md
@@ -410,11 +410,11 @@ module.exports = SomeService;
 const { app, mock, assert } = require('egg-mock/bootstrap');
 
 describe('test/app/middleware/robot.test.js', () => {
-  it('should block robot', () => {
-    return app.httpRequest()
-      .get('/')
-      .set('User-Agent', "Baiduspider")
-      .expect(403);
+  it('should block robot', async () => {
+    const { status } = await app.httpRequest('/')
+      .set('User-Agent', "Baiduspider");
+
+    assert(status === 403);
   });
 });
 ```


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
- 依赖 https://github.com/eggjs/egg-mock/pull/66
- support `app.httpRequest('/')` as shorthand of `app.httpRequest().get('/')`
- use `assert` style

```js
// from
it('should redirect', () => {
  return app.httpRequest('/')
    .expect(302);
});

// to
it('should GET /', async () => {
  const { res, status } = await app.httpRequest('/');
  assert(status === 200);
  assert(res.text === 'some text');
});
```

但感觉还不够完美，不支持 json 的 assert

```
// from
it('should redirect', () => {
  return app.httpRequest('/')
    .expect({ name: 'egg' });
});

// to
it('should GET /', async () => {
  const { res } = await app.httpRequest('/');
  // 要自己 stringify 才行，res 上没有自动转为 json， 用不了 assert.deeepEquals
  assert(res.text === JSON.stringify({ name: 'egg' }));
});
```