### PR TITLE
:zap: use Math.floor instead of parseInt

### DIFF
--- a/app/middleware/meta.js
+++ b/app/middleware/meta.js
@@ -16,7 +16,10 @@ module.exports = options => {
     // try to support Keep-Alive Header
     const server = ctx.app.server;
     if (server && server.keepAliveTimeout && server.keepAliveTimeout >= 1000 && ctx.header.connection !== 'close') {
-      const timeout = parseInt(server.keepAliveTimeout / 1000);
+      /**
+       * use Math.floor instead of parseInt. More: https://github.com/eggjs/egg/pull/2702
+       */
+      const timeout = Math.floor(server.keepAliveTimeout / 1000);
       ctx.set('keep-alive', `timeout=${timeout}`);
     }
   };


### PR DESCRIPTION
##### Checklist
- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)

##### Description of change
* :zap: use Math.floor instead of parseInt, based on performance and readability.
* More: https://github.com/eggjs/egg/pull/2702
