### PR TITLE
feat(d.ts): make app.locals and ctx.locals definitions merging available

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,7 +187,7 @@ declare module 'egg' {
    * ```js
    * // config/config.default.ts
    * import { EggAppInfo } from 'egg';
-   * 
+   *
    * export default (appInfo: EggAppInfo) => {
    *   return {
    *     keys: appInfo.name + '123456',
@@ -570,7 +570,7 @@ declare module 'egg' {
      * global locals for view
      * @see Context#locals
      */
-    locals: any;
+    locals: IApplicationLocals;
 
     /**
      * HTTP get method
@@ -626,6 +626,8 @@ declare module 'egg' {
      */
     runInBackground(scope: (ctx: Context) => void): void;
   }
+
+  export interface IApplicationLocals {}
 
   export interface FileStream extends Readable { // tslint:disable-line
     fields: any;
@@ -792,7 +794,7 @@ declare module 'egg' {
      *
      * @member {Object} Context#locals
      */
-    locals: any;
+    locals: IContextLocals;
 
     /**
      * alias to {@link locals}, compatible with koa that use this variable
@@ -874,6 +876,8 @@ declare module 'egg' {
      */
     redirect(url: string, alt?: string): void;
   }
+
+  export interface IContextLocals {}
 
   export class Controller extends BaseContextClass { }
 
@@ -998,7 +1002,7 @@ declare module 'egg' {
    * Powerful Partial, Support adding ? modifier to a mapped property in deep level
    * @example
    * import { PowerPartial, EggAppConfig } from 'egg';
-   * 
+   *
    * // { view: { defaultEngines: string } } => { view?: { defaultEngines?: string } }
    * type EggConfig = PowerPartial<EggAppConfig>
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -794,7 +794,7 @@ declare module 'egg' {
      *
      * @member {Object} Context#locals
      */
-    locals: IContextLocals;
+    locals: IApplicationLocals & IContextLocals;
 
     /**
      * alias to {@link locals}, compatible with koa that use this variable

--- a/index.d.ts
+++ b/index.d.ts
@@ -627,7 +627,7 @@ declare module 'egg' {
     runInBackground(scope: (ctx: Context) => void): void;
   }
 
-  export interface IApplicationLocals {}
+  export interface IApplicationLocals extends PlainObject {}
 
   export interface FileStream extends Readable { // tslint:disable-line
     fields: any;
@@ -877,7 +877,7 @@ declare module 'egg' {
     redirect(url: string, alt?: string): void;
   }
 
-  export interface IContextLocals {}
+  export interface IContextLocals extends PlainObject {}
 
   export class Controller extends BaseContextClass { }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
In the past ``Application.locals`` and ``Context#locals`` are defined to be ``any``,
which makes developers not able to defined their type of ``locals``.

Now after these changes. Developers can easily defined ``locals``:
```
// index.d.ts
declare module 'egg' {
  export interface IApplicationLocals {
    foo: number;
  }

  export interface IContextLocals {
    foo: number;
  }
}
```