### PR TITLE
feat: display router when log app

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -184,10 +184,11 @@ class EggApplication extends EggCore {
     abbr(res, this, [
       'config',
       'controller',
-      'serviceClasses',
-      'middlewares',
       'httpclient',
       'loggers',
+      'middlewares',
+      'router',
+      'serviceClasses',
     ]);
 
     return res;


### PR DESCRIPTION
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- ~~tests and/or benchmarks are included~~
- ~~documentation is changed or added~~
- [x] commit message follows commit guidelines

### Affected core subsystem(s)

No


### Description of change

The developer will be less confused  when they run 
```js
console.log(app)
```
`console` will not swallow the `router` property of `app`

More information in https://github.com/eggjs/egg/issues/2228
