### PR TITLE
docs: plugin.md add config notice for `addSingleton`  function

### DIFF
--- a/docs/source/en/advanced/plugin.md
+++ b/docs/source/en/advanced/plugin.md
@@ -269,7 +269,7 @@ Some plugins are made to introduce existing service into framework, like [egg-my
 - Use different instances of the same service in one application(e.g:connect to two different MySQL Databases)
 - Dynamically initialize connection after getting config from other service(gets MySQL server address from configuration center and then creates connection)
 
-If each plugin makes their own implementation, all sorts of configs  and  initializations will be chaotic. So the framework supplies the  `app.addSingleton(name, creator)` API to unify the creation of this kind of services.
+If each plugin makes their own implementation, all sorts of configs  and  initializations will be chaotic. So the framework supplies the  `app.addSingleton(name, creator)` API to unify the creation of this kind of services. Note that while using the `app.addSingleton(name, creator)` method, the configuration file must have the `client` or `clients` key configuration as the `config` to the `creator` function.
 
 #### Writing Plugin
 
@@ -340,7 +340,7 @@ class PostController extends Controller {
 
 ##### Multiple Instances
 
-1. Of course we need to configure MySQL in the config file, but different from single instance, we need to add  `clients` in the config to declare the configuration of different instances. meanwhile, the `default` field can be used to configure the shared configuration in multiple instances(e.g. host and port).
+1. Of course we need to configure MySQL in the config file, but different from single instance, we need to add  `clients` in the config to declare the configuration of different instances. meanwhile, the `default` field can be used to configure the shared configuration in multiple instances(e.g. host and port). Note that in this case,should use `get` function to specify the corresponding instance(eg: use `app.mysql.get('db1').query()` instead of using `app.mysql.query()` directly to get a `undefined`).
 
 ```js
 // config/config.default.js

--- a/docs/source/zh-cn/advanced/plugin.md
+++ b/docs/source/zh-cn/advanced/plugin.md
@@ -269,7 +269,7 @@ $ npm test
 - 在一个应用中同时使用同一个服务的不同实例（连接到两个不同的 MySQL 数据库）。
 - 从其他服务获取配置后动态初始化连接（从配置中心获取到 MySQL 服务地址后再建立连接）。
 
-如果让插件各自实现，可能会出现各种奇怪的配置方式和初始化方式，所以框架提供了 `app.addSingleton(name, creator)` 方法来统一这一类服务的创建。
+如果让插件各自实现，可能会出现各种奇怪的配置方式和初始化方式，所以框架提供了 `app.addSingleton(name, creator)` 方法来统一这一类服务的创建。需要注意的是在使用 `app.addSingleton(name, creator)` 方法时，配置文件中一定要有 `client` 或者 `clients` 为 key 的配置作为传入 `creator` 函数 的 `config`。
 
 #### 插件写法
 
@@ -340,7 +340,7 @@ class PostController extends Controller {
 
 ##### 多实例
 
-1. 同样需要在配置文件中声明 MySQL 的配置，不过和单实例时不同，配置项中需要有一个 `clients` 字段，分别申明不同实例的配置，同时可以通过 `default` 字段来配置多个实例中共享的配置（如 host 和 port）。
+1. 同样需要在配置文件中声明 MySQL 的配置，不过和单实例时不同，配置项中需要有一个 `clients` 字段，分别申明不同实例的配置，同时可以通过 `default` 字段来配置多个实例中共享的配置（如 host 和 port）。需要注意的是在这种情况下要用 `get` 方法指定相应的实例。（例如：使用 `app.mysql.get('db1').query()`，而不是直接使用 `app.mysql.query()` 得到一个 `undefined`）。
 
 ```js
 // config/config.default.js


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

Recent I try to develop a egg plugin for my project，and was troubled by `addSingleton` function just because config file need `client` or `clients` key configuration as the config to the `creator` function。

And it seems that many people have encountered the same problem before.

- https://cnodejs.org/topic/59a5232ad97b7e2308242846
- https://github.com/eggjs/egg/issues/552
- https://github.com/eggjs/egg/issues/2226
- https://github.com/eggjs/egg/issues/1955