### PR TITLE
doc: Fix some translations with some icons

### DIFF
--- a/docs/source/en/core/cookie-and-session.md
+++ b/docs/source/en/core/cookie-and-session.md
@@ -156,15 +156,16 @@ exports.deleteSession = function* (ctx) {
 
 What you need to pay special attention to is that you need to avoid the following situations when setting session properties (which can cause field loss, See for details [koa-session source code](https://github.com/koajs/session/blob/master/lib/session.js#L37-L47)):
 
-* do not startsWith `_`
-* can not be `isNew`
+* Don't start with `_`
+* Don't use `isNew`
 
 ```js
-ctx.session._visited = 1;   // ×   --> property will lost
-ctx.session.isNew = 'HeHe'; // ×   --> session keyword, should not write it
+// ❌ Wrong way
+ctx.session._visited = 1;   //   --> property will lost
+ctx.session.isNew = 'HeHe'; //   --> session keyword, should not write it
 
-// right way
-ctx.session.visited = 1;    // ✅  -->  Everything is all right!
+// ✅ Right way
+ctx.session.visited = 1;    //   -->  Everything is all right
 ```
 
 Session is built on top of Cookie.

--- a/docs/source/zh-cn/core/cookie-and-session.md
+++ b/docs/source/zh-cn/core/cookie-and-session.md
@@ -136,11 +136,12 @@ ctx.session = null;
 * 不能为 `isNew`
 
 ```js
-ctx.session._visited = 1;   // ×   --> 该字段会在下一次请求时丢失
-ctx.session.isNew = 'HeHe'; // ×   --> 为内部关键字, 不应该去更改
+// ❌ 错误的用法
+ctx.session._visited = 1;   //    --> 该字段会在下一次请求时丢失
+ctx.session.isNew = 'HeHe'; //    --> 为内部关键字, 不应该去更改
 
-// 正确的用法
-ctx.session.visited = 1;    // ✅  -->  Everything is all right!
+// ✅ 正确的用法
+ctx.session.visited = 1;    //   -->  此处没有问题
 ```
 
 Session 的实现是基于 Cookie 的，默认配置下，用户 Session 的内容加密后直接存储在 Cookie 中的一个字段中，用户每次请求我们网站的时候都会带上这个 Cookie，我们在服务端解密后使用。Session 的默认配置如下：


### PR DESCRIPTION
1) Fix some English translations for 'cookies-and-session.md' file.
2) Union some icons for 'Right' and 'Wrong'.

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines
