### PR TITLE
fix: runInBackground should emit error event

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -218,8 +218,12 @@ const proto = module.exports = {
         ctx.coreLogger.info('[egg:background] task:%s success (%dms)', taskName, Date.now() - start);
       })
       .catch(err => {
+        // background task process log
         ctx.coreLogger.info('[egg:background] task:%s fail (%dms)', taskName, Date.now() - start);
-        ctx.coreLogger.error(err);
+
+        // emit error when promise catch, and set err.runInBackground flag
+        err.runInBackground = true;
+        ctx.app.emit('error', err, ctx);
       });
   },
 };

--- a/test/app/extend/context.test.js
+++ b/test/app/extend/context.test.js
@@ -266,10 +266,19 @@ describe('test/app/extend/context.test.js', () => {
 
     it('should run background task error', async () => {
       mm.consoleLevel('NONE');
+
+      let errorHadEmit = false;
+      app.on('error', (err, ctx) => {
+        assert(err.runInBackground);
+        assert(/ENOENT: no such file or directory/.test(err.message));
+        assert(ctx);
+        errorHadEmit = true;
+      });
       await app.httpRequest()
         .get('/error')
         .expect(200)
         .expect('hello error');
+      assert(errorHadEmit);
       await sleep(5000);
       const logdir = app.config.logger.dir;
       const log = fs.readFileSync(path.join(logdir, 'common-error.log'), 'utf8');


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

对 `runInBackground` 核心使用上没有影响，只是当 `catch()` 到错误时，往 app emit 一个事件

对应用性能影响方面可能需要评估

##### Description of change
<!-- Provide a description of the change below this comment. -->

背景：目前 `runInBackground` 相当于吞掉了异常，默认做了 log，使用方如果想统一收集错误做报表或监控，目前会丢失掉这部分

解决方案：

其实当时想到两种方案
1. 自定义一个 `ctx.customRunInBackground`，在 `runInBackground` 内层自己先包裹 `try catch` 然后把错误收集起来，但是这个方法感觉太挫，而且旧有使用 `runInBackground` 的代码都得 change
2. 在原有 `runInBackground` 的 catch 逻辑里增加事件的暴露，就是这个 mr 的方案
