### PR TITLE
fix: Add comments for re-writing properties from Koa

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -710,13 +710,20 @@ declare module 'egg' {
   * the egg's Context interface, which is wrong here because we have our own
   * special properties (e.g: encrypted). So we must remove this property and
   * create our own with the same name.
+  * @see https://github.com/eggjs/egg/pull/2958
+  * 
+  * However, the latest version of Koa has "[key: string]: any" on the
+  * context, and there'll be a type error for "keyof koa.Context".
+  * So we have to directly inherit from "KoaApplication.BaseContext" and
+  * rewrite all the properties to be compatible with types in Koa.
+  * @see https://github.com/eggjs/egg/pull/3329
   */
   export interface Context extends KoaApplication.BaseContext {
     [key: string]: any;
 
     app: Application;
 
-    // property of koa.Context
+    // properties of koa.Context
     req: IncomingMessage;
     res: ServerResponse;
     originalUrl: string;
@@ -789,8 +796,7 @@ declare module 'egg' {
     realStatus: number;
 
     /**
-     * 设置返回资源对象
-     * set the ctx.body.data value
+     * Set the ctx.body.data value
      *
      * @member {Object} Context#data=
      * @example


### PR DESCRIPTION
Because the version of Koa is updated to the latest version,
we cannot simply remove properties but just re-write properties
from the inherited ones. Add more comments on this.

Ref：https://github.com/eggjs/egg/pull/3329

- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines