### PR TITLE
doc(logger.md): Fix incorrect description on default log output level.

### DIFF
--- a/docs/source/en/core/logger.md
+++ b/docs/source/en/core/logger.md
@@ -134,9 +134,9 @@ Logs are designed in 5 levels, including `NONE`, `DEBUG`, `INFO`, `WARN` and `ER
 
 ### Levels
 
-Generally, Egg will only write logs in levels higher than `INFO`, so it means that `NONE` and `DEBUG` information will be lost in files.
+In production environment, Egg will only write logs with level `INFO` and higher, this means `NONE` and `DEBUG` information will be ignored in log files.
 
-If you want to change the level of the logger, you can make it as follow:
+If you want to change logger's default output level, modify in the config as follow:
 
 ```js
 // config/config.${env}.js


### PR DESCRIPTION
1) Correct logger's default output level in production env. in this doc from 'higher than INFO' to 'higher than DEBUG'.
2) Rephrase the description about log level to avoid confusion.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
修改了英文文档`logger.md`中对于默认日志级别的错误，从原版本的`INFO以上才写入`改为了`DEBUG以上才写入`。并且略微润色完善了上下文对于日志级别的一些描述以避免误解。