### PR TITLE
perf: use ~~ instead of parseInt

### DIFF
--- a/app/middleware/meta.js
+++ b/app/middleware/meta.js
@@ -16,7 +16,9 @@ module.exports = options => {
     // try to support Keep-Alive Header
     const server = ctx.app.server;
     if (server && server.keepAliveTimeout && server.keepAliveTimeout >= 1000 && ctx.header.connection !== 'close') {
-      const timeout = parseInt(server.keepAliveTimeout / 1000);
+      // perf: parseInt => ~~
+      /* eslint no-bitwise: off */
+      const timeout = ~~(server.keepAliveTimeout / 1000);
       ctx.set('keep-alive', `timeout=${timeout}`);
     }
   };


### PR DESCRIPTION
##### Checklist
- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

##### Description of change
* [MDN parseInt()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt)
  * parseInt accept string instead of number, if you pass a number, it will pass **number => number.toString()** more.
  * more, not related to the **timeout** logic.
