### PR TITLE
chore(typings): add method `beforeClose` in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -554,6 +554,11 @@ declare module 'egg' {
     addSingleton(name: string, create: any): void;
 
     /**
+     * Register a function that will be called when app close
+     */
+    beforeClose(fn: () => void): void;
+
+    /**
      * Excute scope after loaded and before app start
      */
     beforeStart(scrope: () => void): void;


### PR DESCRIPTION
I try to write a plugin and I noticed that no `beforeClose` method.
![image](https://user-images.githubusercontent.com/9164153/47443706-898df800-d7e7-11e8-8ccf-f44163444910.png)

##### Checklist
- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
typings

##### Description of change
add `beforeClose` definition

