### PR TITLE
doc (package.json,README.zh-CN): Fix some typos

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@
 $ npm install egg --save
 ```
 
-支持 Node.js 8.x 以上版本。
+支持 Node.js 8.x 及以上版本。
 
 ## 特性
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
   "files": [
     "app",
     "config",
-    "bin",
     "lib",
     "index.js",
     "index.d.ts"


### PR DESCRIPTION
1) Remove `bin` from `files`, it seems we don't have this folder.
2) Translation: We should include 8.x itself.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines