### PR TITLE
deps: pin circular-json@0.5.5 to avoid output deprecate message

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -27,5 +27,9 @@ module.exports = {
     '@types/koa-router',
     '@types/urllib',
   ],
+  keep: [
+    // circular-json > 0.5.5 will output some deprecate message, and we don't want to use flatted
+    'circular-json',
+  ],
   test: 'scripts',
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "accepts": "^1.3.5",
     "agentkeepalive": "^3.5.1",
     "cache-content-type": "^1.0.1",
-    "circular-json": "^0.5.5",
+    "circular-json": "0.5.5",
     "cluster-client": "^2.1.1",
     "debug": "^4.0.1",
     "delegates": "^1.0.0",


### PR DESCRIPTION
the author of `circular-json` recommended `flatted` to replace `circular-json`
but `flatted`'s output is too different with JSON.stringify which don't fit our needs

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
