### PR TITLE
fix: context declaration not works

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import * as KoaRouter from 'koa-router';
 import { EventEmitter } from 'events'
 import { Readable } from 'stream';
 import { Socket } from 'net';
+import { IncomingMessage, ServerResponse } from 'http';
 import { EggLogger, EggLoggers, LoggerLevel as EggLoggerLevel, EggContextLogger } from 'egg-logger';
 import { HttpClient2, RequestOptions } from 'urllib';
 import EggCookies = require('egg-cookies');
@@ -710,10 +711,16 @@ declare module 'egg' {
   * special properties (e.g: encrypted). So we must remove this property and
   * create our own with the same name.
   */
-  export interface Context extends RemoveSpecProp<KoaApplication.Context, 'cookies'> {
+  export interface Context extends KoaApplication.BaseContext {
     [key: string]: any;
 
     app: Application;
+
+    // property of koa.Context
+    req: IncomingMessage;
+    res: ServerResponse;
+    originalUrl: string;
+    respond?: boolean;
 
     service: IService;
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

原来 egg 的 context 声明是继承自 `koa.Context` 的，但是 egg 里的 context 中的部分属性 `cookie` 跟 koa 里的不是同一个，因此会产生类型不兼容 ( 在 `skipLibCheck` 为 false 的情况下跑 tsc 会报错 )。

在原来的解决方案中，是通过 `RemoveSpecProp` 这个工具类型将 `koa.Context` 中的 cookie 属性删掉再继承，但是最近 koa 的声明发了个版本在 context 声明上加了 `[key: string]: any` ，加了这个声明后就导致 `keyof koa.Context` 拿到的类型就错了，导致现在拿不到 `koa.Context` 里的声明。

我想到的解决方案是直接用 koa 内部的 `BaseContext` 类型，然后将 `req` 这些在 `koa.Context` 中的属性在 `Context` 中重新写一遍，以此来解决类型兼容问题。

https://github.com/eggjs/egg/pull/2958#issuecomment-448485177
