### PR TITLE
Docs: Fix an error link, change a comment into English

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -32,7 +32,7 @@ module.exports = appInfo => {
     /**
      * The key that signing cookies. It can contain multiple keys seperated by `,`.
      * @member {String} Config#keys
-     * @see https://eggjs.org/zh-cn/basics/controller.html#cookie-秘钥
+     * @see http://eggjs.org/en/core/cookie-and-session.html#cookie-secret-key
      * @default
      * @since 1.0.0
      */

--- a/lib/loader/app_worker_loader.js
+++ b/lib/loader/app_worker_loader.js
@@ -18,7 +18,7 @@ class AppWorkerLoader extends EggLoader {
   }
 
   /**
-   * 开始加载所有约定目录
+   * Load all directories in convention
    * @since 1.0.0
    */
   load() {
@@ -38,7 +38,7 @@ class AppWorkerLoader extends EggLoader {
     // app
     this.loadController();
     // app
-    this.loadRouter(); // 依赖 controller
+    this.loadRouter(); // Dependent on controllers
   }
 
 }


### PR DESCRIPTION
Change logs:

**1) Fixes：**
/egg/config/config.default.js：Fix the error link of "security keys" to a right one in English.

**2) Changes：**
/egg/lib/loader/app_worker_loader.js：Translations from English ones to some Chinese comments.