### PR TITLE
fix: triggerServerDidReady should be triggered only once

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -58,7 +58,7 @@ class EggApplication extends EggCore {
 
     // trigger serverDidReady hook when all app workers
     // and agent worker is ready
-    this.messenger.on('egg-ready', () => {
+    this.messenger.once('egg-ready', () => {
       this.lifecycle.triggerServerDidReady();
     });
 

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -345,6 +345,26 @@ describe('test/lib/egg.test.js', () => {
         .expect(200);
     });
   });
+
+  describe('egg-ready', () => {
+    let app;
+    before(() => {
+      app = utils.app('apps/demo');
+    });
+    after(() => app.close());
+
+    it('should only trigger once', async () => {
+      let triggerCount = 0;
+      mm(app.lifecycle, 'triggerServerDidReady', () => {
+        triggerCount++;
+      });
+      await app.ready();
+      app.messenger.emit('egg-ready');
+      app.messenger.emit('egg-ready');
+      app.messenger.emit('egg-ready');
+      assert(triggerCount === 1);
+    });
+  });
 });
 
 function readJson(p) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
Lifecycle

##### Description of change
<!-- Provide a description of the change below this comment. -->
When worker restart, master process broadcast `egg-ready` event to all workers, so worker should listen `egg-ready` only once.
