### PR TITLE
docs: update installation of getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,13 @@ Node.js >= 8.0.0 required.
 Follow the commands listed below.
 
 ```bash
+# if you are using npm@5.2.0 or above
+$ npx egg-init --type simple showcase && cd showcase
+
+# otherwise
 $ npm install egg-init -g
 $ egg-init --type simple showcase && cd showcase
+
 $ npm install
 $ npm run dev
 $ open http://localhost:7001


### PR DESCRIPTION
We should use `npx` to install `egg-init` instead of installing at global.

`npx` will remove the package once it runs command.

anyway, we just need it to init project. It's unnecessarily installed in the global.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)

<!-- Provide affected core subsystem(s). -->

##### Description of change

<!-- Provide a description of the change below this comment. -->

I update installation of getting started.

I think `npx` should be a good way to init project
