### PR TITLE
fix: should not log timeout with keepAliveTimeout

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -125,7 +125,7 @@ class Application extends EggApplication {
     }
 
     if (typeof this.config.onClientError === 'function') {
-      const p = eggUtils.callFn(this.config.onClientError, [err, socket, this]);
+      const p = eggUtils.callFn(this.config.onClientError, [ err, socket, this ]);
 
       // the returned object should like:
       //
@@ -169,7 +169,7 @@ class Application extends EggApplication {
 
     /* istanbul ignore next */
     graceful({
-      server: [server],
+      server: [ server ],
       error: (err, throwErrorCount) => {
         if (err.message) {
           err.message += ' (uncaughtException throw ' + throwErrorCount + ' times on pid:' + process.pid + ')';
@@ -282,7 +282,7 @@ class Application extends EggApplication {
        * Files from `${baseDir}/app/helper` will be loaded to the prototype of Helper,
        * then you can use all method on `ctx.helper` that is a instance of Helper.
        */
-      class Helper extends this.BaseContextClass { }
+      class Helper extends this.BaseContextClass {}
       this[HELPER] = Helper;
     }
     return this[HELPER];

--- a/lib/application.js
+++ b/lib/application.js
@@ -125,7 +125,7 @@ class Application extends EggApplication {
     }
 
     if (typeof this.config.onClientError === 'function') {
-      const p = eggUtils.callFn(this.config.onClientError, [ err, socket, this ]);
+      const p = eggUtils.callFn(this.config.onClientError, [err, socket, this]);
 
       // the returned object should like:
       //
@@ -157,7 +157,7 @@ class Application extends EggApplication {
 
   _onServerTimeout(socket) {
     const req = socket.parser.incoming;
-    if (req) {
+    if (req && socket._httpMessage) {
       this.coreLogger.warn('[http_server] A request `%s %s` timeout with client (%s:%d)', req.method, req.url, socket.remoteAddress, socket.remotePort);
     }
     socket.destroy();
@@ -169,7 +169,7 @@ class Application extends EggApplication {
 
     /* istanbul ignore next */
     graceful({
-      server: [ server ],
+      server: [server],
       error: (err, throwErrorCount) => {
         if (err.message) {
           err.message += ' (uncaughtException throw ' + throwErrorCount + ' times on pid:' + process.pid + ')';
@@ -282,7 +282,7 @@ class Application extends EggApplication {
        * Files from `${baseDir}/app/helper` will be loaded to the prototype of Helper,
        * then you can use all method on `ctx.helper` that is a instance of Helper.
        */
-      class Helper extends this.BaseContextClass {}
+      class Helper extends this.BaseContextClass { }
       this[HELPER] = Helper;
     }
     return this[HELPER];


### PR DESCRIPTION
2.14.0加入了自定义的serverTimeout，允许用户配置超时时间，egg可以提醒用户超时，但是由于node自身的机制问题，目前所有请求都会报`timeout with client`的警告。

其原因在于，node的server有两个超时的设置，第一个是timeout，第二个是keepAliveTimeout，详见https://nodejs.org/api/http.html#http_server_keepalivetimeout 

node的http server，timeout默认值为2分钟，而keepAliveTimeout默认为5秒，egg的serverTimeout控制的是第一个timeout值。

timeout值控制的是从请求建立到res.end这一阶段的时间；keepAliveTimeout这个值，是控制从res.end到socket销毁的时间。

不幸的是，keepAliveTimeout的实现机制，利用了server.setTimeout，所以必然会触发timeout callback，详见node源码： https://github.com/nodejs/node/blob/master/lib/_http_server.js#L579 

这就导致了本次bug的出现，任意请求都会触发egg/application里的`_onServerTimeout`方法，打印出了警告日志。

修复的手段其实就是在timeout callback里判断当前的response是否结束，不过由于server.timeout事件是由node自身触发的事件，只带了socket而没有带response，所以不能直接使用response.finished这一属性。

但是keepAliveTimeout绑定回调事件，是在[resOnFinish](https://github.com/nodejs/node/blob/f3b49cfa7b3c2887ca8147b3d47ce1834b3923bf/lib/_http_server.js#L552) 里发生的，在它之前执行了`res.detachSocket(socket)`，而在这个方法里`socket._httpMessage`被置为null，node实现代码如下，详见[这里](https://github.com/nodejs/node/blob/f3b49cfa7b3c2887ca8147b3d47ce1834b3923bf/lib/_http_server.js#L183) 。

```javascript
function detachSocket(socket) {
  assert(socket._httpMessage === this);
  socket.removeListener('close', onServerResponseClose);
  socket._httpMessage = null;
  this.socket = this.connection = null;
};
```

所以可以通过`socket._httpMessage`是否存在来判断这个timeout callback到底是哪个阶段触发的。

也就是在egg/application里的`_onServerTimeout`方法中增加判定即可：
```diff
- if (req) {
+ if (req && socket._httpMessage) {
```
