### PR TITLE
doc (CONTRIBUTION): Add missing English translations and clearify dns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,11 +130,11 @@ BREAKING CHANGE:
   Breaks foo.bar api, foo.baz should be used instead
 ```
 
-Look at [these files](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more detials.
+Look at [these files](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit) for more details.
 
 ## Release
 
-egg uses semantic versioning in release process based on [semver].
+Egg uses semantic versioning in release process based on [semver].
 
 ### Branch Strategy
 
@@ -159,14 +159,19 @@ In the release of every stable version, there will be a PM who has the following
 
 - Confirm that performance test is passed and all issues in current Milestone are either closed or can be delayed to later versions.
 - Open a new [Release Proposal MR], and write `History` as [node CHANGELOG]. Don't forget to correct content in documentation which is related to the releasing version. Commits can be generated automatically.
-    ```
+    ```bash
     $ npm run commits
     ```
 - Nominate PM for next stable version.
 
 #### During Release
 
-All tags mentioned above refere to adding tags from npm in `package.json`.
+- Back up the stable version (master) onto the branch named after the current major (e.g: `1.x`), and set the tag to `release-{v}.x` (v is the current version like `release-1.x`).
+- Push the `next` branch to `master`, make it to the last stable one and remove `next` tag, change the contents corresponding to the branch in README.
+- Publish the latest stable version to [npm], and notify the previous framework to be upgraded.
+- Before doing `npm publish`, please read [How to deploy an npm package].
+
+All tags mentioned above means the tags of npm in `package.json`.
 
 ```json
 "publishConfig": {
@@ -174,8 +179,9 @@ All tags mentioned above refere to adding tags from npm in `package.json`.
 }
 ```
 
-[semver]: http://semver.org/lang/zh-CN/
-[Release proposal MR]: https://github.com/nodejs/node/pull/4181
+[semver]: https://semver.org/
+[Release Proposal MR]: https://github.com/nodejs/node/pull/4181
 [node CHANGELOG]: https://github.com/nodejs/node/blob/master/CHANGELOG.md
 [1.x milestone]: https://github.com/eggjs/egg/milestone/1
-[『我是如何发布一个 npm 包的』]: https://fengmk2.com/blog/2016/how-i-publish-a-npm-package
+[npm]: http://npmjs.com/
+[How to deploy an npm package]: https://fengmk2.com/blog/2016/how-i-publish-a-npm-package

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -60,8 +60,6 @@ $ git commit -m "fix(role): role.use must xxx"
 $ git push origin branch-name
 ```
 
-提交后就可以在 [egg](https://github.com/eggjs/egg/pulls) 创建 Pull Request 了。
-
 由于谁也无法保证过了多久之后还记得多少，为了后期回溯历史的方便，请在提交 MR 时确保提供了以下信息。
 
 1. 需求点（一般关联 issue 或者注释都算）
@@ -136,7 +134,7 @@ BREAKING CHANGE:
   Breaks foo.bar api, foo.baz should be used instead
 ```
 
-查看具体[文档](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit)
+详情请查看具体[文档](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit)。
 
 ## 发布管理
 
@@ -175,7 +173,7 @@ egg 基于 [semver] 语义化版本号进行发布。
 - 将老的稳定版本（master）备份到以当前大版本为名字的分支上（例如 `1.x`），并设置 tag 为 `release-{v}.x`（ v 为当前版本，例如 `release-1.x`）。
 - 将 `next` 分支推送到 `master`，成为新的稳定版本分支，并去除 `next` tag，修改 README 中与分支相关的内容。
 - 发布新的稳定版本到 [npm]，并通知上层框架进行更新。
-- `npm publish` 之前，请先阅读[『我是如何发布一个 npm 包的』]。
+- `npm publish` 之前，请先阅读 [我是如何发布一个 npm 包的]。
 
 上述描述中所有的设置 tag 都是指在 `package.json` 中设置 npm 的 tag。
 
@@ -185,9 +183,9 @@ egg 基于 [semver] 语义化版本号进行发布。
 }
 ```
 
-[semver]: http://semver.org/lang/zh-CN/
-[Release proposal MR]: https://github.com/nodejs/node/pull/4181
+[semver]: https://semver.org/lang/zh-CN/
+[Release Proposal MR]: https://github.com/nodejs/node/pull/4181
 [node CHANGELOG]: https://github.com/nodejs/node/blob/master/CHANGELOG.md
 [1.x milestone]: https://github.com/eggjs/egg/milestone/1
 [npm]: http://npmjs.com/
-[『我是如何发布一个 npm 包的』]: https://fengmk2.com/blog/2016/how-i-publish-a-npm-package
+[我是如何发布一个 npm 包的]: https://fengmk2.com/blog/2016/how-i-publish-a-npm-package

--- a/lib/core/dnscache_httpclient.js
+++ b/lib/core/dnscache_httpclient.js
@@ -26,8 +26,7 @@ class DNSCacheHttpClient extends HttpClient {
 
     // the callback style
     if (callback) {
-      this.app.deprecate('[dnscache_httpclient] Please don\'t use callback when `request()`');
-
+      this.app.deprecate('[dnscache_httpclient] We now support async for this function, so callback isn\'t recommended.');
       this[DNSLOOKUP](url, args)
         .then(result => {
           return super.request(result.url, result.args);

--- a/test/lib/core/dnscache_httpclient.test.js
+++ b/test/lib/core/dnscache_httpclient.test.js
@@ -24,6 +24,8 @@ describe('test/lib/core/dnscache_httpclient.test.js', () => {
 
   afterEach(mm.restore);
   afterEach(() => {
+    // After trying to set Server Ips forcely,
+    // try to restore them to usual ones
     dns.setServers(originalDNSServers);
   });
 
@@ -42,10 +44,19 @@ describe('test/lib/core/dnscache_httpclient.test.js', () => {
       .expect(/"host":"localhost2\.foo\.com"/);
   });
 
+  /**
+   * This test failure can be totally ignored because it depends on how your service provider
+   * deals with the domain when you cannot find that：Some providers will batchly switch
+   * those invalid domains to a certain server. So you can still find the fixed IP by
+   * calling `dns.lookup()`.
+   *
+   * To make sure that your domain exists or not, just use `ping your_domain_here` instead.
+   */
   it('should throw error when the first dns lookup fail', async () => {
     if (!process.env.CI) {
       // Avoid Network service provider DNS pollution
       // alidns http://www.alidns.com/node-distribution/
+      // Not sure it will work for all servers
       dns.setServers([
         '223.5.5.5',
         '223.6.6.6',
@@ -90,10 +101,19 @@ describe('test/lib/core/dnscache_httpclient.test.js', () => {
     });
   });
 
+  /**
+   * This test failure can be totally ignored because it depends on how your service provider
+   * deals with the domain when you cannot find that：Some providers will batchly switch
+   * those invalid domains to a certain server. So you can still find the fixed IP by
+   * calling `dns.lookup()`.
+   *
+   * To make sure that your domain exists or not, just use `ping your_domain_here` instead.
+   */
   it('should callback style work on domain not exists', done => {
     if (!process.env.CI) {
       // Avoid Network service provider DNS pollution
       // alidns http://www.alidns.com/node-distribution/
+      // Not sure it will work for all servers
       dns.setServers([
         '223.5.5.5',
         '223.6.6.6',
@@ -116,10 +136,19 @@ describe('test/lib/core/dnscache_httpclient.test.js', () => {
     });
   });
 
+  /**
+   * This test failure can be totally ignored because it depends on how your service provider
+   * deals with the domain when you cannot find that：Some providers will batchly switch
+   * those invalid domains to a certain server. So you can still find the fixed IP by
+   * calling `dns.lookup()`.
+   *
+   * To make sure that your domain exists or not, just use `ping your_domain_here` instead.
+   */
   it('should thunk style work on domain not exists', done => {
     if (!process.env.CI) {
       // Avoid Network service provider DNS pollution
       // alidns http://www.alidns.com/node-distribution/
+      // Not sure it will work for all servers
       dns.setServers([
         '223.5.5.5',
         '223.6.6.6',

--- a/test/lib/core/httpclient.test.js
+++ b/test/lib/core/httpclient.test.js
@@ -79,22 +79,6 @@ describe('test/lib/core/httpclient.test.js', () => {
     await client.requestThunk(url, args);
   });
 
-  it.skip('should request error with log', done => {
-    mm.http.requestError(/.*/i, null, 'mock res error');
-
-    client.once('response', info => {
-      assert(info.req.options.headers['mock-traceid'] === 'mock-traceid');
-      assert(info.req.options.headers['mock-rpcid'] === 'mock-rpcid');
-      assert(info.error.message.includes('mock res error'));
-      done();
-    });
-
-    client.request(url).catch(() => {
-      // it will print
-      // console.error(e.stack);
-    });
-  });
-
   describe('httpclient.httpAgent.timeout < 30000', () => {
     let app;
     before(() => {


### PR DESCRIPTION
1) Due to different service providors have a variety ways of coping with
a dns that cannot be analysed, we have to make it clear to users that
dns unit tests may fail (See: #3033).

2) Comment out a skip unit test in 'httpclient.test.js', no need to show
the 'pending' state but with comments above.

3) Add missing English part in CONTRIBUTING.md.

4) Change the warning info, because we can still use this callback but
NOT recommended.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines