### PR TITLE
fix(typescript): Add missing `ignore/match`

### DIFF
--- a/docs/source/en/basics/middleware.md
+++ b/docs/source/en/basics/middleware.md
@@ -230,7 +230,7 @@ module.exports = {
 ```
 match and ignore support various types of configuration ways:
 
-1. String: when string, it sets the prefix of a url path, and all urls starting with this prefix will be matched.
+1. String: when string, it sets the prefix of a url path, and all urls starting with this prefix will be matched. A string array is also accepted.
 2. Regular expression: when regular expression, all urls satisfy this regular expression will be matched.
 3. Function: when function, the request context will be passed to it and what it returns(true/false) determines whether the request is matched or not.
 
@@ -245,3 +245,4 @@ module.exports = {
   },
 };
 ```
+For more configs about `match` and `ignore`, please refer to [egg-path-matching](https://github.com/eggjs/egg-path-matching).

--- a/docs/source/zh-cn/basics/middleware.md
+++ b/docs/source/zh-cn/basics/middleware.md
@@ -232,6 +232,7 @@ module.exports = {
 match 和 ignore 支持多种类型的配置方式
 
 1. 字符串：当参数为字符串类型时，配置的是一个 url 的路径前缀，所有以配置的字符串作为前缀的 url 都会匹配上。
+当然，你也可以直接使用字符串数组。
 2. 正则：当参数为正则时，直接匹配满足正则验证的 url 的路径。
 3. 函数：当参数为一个函数时，会将请求上下文传递给这个函数，最终取函数返回的结果（ture/false）来判断是否匹配。
 
@@ -246,3 +247,5 @@ module.exports = {
   },
 };
 ```
+有关更多的 match 和 ignore 配置情况，详见
+[egg-path-matching](https://github.com/eggjs/egg-path-matching).

--- a/index.d.ts
+++ b/index.d.ts
@@ -209,6 +209,9 @@ declare module 'egg' {
     root: string; // baseDir when local and unittest, HOME when other environment
   }
 
+  type IgnoreItem = string | RegExp | ((ctx: Context) => boolean);
+  type IgnoreOrMatch = IgnoreItem | IgnoreItem[];
+
   export interface EggAppConfig {
     workerStartTimeout: number;
     baseDir: string;
@@ -236,17 +239,19 @@ declare module 'egg' {
       encoding: string;
       formLimit: string;
       jsonLimit: string;
-      strict: true;
+      strict: boolean;
       queryString: {
         arrayLimit: number;
         depth: number;
         parameterLimit: number;
       };
+      ignore: IgnoreOrMatch;
+      match: IgnoreOrMatch;
       enableTypes: string[];
       extendTypes: {
-        json?: string[];
-        form?: string[];
-        text?: string[];
+        json: string[];
+        form: string[];
+        text: string[];
       };
     };
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "egg-alinode": "^1.0.3",
     "egg-bin": "^4.8.5",
     "egg-doctools": "^2.4.0",
-    "egg-mock": "^3.20.0",
+    "egg-mock": "^3.20.1",
     "egg-plugin-puml": "^2.4.0",
     "egg-tracer": "^1.1.0",
     "egg-view-nunjucks": "^2.2.0",

--- a/test/fixtures/apps/app-ts/tsconfig.json
+++ b/test/fixtures/apps/app-ts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2015",
     "baseUrl": ".",
     "paths": {
       "egg": ["../../../../index"]

--- a/test/lib/agent.test.js
+++ b/test/lib/agent.test.js
@@ -27,7 +27,7 @@ describe('test/lib/agent.test.js', () => {
           setTimeout(() => {
             const body = fs.readFileSync(path.join(baseDir, 'logs/agent-throw/common-error.log'), 'utf8');
             assert(body.includes('nodejs.unhandledExceptionError: agent error'));
-            app.notExpect(/nodejs.AgentWorkerDiedError/);
+            app.notExpect('stderr', /nodejs.AgentWorkerDiedError/);
             done();
           }, 1000);
         });


### PR DESCRIPTION
1) Compared with comments above 'bodyParser', we've missed 'ignore' and 'match'. So add them together into the 'index.d.ts' for TypeScript (Ref: https://github.com/eggjs/egg/issues/3006).

2) Update 'egg-mock' and fix a unit test in 'agent.test.js'.

3) Show detail info about 'ignore' and 'match' in both Chinese and English docs.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
