### PR TITLE
(backport 1.x) refactor: separate dumping config object and config file

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -323,11 +323,11 @@ class EggApplication extends EggCore {
   }
 
   /**
-   * save app.config to `run/${type}_config.json`
+   * dump out the config and meta object
    * @private
+   * @return {Object} the result
    */
-  dumpConfig() {
-    const rundir = this.config.rundir;
+  dumpConfigToObject() {
     let ignoreList;
     try {
       // support array and set
@@ -335,19 +335,35 @@ class EggApplication extends EggCore {
     } catch (_) {
       ignoreList = [];
     }
+
+    const json = extend(true, {}, { config: this.config, plugins: this.plugins });
+    utils.convertObject(json, ignoreList);
+    return {
+      config: json,
+      meta: this.loader.configMeta,
+    };
+  }
+
+  /**
+   * save app.config to `run/${type}_config.json`
+   * @private
+   */
+  dumpConfig() {
+    const rundir = this.config.rundir;
     try {
       /* istanbul ignore if */
       if (!fs.existsSync(rundir)) fs.mkdirSync(rundir);
 
+      // get dumpped object
+      const { config, meta } = this.dumpConfigToObject();
+
       // dump config
-      const json = extend(true, {}, { config: this.config, plugins: this.plugins });
-      utils.convertObject(json, ignoreList);
       const dumpFile = path.join(rundir, `${this.type}_config.json`);
-      fs.writeFileSync(dumpFile, CircularJSON.stringify(json, null, 2));
+      fs.writeFileSync(dumpFile, CircularJSON.stringify(config, null, 2));
 
       // dump config meta
       const dumpMetaFile = path.join(rundir, `${this.type}_config_meta.json`);
-      fs.writeFileSync(dumpMetaFile, CircularJSON.stringify(this.loader.configMeta, null, 2));
+      fs.writeFileSync(dumpMetaFile, CircularJSON.stringify(meta, null, 2));
     } catch (err) {
       this.coreLogger.warn(`dumpConfig error: ${err.message}`);
     }

--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
+    "index.js",
+    "lib",
     "app",
     "config",
-    "lib",
-    "index.js",
     "index.d.ts"
   ],
   "scripts": {

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -27,9 +27,17 @@ describe('test/lib/egg.test.js', () => {
       assert(json.config.name === 'demo');
       assert(json.config.tips === 'hello egg');
       json = require(path.join(baseDir, 'run/application_config.json'));
-      assert(/\d+\.\d+\.\d+/.test(json.plugins.onerror.version));
-      // should dump dynamic config
-      assert(json.config.tips === 'hello egg started');
+      checkApp(json);
+
+      const dumpped = app.dumpConfigToObject();
+      checkApp(dumpped.config);
+
+      function checkApp(json) {
+        assert(/\d+\.\d+\.\d+/.test(json.plugins.onerror.version));
+        assert(json.config.name === 'demo');
+        // should dump dynamic config
+        assert(json.config.tips === 'hello egg started');
+      }
     });
 
     it('should dump router json', () => {
@@ -52,35 +60,50 @@ describe('test/lib/egg.test.js', () => {
       let json = require(path.join(baseDir, 'run/agent_config_meta.json'));
       assert(json.name === path.join(__dirname, '../../config/config.default.js'));
       assert(json.buffer === path.join(baseDir, 'config/config.default.js'));
+
       json = require(path.join(baseDir, 'run/application_config_meta.json'));
-      assert(json.name === path.join(__dirname, '../../config/config.default.js'));
-      assert(json.buffer === path.join(baseDir, 'config/config.default.js'));
+      checkApp(json);
+
+      const dumpped = app.dumpConfigToObject();
+      checkApp(dumpped.meta);
+
+      function checkApp(json) {
+        assert(json.name === path.join(__dirname, '../../config/config.default.js'));
+        assert(json.buffer === path.join(baseDir, 'config/config.default.js'));
+      }
     });
 
     it('should ignore some type', () => {
       const json = require(path.join(baseDir, 'run/application_config.json'));
-      assert(json.config.mysql.accessId === 'this is accessId');
+      checkApp(json);
 
-      assert(json.config.name === 'demo');
-      assert(json.config.keys === '<String len: 3>');
-      assert(json.config.buffer === '<Buffer len: 4>');
-      assert(json.config.siteFile['/favicon.ico'] === '<Buffer len: 14191>');
+      const dumpped = app.dumpConfigToObject();
+      checkApp(dumpped.config);
 
-      assert(json.config.pass === '<String len: 12>');
-      assert(json.config.pwd === '<String len: 11>');
-      assert(json.config.password === '<String len: 16>');
-      assert(json.config.passwordNew === 'this is passwordNew');
-      assert(json.config.mysql.passd === '<String len: 13>');
-      assert(json.config.mysql.passwd === '<String len: 14>');
-      assert(json.config.mysql.secret === '<String len: 10>');
-      assert(json.config.mysql.secretNumber === '<Number>');
-      assert(json.config.mysql.masterKey === '<String len: 17>');
-      assert(json.config.mysql.accessKey === '<String len: 17>');
-      assert(json.config.mysql.consumerSecret === '<String len: 22>');
-      assert(json.config.mysql.someSecret === null);
+      function checkApp(json) {
+        assert(json.config.mysql.accessId === 'this is accessId');
 
-      // don't change config
-      assert(app.config.keys === 'foo');
+        assert(json.config.name === 'demo');
+        assert(json.config.keys === '<String len: 3>');
+        assert(json.config.buffer === '<Buffer len: 4>');
+        assert(json.config.siteFile['/favicon.ico'].startsWith('<Buffer len:'));
+
+        assert(json.config.pass === '<String len: 12>');
+        assert(json.config.pwd === '<String len: 11>');
+        assert(json.config.password === '<String len: 16>');
+        assert(json.config.passwordNew === 'this is passwordNew');
+        assert(json.config.mysql.passd === '<String len: 13>');
+        assert(json.config.mysql.passwd === '<String len: 14>');
+        assert(json.config.mysql.secret === '<String len: 10>');
+        assert(json.config.mysql.secretNumber === '<Number>');
+        assert(json.config.mysql.masterKey === '<String len: 17>');
+        assert(json.config.mysql.accessKey === '<String len: 17>');
+        assert(json.config.mysql.consumerSecret === '<String len: 22>');
+        assert(json.config.mysql.someSecret === null);
+
+        // don't change config
+        assert(app.config.keys === 'foo');
+      }
     });
 
     it('should console.log call inspect()', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
