### PR TITLE
feat: support customized client error

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -321,5 +321,31 @@ module.exports = appInfo => {
     responseTimeout: 60000,
   };
 
+  /**
+   * This function / async function will be called when a client error occurred and return the response.
+   *
+   * The arguments are `err`, `socket` and `application` which indicate current client error object, current socket
+   * object and the application object.
+   *
+   * The response to be returned should include properties below:
+   *
+   * @member {Function} Config#onClientError
+   * @property [body] {String|Buffer} - the response body
+   * @property [status] {Number} - the response status code
+   * @property [headers] {Object} - the response header key-value pairs
+   *
+   * @example
+   * exports.onClientError = async (err, socket, app) => {
+   *   return {
+   *     body: 'error',
+   *     status: 400,
+   *     headers: {
+   *       'powered-by': 'Egg.js',
+   *     }
+   *   };
+   * }
+   */
+  config.onClientError = null;
+
   return config;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -405,6 +405,14 @@ declare module 'egg' {
     };
 
     watcher: PlainObject;
+
+    onClientError(err: Error, socket: Socket, app: EggApplication): ClientErrorResponse | Promise<ClientErrorResponse>;
+  }
+
+  export interface ClientErrorResponse {
+    body: string | Buffer;
+    status: number;
+    headers: object;
   }
 
   export interface Router extends KoaRouter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -412,7 +412,7 @@ declare module 'egg' {
   export interface ClientErrorResponse {
     body: string | Buffer;
     status: number;
-    headers: object;
+    headers: { [key: string]: string };
   }
 
   export interface Router extends KoaRouter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import * as KoaApplication from 'koa';
 import * as KoaRouter from 'koa-router';
 import { RequestOptions } from 'urllib';
 import { Readable } from 'stream';
+import { Socket } from 'net';
 import 'egg-onerror';
 import 'egg-session';
 import 'egg-i18n';

--- a/lib/application.js
+++ b/lib/application.js
@@ -84,7 +84,7 @@ class Application extends EggApplication {
 
   [RESPONSE_RAW](socket, raw) {
     if (!socket.writable) return;
-    if (raw) return socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+    if (!raw) return socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
 
     let body = (raw.body == null) ? DEFAULT_BAD_REQUEST_HTML : raw.body;
     const headers = raw.headers || {};

--- a/lib/application.js
+++ b/lib/application.js
@@ -137,9 +137,11 @@ class Application extends EggApplication {
         this[RESPONSE_RAW](socket, ret || {});
       }).catch(err => {
         this.logger.error(err);
-        socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+        if (socket.writable) {
+          socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+        }
       });
-    } else {
+    } else if (socket.writable) {
       // because it's a raw socket object, we should return the raw HTTP response
       // packet.
       socket.end(DEFAULT_BAD_REQUEST_RESPONSE);

--- a/lib/application.js
+++ b/lib/application.js
@@ -85,7 +85,7 @@ class Application extends EggApplication {
   [RESPONSE_RAW](socket, raw) {
     if (!socket.writable) return;
 
-    let body = (raw.body === null || raw.body === undefined) ? DEFAULT_BAD_REQUEST_HTML : raw.body;
+    let body = (raw.body == null) ? DEFAULT_BAD_REQUEST_HTML : raw.body;
     const headers = raw.headers || {};
     const status = raw.status || 400;
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -19,6 +19,7 @@ const WARN_CONFUSED_CONFIG = Symbol('Application#warnConfusedConfig');
 const EGG_LOADER = Symbol.for('egg#loader');
 const EGG_PATH = Symbol.for('egg#eggPath');
 const CLUSTER_CLIENTS = Symbol.for('egg#clusterClients');
+const RESPONSE_RAW = Symbol('Application#responseRaw');
 
 // client error => 400 Bad Request
 // Refs: https://nodejs.org/dist/latest-v8.x/docs/api/http.html#http_event_clienterror
@@ -34,6 +35,14 @@ const DEFAULT_BAD_REQUEST_RESPONSE =
   `HTTP/1.1 400 Bad Request\r\nContent-Length: ${DEFAULT_BAD_REQUEST_HTML_LENGTH}` +
   `\r\n\r\n${DEFAULT_BAD_REQUEST_HTML}`;
 
+// Refs: https://github.com/nodejs/node/blob/b38c81/lib/_http_outgoing.js#L706-L710
+function escapeHeaderValue(value) {
+  // Protect against response splitting. The regex test is there to
+  // minimize the performance impact in the common case.
+  return /[\r\n]/.test(value) ? value.replace(/[\r\n]+[ \t]*/g, '') : value;
+}
+
+// Refs: https://github.com/nodejs/node/blob/b38c81/lib/_http_outgoing.js#L706-L710
 /**
  * Singleton instance in App Worker, extend {@link EggApplication}
  * @extends EggApplication
@@ -73,6 +82,32 @@ class Application extends EggApplication {
     return path.join(__dirname, '..');
   }
 
+  [RESPONSE_RAW](socket, raw) {
+    if (!socket.writable) return;
+
+    let body = (raw.body === null || raw.body === undefined) ? DEFAULT_BAD_REQUEST_HTML : raw.body;
+    const headers = raw.headers || {};
+    const status = raw.status || 400;
+
+    let responseHeaderLines = '';
+    let lengthOutputed = false;
+    const firstLine = `HTTP/1.1 ${status} ${http.STATUS_CODES[status] || 'Unknown'}`;
+
+    // Not that safe because no validation for header keys.
+    // Refs: https://github.com/nodejs/node/blob/b38c81/lib/_http_outgoing.js#L451
+    for (const key of Object.keys(headers)) {
+      if (key.toLowerCase() === 'content-length') lengthOutputed = true;
+      responseHeaderLines += `${key}: ${escapeHeaderValue(headers[key])}\r\n`;
+    }
+
+    if (!lengthOutputed) {
+      if (!Buffer.isBuffer(body)) body = Buffer.from(body);
+      responseHeaderLines += `Content-Length: ${body.byteLength}\r\n`;
+    }
+
+    socket.end(`${firstLine}\r\n${responseHeaderLines}\r\n${body.toString()}`);
+  }
+
   onClientError(err, socket) {
     this.logger.error('A client (%s:%d) error [%s] occurred: %s',
       socket.remoteAddress,
@@ -80,9 +115,42 @@ class Application extends EggApplication {
       err.code,
       err.message);
 
-    // because it's a raw socket object, we should return the raw HTTP response
-    // packet.
-    socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+    if (typeof this.config.onClientError === 'function') {
+      const p = this.config.onClientError(err, socket, this);
+
+      // the returned object should like:
+      //
+      //   {
+      //     body: '...',
+      //     headers: {
+      //       ...
+      //     },
+      //     status: 400
+      //   }
+      //
+      // default values:
+      //
+      // + body: ''
+      // + headers: {}
+      // + status: 400
+
+      if (p && typeof p.then === 'function') {
+        // promise returned
+        p.then(ret => {
+          this[RESPONSE_RAW](socket, ret || {});
+        }).catch(err => {
+          this.logger.error(err);
+          socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+        });
+      } else {
+        // raw result returned
+        this[RESPONSE_RAW](socket, p || {});
+      }
+    } else {
+      // because it's a raw socket object, we should return the raw HTTP response
+      // packet.
+      socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+    }
   }
 
   onServer(server) {

--- a/lib/application.js
+++ b/lib/application.js
@@ -116,7 +116,7 @@ class Application extends EggApplication {
       err.message);
 
     if (typeof this.config.onClientError === 'function') {
-      const p = this.config.onClientError(err, socket, this);
+      const p = eggUtils.callFn(this.config.onClientError, [ err, socket, this ]);
 
       // the returned object should like:
       //
@@ -133,19 +133,12 @@ class Application extends EggApplication {
       // + body: ''
       // + headers: {}
       // + status: 400
-
-      if (p && typeof p.then === 'function') {
-        // promise returned
-        p.then(ret => {
-          this[RESPONSE_RAW](socket, ret || {});
-        }).catch(err => {
-          this.logger.error(err);
-          socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
-        });
-      } else {
-        // raw result returned
-        this[RESPONSE_RAW](socket, p || {});
-      }
+      p.then(ret => {
+        this[RESPONSE_RAW](socket, ret || {});
+      }).catch(err => {
+        this.logger.error(err);
+        socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+      });
     } else {
       // because it's a raw socket object, we should return the raw HTTP response
       // packet.

--- a/lib/application.js
+++ b/lib/application.js
@@ -84,6 +84,7 @@ class Application extends EggApplication {
 
   [RESPONSE_RAW](socket, raw) {
     if (!socket.writable) return;
+    if (raw) return socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
 
     let body = (raw.body == null) ? DEFAULT_BAD_REQUEST_HTML : raw.body;
     const headers = raw.headers || {};
@@ -137,14 +138,12 @@ class Application extends EggApplication {
         this[RESPONSE_RAW](socket, ret || {});
       }).catch(err => {
         this.logger.error(err);
-        if (socket.writable) {
-          socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
-        }
+        this[RESPONSE_RAW](socket);
       });
-    } else if (socket.writable) {
+    } else {
       // because it's a raw socket object, we should return the raw HTTP response
       // packet.
-      socket.end(DEFAULT_BAD_REQUEST_RESPONSE);
+      this[RESPONSE_RAW](socket);
     }
   }
 

--- a/test/fixtures/apps/app-server-customized-client-error/app.js
+++ b/test/fixtures/apps/app-server-customized-client-error/app.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  app.on('server', () => {
+    app.serverEmit = true;
+  });
+};

--- a/test/fixtures/apps/app-server-customized-client-error/app/router.js
+++ b/test/fixtures/apps/app-server-customized-client-error/app/router.js
@@ -1,0 +1,5 @@
+module.exports = app => {
+  app.get('/', function* () {
+    this.body = this.app.serverEmit;
+  });
+};

--- a/test/fixtures/apps/app-server-customized-client-error/config/config.default.js
+++ b/test/fixtures/apps/app-server-customized-client-error/config/config.default.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const sleep = require('mz-modules/sleep');
+
+exports.keys = 'my keys';
+
+exports.onClientError = async (err, socket, app) => {
+  app.logger.error(err);
+  await sleep(50);
+  return {
+    body: err.rawPacket,
+    headers: { foo: 'bar' },
+    status: 418,
+  };
+};

--- a/test/fixtures/apps/app-server-customized-client-error/config/config.default.js
+++ b/test/fixtures/apps/app-server-customized-client-error/config/config.default.js
@@ -4,9 +4,15 @@ const sleep = require('mz-modules/sleep');
 
 exports.keys = 'my keys';
 
+let times = 0;
 exports.onClientError = async (err, socket, app) => {
   app.logger.error(err);
   await sleep(50);
+
+  times++;
+  if (times === 2) times = 0;
+  if (!times) throw new Error('test throw');
+
   return {
     body: err.rawPacket,
     headers: { foo: 'bar' },

--- a/test/fixtures/apps/app-server-customized-client-error/package.json
+++ b/test/fixtures/apps/app-server-customized-client-error/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "app-server"
+}

--- a/test/lib/cluster/app_worker.test.js
+++ b/test/lib/cluster/app_worker.test.js
@@ -5,6 +5,14 @@ const address = require('address');
 const assert = require('assert');
 const utils = require('../../utils');
 
+const DEFAULT_BAD_REQUEST_HTML = `<html>
+  <head><title>400 Bad Request</title></head>
+  <body bgcolor="white">
+  <center><h1>400 Bad Request</h1></center>
+  <hr><center>❤</center>
+  </body>
+  </html>`;
+
 describe('test/lib/cluster/app_worker.test.js', () => {
   let app;
   before(() => {
@@ -48,17 +56,9 @@ describe('test/lib/cluster/app_worker.test.js', () => {
     test1.request().path = '/foo bar';
     test2.request().path = '/foo baz';
 
-    const html = `<html>
-  <head><title>400 Bad Request</title></head>
-  <body bgcolor="white">
-  <center><h1>400 Bad Request</h1></center>
-  <hr><center>❤</center>
-  </body>
-  </html>`;
-
     await Promise.all([
-      test1.expect(html).expect(400),
-      test2.expect(html).expect(400),
+      test1.expect(DEFAULT_BAD_REQUEST_HTML).expect(400),
+      test2.expect(DEFAULT_BAD_REQUEST_HTML).expect(400),
     ]);
   });
 
@@ -81,9 +81,15 @@ describe('test/lib/cluster/app_worker.test.js', () => {
           'deflate\r\nUser-Agent: node-superagent/3.8.2\r\nConnection: close\r\n\r\n');
       }
 
-      const test = app.httpRequest().get('/foo bar');
-      test.request().path = '/foo bar';
-      await test.expect(html).expect('foo', 'bar').expect(418);
+      // customized client error response
+      const test1 = app.httpRequest().get('/foo bar');
+      test1.request().path = '/foo bar';
+      await test1.expect(html).expect('foo', 'bar').expect(418);
+
+      // customized client error handle function throws
+      const test2 = app.httpRequest().get('/foo bar');
+      test2.request().path = '/foo bar';
+      await test2.expect(DEFAULT_BAD_REQUEST_HTML).expect(400);
     });
   });
 

--- a/test/lib/core/httpclient.test.js
+++ b/test/lib/core/httpclient.test.js
@@ -179,7 +179,7 @@ describe('test/lib/core/httpclient.test.js', () => {
   });
 
   describe('httpclient tracer', () => {
-    const url = 'https://eggjs.org/';
+    const url = 'https://www.alibaba.com/';
     let app;
     before(() => {
       app = utils.app('apps/httpclient-tracer');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

application

##### Description of change
<!-- Provide a description of the change below this comment. -->

Add `onClientError` configuration to customize handling client error and get `rawPacket`.