### PR TITLE
docs: optimize egg-validate usage

### DIFF
--- a/docs/source/en/tutorials/restful.md
+++ b/docs/source/en/tutorials/restful.md
@@ -155,7 +155,7 @@ class TopicController extends Controller {
     const ctx = this.ctx;
     // validate the `ctx.request.body` with the expected format
     // status = 422 exception will be thrown if not passing the parameter validation
-    ctx.validate(createRule);
+    ctx.validate(createRule, ctx.request.body);
     // call service to create a topic
     const id = await ctx.service.topics.create(ctx.request.body);
     // configure the response body and status code

--- a/docs/source/zh-cn/tutorials/restful.md
+++ b/docs/source/zh-cn/tutorials/restful.md
@@ -156,7 +156,7 @@ class TopicController extends Controller {
     const ctx = this.ctx;
     // 校验 `ctx.request.body` 是否符合我们预期的格式
     // 如果参数校验未通过，将会抛出一个 status = 422 的异常
-    ctx.validate(createRule);
+    ctx.validate(createRule, ctx.request.body);
     // 调用 service 创建一个 topic
     const id = await ctx.service.topics.create(ctx.request.body);
     // 设置响应体和状态码


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

优化在文档 restful API 章节中， egg-validate 的使用，由原来的 ctx.validate(rule) 调整为 ctx.validate(rule, ctx.request.body)。

因为自己参照文档学习使用 egg 开发 cnode 范例的时候，不知道传第二个参数（即被检测的对象），踩了这个坑。。