### PR TITLE
Docs: Correct an error syntax of English

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -30,7 +30,7 @@ class Agent extends EggApplication {
     this.dumpConfig();
     this.coreLogger.info('[egg:core] dump config after load, %s', ms(Date.now() - dumpStartTime));
 
-    // keep agent alive even it don't have any io tasks
+    // keep agent alive even it doesn't have any io tasks
     setInterval(() => {}, 24 * 60 * 60 * 1000);
 
     this._uncaughtExceptionHandler = this._uncaughtExceptionHandler.bind(this);


### PR DESCRIPTION
Change logs:

1) /egg/lib/agent.js：do => doesn't, due to the syntax error.