### PR TITLE
Chore: Fix spellings and update typescript compiler version to 3.X

### DIFF
--- a/docs/assets/lifecycle_en.puml
+++ b/docs/assets/lifecycle_en.puml
@@ -45,8 +45,8 @@ partition agent {
   endfork
   : async willReady;
   note left
-    All the plug-ins are loaded,
-    All the plug-ins are normal,
+    All the plugins are loaded,
+    All the plugins are normal,
     To execute some tasks before request enters,
     E.g: Pull some configs for applications
   end note
@@ -108,8 +108,8 @@ partition app {
   end fork
     : async WillReady;
   note left
-    All the plug-ins are loaded,
-    All the plug-ins are normal,
+    All the plugins are loaded,
+    All the plugins are normal,
     To execute some tasks before request enters,
     E.g: Pull some configs for applications
   end note

--- a/docs/source/en/advanced/loader.md
+++ b/docs/source/en/advanced/loader.md
@@ -189,7 +189,7 @@ The framework has provided you several functions to handle during the whole life
 - `configWillLoad`: All the config files are ready to load, so this is the LAST chance to modify them.
 - `configDidLoad`: When all the config files have been loaded.
 - `didLoad`: When all the files have been loaded.
-- `willReady`: When all the plug-ins are ready.
+- `willReady`: When all the plugins are ready.
 - `didReady`: When all the workers are ready.
 - `serverDidReady`: When the server is ready.
 - `beforeClose`: Before the application is closed.
@@ -241,7 +241,8 @@ module.exports = AppBootHook;
 The framework will automatically load and initialize this class after developers have defined `app.js` and `agenet.js` in the form of class, and it will call the corresponding methods during each of the life cycles.
 
 Here's the image of starting process:
-![](https://user-images.githubusercontent.com/40081831/47344099-3bd79980-d6da-11e8-8bc2-5adad70cdf95.png)
+
+![](https://user-images.githubusercontent.com/40081831/50545997-4757bb80-0c5b-11e9-83e0-803bbd6576b3.png)
 
 **Notice: We have an expiring time limitation when using `beforeClose` to close the processing of the framework. If a worker has accepted the signal of exit but doesn't exit within the limit period, it will be FORCELY closed.**
 
@@ -251,11 +252,11 @@ Deprecated methods:
 
 ## beforeStart
 
-`beforeStart` is called during the loading process, all of its methods are running in parallel. So we usually execute some asynchronized methods (e.g: Check the state of connection, in [`egg-mysql`](https://github.com/eggjs/egg-mysql/blob/master/lib/mysql.js) we use this method to check the connection state with mysql). When all the tasks in `beforeStart` finished, the state will be `ready`. It's NOT recommended to excute a function that consumes too much time there, which will cause the expiration of application's start.Plug-in developers should use `didLoad` instead, for application developers, `willReady` is the replacer.
+`beforeStart` is called during the loading process, all of its methods are running in parallel. So we usually execute some asynchronized methods (e.g: Check the state of connection, in [`egg-mysql`](https://github.com/eggjs/egg-mysql/blob/master/lib/mysql.js) we use this method to check the connection state with mysql). When all the tasks in `beforeStart` finished, the state will be `ready`. It's NOT recommended to excute a function that consumes too much time there, which will cause the expiration of application's start.plugin developers should use `didLoad` instead, for application developers, `willReady` is the replacer.
 
 ## ready
 
-All the methods mounted on `ready` will be executed when load ends, and after all the methods in `beforeStart` have finished executing. By the time Http server's listening also starts. This means all the plug-ins are fully loaded and everything is ready, So we use it to process some tasks after start. For developers now, we use `didReady` instead.
+All the methods mounted on `ready` will be executed when load ends, and after all the methods in `beforeStart` have finished executing. By the time Http server's listening also starts. This means all the plugins are fully loaded and everything is ready, So we use it to process some tasks after start. For developers now, we use `didReady` instead.
 
 ## beforeClose
 

--- a/docs/source/en/basics/controller.md
+++ b/docs/source/en/basics/controller.md
@@ -312,7 +312,7 @@ If user request exceeds the maximum length for parsing that we configured, the f
 
 ### Acquire the submitted files
 
-The `body` in the request can carry parameters as well as files. Generally speaking, our browsers always send files in `multipart/form-data`, and we now have two kinds of ways supporting submitting and acquiring files with the help of the framework's plug-in [Multipart](https://github.com/eggjs/egg-multipart).
+The `body` in the request can carry parameters as well as files. Generally speaking, our browsers always send files in `multipart/form-data`, and we now have two kinds of ways supporting submitting and acquiring files with the help of the framework's plugin [Multipart](https://github.com/eggjs/egg-multipart).
 
 - #### `File` Mode:
 If you have no ideas about Nodejs's Stream at all, the `File` mode suits you well:

--- a/docs/source/en/basics/plugin.md
+++ b/docs/source/en/basics/plugin.md
@@ -57,7 +57,7 @@ Then you need to declare it in the `config / plugin.js` application or framework
 
 ```js
 // config / plugin.js
-// Use mysql plug-in
+// Use mysql plugin
 exports.mysql = {
   enable: true,
   package: 'egg-mysql'

--- a/docs/source/en/core/security.md
+++ b/docs/source/en/core/security.md
@@ -20,13 +20,13 @@ The framework itself has a rich solution for common security risks on the Web si
 - customizable white list for safe redirect and url filtering.
 - all kinds of template related tools for preprocessing.
 
-Security plug-ins [egg-security](https://github.com/eggjs/egg-security) are built into the framework, provides default security practices.
+Security plugins [egg-security](https://github.com/eggjs/egg-security) are built into the framework, provides default security practices.
 
 ### Open or close the configuration
 
-Note: it is not recommended to turn off the functions provided by the security plug-ins unless the consequences are clearly confirmed.
+Note: it is not recommended to turn off the functions provided by the security plugins unless the consequences are clearly confirmed.
 
-The security plug-in for the framework opens by default, if we want to close some security protection, directly set the `enable` attribute to false. For example, close xframe precautions:
+The security plugin for the framework opens by default, if we want to close some security protection, directly set the `enable` attribute to false. For example, close xframe precautions:
 
 
 ```js
@@ -296,7 +296,7 @@ module.exports = {
 };
 ```
 
-In order to prevent the [BREACH attack](http://breachattack.com/), CSRF token rendered on the page will be changed everytime request changed, and the view plug-in, such as `egg-view-nunjucks`, will automatically inject the hidden field in Form without any perception of the application developer.
+In order to prevent the [BREACH attack](http://breachattack.com/), CSRF token rendered on the page will be changed everytime request changed, and the view plugin, such as `egg-view-nunjucks`, will automatically inject the hidden field in Form without any perception of the application developer.
 
 ##### AJAX Request
 

--- a/docs/source/en/intro/index.md
+++ b/docs/source/en/intro/index.md
@@ -4,9 +4,9 @@ title: What is Egg?
 **Egg is born for building enterprise application and framework**，we hope Egg will give birth to more application framework to help developers and developing team reduce development and maintenance costs.
 ## Design principles
 
-Since we know well that enterprise applications need to consider how to balance the differences between different teams, seeking common ground while reserving differences in the pursuit of clarifying specification and cooperation, we focus on providing core features for Web development and a flexible and extensible plug-in mechanism instead of giant bazaar mode which is popular in common Web frameworks(with integrated such as database, template engine, front-end framework and other functions). We will not make technical selection because default technical selection makes the scalability of the framework too poor to meet a variety of custom requirements. With the help of Egg , it is very easy for architects and technical leaders to build their own framework which is suitable for their business scenarios based on existing technology stack .
+Since we know well that enterprise applications need to consider how to balance the differences between different teams, seeking common ground while reserving differences in the pursuit of clarifying specification and cooperation, we focus on providing core features for Web development and a flexible and extensible plugin mechanism instead of giant bazaar mode which is popular in common Web frameworks (with integrated such as database, template engine, front-end framework and other functions). We will not make technical selection because default technical selection makes the scalability of the framework too poor to meet a variety of custom requirements. With the help of Egg, it is very easy for architects and technical leaders to build their own framework which is suitable for their business scenarios based on existing technology stack .
 
-The plug-in mechanism of Egg is very extensible, **one purpose for one plugin**(Eg: [Nunjucks] is encapsulated into [egg-view-nunjucks](https://github.com/eggjs/egg-view-nunjucks), and MySQL is encapsulated into [egg-mysql](https://github.com/eggjs/egg-mysql)). Aggregating the plugins and customizing the configurations according to their own business scenarios greatly reduces the development cost.
+The plugin mechanism of Egg is very extensible, **one purpose for one plugin**(Eg: [Nunjucks] is encapsulated into [egg-view-nunjucks](https://github.com/eggjs/egg-view-nunjucks), and MySQL is encapsulated into [egg-mysql](https://github.com/eggjs/egg-mysql)). Aggregating the plugins and customizing the configurations according to their own business scenarios greatly reduces the development cost.
 
 Egg is a convention-over-configuration framework, follows the [Loader](../advanced/loader.md) to do the development, it helps to reduce the cost of learning. Developers no longer work as 'nails'. The cost of communication is very high for a team without convention. it is easy to get fault without convention. However convention is not equal to diffcult extension, instead, Egg does well in extension part, you can build your own framework according to team convention.  [Loader](../advanced/loader.md) can help load different default configuration in different environment, Egg default convention can also be covered by your own.
 
@@ -14,12 +14,12 @@ Egg is a convention-over-configuration framework, follows the [Loader](../advanc
 
 [Express] is well used in Node.js community, it is easy and extensible, fit personal project a lot. However, without default convention, standard mvc model has lots of strange impl which would lead to misunderstandings. Egg's teamwork cost is really low by following convention convention-over-configuration.
 
-[Sails] is a framework that also follows convention-over-configuration,it does well in extensible work. Compared with Egg, [Sails] supports blueprint REST API, [WaterLine] , Frontend integration, WebSocket and so on, all of these are provided by Sails. Egg does not provide these functions, it only has integration of different functional extensions, such as egg-blueprint, egg-waterline, if you use sails-egg to integrate these extensions, [Sails] can be replaced.
+[Sails] is a framework that also follows convention-over-configuration,it does well in extensible work. Compared with Egg, [Sails] supports blueprint REST API, [WaterLine] , Frontend integration, WebSocket and so on, all of these are provided by [Sails]. Egg does not provide these functions, it only has integration of different functional extensions, such as egg-blueprint, egg-waterline, if you use sails-egg to integrate these extensions, [Sails] can be replaced.
 
 ## features
 
 - Provide capability to [customizd framework](../advanced/framework.md) base on Egg
-- Highly extensible [plug-in mechanism](../basics/plugin.md)
+- Highly extensible [plugin mechanism](../basics/plugin.md)
 - Built-in [cluster](../advanced/cluster-client.md)
 - Based on [Koa] with high performance
 - Stable core framework with high test coverage

--- a/docs/source/en/intro/quickstart.md
+++ b/docs/source/en/intro/quickstart.md
@@ -148,14 +148,14 @@ In most cases, data are usually read, processed and rendered by the templates be
 Thus we need to introduce corresponding template engines to handle it.
 
 Egg does not force to use any particular template engines,
-but specifies the [View Plug-ins Specification](../advanced/view-plugin.md)
-to allow the developers to use different plug-ins for their individual needs instead.
+but specifies the [View Plugins Specification](../advanced/view-plugin.md)
+to allow the developers to use different plugins for their individual needs instead.
 
 For more information, cf. [View](../core/view.md).
 
 In this example, we will use [Nunjucks].
 
-First install the corresponding plug-in [egg-view-nunjucks].
+First install the corresponding plugin [egg-view-nunjucks].
 
 ```bash
 $ npm i egg-view-nunjucks --save
@@ -239,7 +239,7 @@ module.exports = app => {
 Open a browser window and navigate to http://localhost:7001/news.
 You should be able to see the rendered page.
 
-**Tip：In development, Egg enables the [development][egg-development] plug-in by default, which reloads your worker process when changes are made to your back-end code.**
+**Tip：In development, Egg enables the [development][egg-development] plugin by default, which reloads your worker process when changes are made to your back-end code.**
 
 ### Create a Service
 
@@ -392,7 +392,7 @@ it is inevitable that we need to manage configurations.
 Egg provides a powerful way to manage them in a merged configuration file.
 
 - Environment-specific configuration files are well supported, e.g. config.local.js, config.prod.js, etc.
-- Configurations could be set wherever convenient, e.g. near Applications/Plug-ins/Framesworks, and Egg will be careful to merge and load them.
+- Configurations could be set wherever convenient for Applications/Plugins/Framesworks, and Egg will be careful to merge and load them.
 - For more information on merging, see [Configurations](../basics/config.md).
 
 ```js

--- a/docs/source/en/tutorials/typescript.md
+++ b/docs/source/en/tutorials/typescript.md
@@ -8,7 +8,7 @@ For a large number of enterprises' applications, TypeScript's static type checki
 However, we've met some problems influencing users' experience when developing Egg in TypeScript:
 
 * The most outstanding Loader Mechanism (Auto-loading) makes TS not analyze dependencies in static.
-* How to validate and show intellisense in `config.{env}.js`, when we modify settings by plug-in and these configurations are automatically merged?
+* How to validate and show intellisense in `config.{env}.js`, when we modify settings by plugin and these configurations are automatically merged?
 * During the period of developing, `tsc -w` is created as an independent process to build up codes, it makes us entangled about where to save the temporary files, and the complicated `npm scripts`.
 * How to map to the TS source files instead of compiled js files in unit tests, coverage tests and error stacks online?
 
@@ -42,7 +42,7 @@ The boilerplate above will create a very simple example, for a detailed one plea
 **Some constraints:**
 
 * We've no plans for re-writing Egg in TS yet.
-* Egg itself, with its plug-in, will have corresponding `index.d.ts` for users to use easily.
+* Egg itself, with its plugin, will have corresponding `index.d.ts` for users to use easily.
 * TypeScript only belongs to a communication practice. We support it to some extent with our tool chain.
 * TypeScript's version MUST BE 2.8 at least.
 
@@ -241,7 +241,7 @@ export interface BizConfig {
 export default (appInfo: EggAppInfo) => {
   const config = {} as PowerPartial<EggAppConfig> & BizConfig;
 
-  // Override the framework, plug-in's configurations
+  // Override the framework, plugin's configurations
   config.keys = appInfo.name + '123456';
   config.view = {
     defaultViewEngine: 'nunjucks',
@@ -290,7 +290,7 @@ type PowerPartial<T> = {
 };
 ```
 
-### Plug-in
+### Plugin
 
 ```javascript
 // config/plugin.ts
@@ -552,16 +552,16 @@ For more detailed info:
 
 ---
 
-## Guides to the developments of Plug-in/Framework
+## Guides to the developments of Plugin/Framework
 
 **Principles:**
 
-* DO NOT recommend to develop plug-in/framework in TS directly, we should publish them in js to npm.
-* When you write a plug-in/framework, the corresponding `index.d.ts` should be included.
-* By [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) we can inject the functions of plug-in/framework into Egg.
+* DO NOT recommend to develop plugin/framework in TS directly, we should publish them in js to npm.
+* When you write a plugin/framework, the corresponding `index.d.ts` should be included.
+* By [Declaration Merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) we can inject the functions of plugin/framework into Egg.
 * All are mounted on `egg` module, DO NOT use the outer layer.
 
-### Plug-in
+### Plugin
 
 Styles can be referred from the automatically generated `egg-ts-helper`:
 
@@ -606,11 +606,11 @@ Definitions:
 
 import * as Egg from 'egg';
 
-// With 'import' to include the outer framework's plug-in.
+// With 'import' to include the outer framework's plugin.
 import 'my-plugin';
 
 declare module 'egg' {
-  // Extend egg like plug-in...
+  // Extend egg like plugin...
 }
 
 // Export the whole Egg

--- a/docs/source/zh-cn/intro/index.md
+++ b/docs/source/zh-cn/intro/index.md
@@ -17,7 +17,7 @@ Egg 奉行『**约定优于配置**』，按照[一套统一的约定](../advanc
 
 [Express] 是 Node.js 社区广泛使用的框架，简单且扩展性强，非常适合做个人项目。但框架本身缺少约定，标准的 MVC 模型会有各种千奇百怪的写法。Egg 按照约定进行开发，奉行『约定优于配置』，团队协作成本低。
 
-[Sails] 是和 Egg 一样奉行『约定优于配置』的框架，扩展性也非常好。但是相比 Egg，[Sails] 支持 Blueprint REST API、[WaterLine] 这样可扩展的 ORM、前端集成、WebSocket 等，但这些功能都是由 Sails 提供的。而 Egg 不直接提供功能，只是集成各种功能插件，比如实现 egg-blueprint，egg-waterline 等这样的插件，再使用 sails-egg 框架整合这些插件就可以替代 [Sails] 了。
+[Sails] 是和 Egg 一样奉行『约定优于配置』的框架，扩展性也非常好。但是相比 Egg，[Sails] 支持 Blueprint REST API、[WaterLine] 这样可扩展的 ORM、前端集成、WebSocket 等，但这些功能都是由 [Sails] 提供的。而 Egg 不直接提供功能，只是集成各种功能插件，比如实现 egg-blueprint，egg-waterline 等这样的插件，再使用 sails-egg 框架整合这些插件就可以替代 [Sails] 了。
 
 ## 特性
 

--- a/docs/source/zh-cn/tutorials/typescript.md
+++ b/docs/source/zh-cn/tutorials/typescript.md
@@ -289,7 +289,7 @@ type PowerPartial<T> = {
 };
 ```
 
-### 插件（Plug-in）
+### 插件（Plugin）
 
 ```javascript
 // config/plugin.ts

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "spy": "^1.0.0",
     "supertest": "^3.3.0",
     "ts-node": "^3.0.6",
-    "typescript": "^2.8.0",
+    "typescript": "^3.2.2",
     "webstorm-disable-index": "^1.1.2"
   },
   "main": "index.js",


### PR DESCRIPTION
 1. For "Sails" in both Chinese and English versions, we should also add the links for them.
 2. Union the spellings of "Plugin" instead of "Plug-in".

 **3. IMPORTANT!! 
Update to the latest version of Typescript, because yard has used "unknown" type, which MUST BE supported since v3.X.**

Here's the screenshot before update:
![unknown](https://user-images.githubusercontent.com/40081831/50546923-4169d680-0c6b-11e9-9081-fd4c275bc470.PNG)

- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines