### PR TITLE
deps: pin circular-json@0.5.5 to avoid output deprecate message

### DIFF
--- a/.autod.conf.js
+++ b/.autod.conf.js
@@ -29,5 +29,9 @@ module.exports = {
   semver: [
     'koa-bodyparser@2',
   ],
+  keep: [
+    // circular-json > 0.5.5 will output some deprecate message, and we don't want to use flatted
+    'circular-json',
+  ],
   test: 'scripts',
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/koa-router": "^7.0.23",
     "accepts": "^1.3.4",
     "agentkeepalive": "^3.3.0",
-    "circular-json": "^0.5.3",
+    "circular-json": "0.5.5",
     "cluster-client": "^1.7.1",
     "co": "^4.6.0",
     "debug": "^3.1.0",

--- a/test/lib/agent.test.js
+++ b/test/lib/agent.test.js
@@ -27,7 +27,7 @@ describe('test/lib/agent.test.js', () => {
           setTimeout(() => {
             const body = fs.readFileSync(path.join(baseDir, 'logs/agent-throw/common-error.log'), 'utf8');
             assert(body.includes('nodejs.unhandledExceptionError: agent error'));
-            app.notExpect(/nodejs.AgentWorkerDiedError/);
+            app.notExpect('stderr', /nodejs.AgentWorkerDiedError/);
             done();
           }, 1000);
         });


### PR DESCRIPTION
the author of `circular-json` recommended `flatted` to replace `circular-json`
but `flatted`'s output is too different with JSON.stringify which don't fit our needs

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
