### PR TITLE
doc (objects.md): Fix number and code errors

### DIFF
--- a/docs/source/en/basics/objects.md
+++ b/docs/source/en/basics/objects.md
@@ -57,7 +57,7 @@ Almost all files (Controller, Service, Schedule, etc.) loaded by the [Loader] (.
   // app/controller/user.js
   class UserController extends Controller {
     async fetch() {
-      this.ctx.body = app.cache.get(this.ctx.query.id);
+      this.ctx.body = this.app.cache.get(this.ctx.query.id);
     }
   }
   ```
@@ -262,7 +262,7 @@ We can get the config object from the Application instance via `app.config`, or 
 
 ## Logger
 
-Egg builds in powerful [logger](../core/logger.md), it is very convenient to print a variety of levels of logs to the corresponding log file, each logger object provides 5 level methods:
+Egg builds in powerful [logger](../core/logger.md), it is very convenient to print a variety of levels of logs to the corresponding log file, each logger object provides 4 level methods:
 
 - `logger.debug()`
 - `logger.info()`

--- a/docs/source/zh-cn/basics/objects.md
+++ b/docs/source/zh-cn/basics/objects.md
@@ -57,7 +57,7 @@ Application 对象几乎可以在编写应用时的任何一个地方获取到�
   // app/controller/user.js
   class UserController extends Controller {
     async fetch() {
-      this.ctx.body = app.cache.get(this.ctx.query.id);
+      this.ctx.body = this.app.cache.get(this.ctx.query.id);
     }
   }
   ```
@@ -262,7 +262,7 @@ module.exports = {
 
 ## Logger
 
-框架内置了功能强大的[日志功能](../core/logger.md)，可以非常方便的打印各种级别的日志到对应的日志文件中，每一个 logger 对象都提供了 5 个级别的方法：
+框架内置了功能强大的[日志功能](../core/logger.md)，可以非常方便的打印各种级别的日志到对应的日志文件中，每一个 logger 对象都提供了 4 个级别的方法：
 
 - `logger.debug()`
 - `logger.info()`


### PR DESCRIPTION
1) 'app....' should be 'this.app....'.
2) 4 levels instead of 5 for each logger instance.

Ref:
1) https://github.com/eggjs/egg/pull/3019
2) https://github.com/eggjs/egg/pull/3018

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
