### PR TITLE
docs: fix ws engine error

### DIFF
--- a/docs/source/en/tutorials/socketio.md
+++ b/docs/source/en/tutorials/socketio.md
@@ -52,12 +52,12 @@ exports.io = {
 
 ** uws: **
 
-If you want to use [uws] instead of the default `us` you can do the following configuration
+If you want to use [uws] instead of the default `ws` you can do the following configuration
 
 ```js
 // {app_root} / config / config. $ {env} .js
 exports.io = {
-  init: { wsEngine: 'uws' } // default: us
+  init: { wsEngine: 'uws' } // default: ws
 };
 ```
 

--- a/docs/source/en/tutorials/socketio.md
+++ b/docs/source/en/tutorials/socketio.md
@@ -50,7 +50,7 @@ exports.io = {
 
 > Namespaces are `/` and `/ example`, not`example`
 
-** uws: **
+**uws:**
 
 If you want to use [uws] instead of the default `ws` you can do the following configuration
 

--- a/docs/source/zh-cn/tutorials/socketio.md
+++ b/docs/source/zh-cn/tutorials/socketio.md
@@ -53,12 +53,12 @@ exports.io = {
 
 **uws:**
 
-如果想要使用 [uws] 替代默认的 `us` 可以做如下配置
+如果想要使用 [uws] 替代默认的 `ws` 可以做如下配置
 
 ```js
 // {app_root}/config/config.${env}.js
 exports.io = {
-  init: { wsEngine: 'uws' }, // default: us
+  init: { wsEngine: 'uws' }, // default: ws
 };
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

```
#### uws

> If you want to replace the default `ws` with [uws](https://github.com/uWebSockets/uWebSockets), you can config like this:

exports.io = {
  init: { wsEngine: 'uws' },  // default 'ws'
};
```

- [#L106](https://github.com/socketio/engine.io/blob/6a16ea119280a02029618544d44eb515f7f2d076/lib/server.js#L106)
