### PR TITLE
fix: add key any to Context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -668,6 +668,8 @@ declare module 'egg' {
   }
 
   export interface Context extends KoaApplication.Context {
+    [key: string]: any;
+
     app: Application;
 
     service: IService;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

https://github.com/eggjs/egg/issues/2644

因为最近 koa 发的 typings 版本，在 Context 中将 `[key: string]: any` 去掉了，所以在我们这里补上。

在想 `EggApplication` 是否也需要加上 key any 参数，来保证至少不会抛编译错误？
