### PR TITLE
Chore: Fix some chore issues

### DIFF
--- a/docs/source/en/tutorials/typescript.md
+++ b/docs/source/en/tutorials/typescript.md
@@ -667,7 +667,7 @@ On the contrary, `ts-node` can reduce the cost of management for compiled files 
 
 There're mainly two reasons causing this problem:
 
-**1. No related defination 'd.ts' file for the plugin**
+**1. No related defination `d.ts` file for the plugin**
 
 If you want to load some object into egg, you MUST follow the `Plugin / Framework Development Instructions` below by making a declaration file into your own plugin.
 
@@ -699,11 +699,11 @@ If you use `egg-ts-helper`, it will automatically generate the exclipit importin
 import 'egg-dashboard';
 ```
 
-**Notice: You MUST use 'import' in 'd.ts', because most of egg's plugins are without main entry points. There'll be errors occuring if you import directly in ts.**
+**Notice: You MUST use 'import' in `d.ts`, because most of egg's plugins are without main entry points. There'll be errors occuring if you import directly in ts.**
 
 ### `paths` is invalid in `tsconfig.json`
 
-Strictly speaking, this has nothing to do with egg but with many people's questions, and we'll give our answer to it. The reason is `tsc` WON'T convert the import path when compiling ts to js, so when you config paths in `tsconfig.json` and if you use `paths` to import the related modules, you are running the high risk that you cannot find them when compiled to js.
+Strictly speaking, this has nothing to do with egg but with many people's questions, and we'll give our answer to it. The reason is `tsc` WON'T convert the import path when compiling ts to js, so when you config `paths` in `tsconfig.json` and if you use `paths` to import the related modules, you are running the high risk that you cannot find them when compiled to js.
 
 The solution is either you don't use `paths`, or you can ONLY import some declarations instead of detailed values. Another way is that you can use [tsconfig-paths](https://github.com/dividab/tsconfig-paths) to hook the process logic in node's path module to support `paths` in `tsconfig.json`.
 

--- a/docs/source/zh-cn/advanced/loader.md
+++ b/docs/source/zh-cn/advanced/loader.md
@@ -89,7 +89,7 @@ module.exports = {
 +-----------------------------------+--------+
 ```
 
-## loadUnit
+## 加载单元（loadUnit）
 
 Egg 将应用、框架和插件都称为加载单元（loadUnit），因为在代码结构上几乎没有什么差异，下面是目录结构
 
@@ -183,7 +183,7 @@ plugin1 为 framework1 依赖的插件，配置合并后 object key 的顺序会
 - 加载 [controller](../basics/controller.md)，加载应用的 `app/controller` 目录
 - 加载 [router](../basics/router.md)，加载应用的 `app/router.js`
 
-注意
+注意：
 
 - 加载时如果遇到同名的会覆盖，比如想要覆盖 `ctx.ip` 可以直接在应用的 `app/extend/context.js` 定义 ip 就可以了。
 - 应用完整启动顺序查看[框架开发](./framework.md)

--- a/docs/source/zh-cn/tutorials/typescript.md
+++ b/docs/source/zh-cn/tutorials/typescript.md
@@ -699,7 +699,7 @@ declare module 'egg' {
 import 'egg-dashboard';
 ```
 
-**注意：必须在 d.ts 中 import ，因为 egg 插件大部分没有入口文件，如果在 ts 中 import 的话运行会出问题。**
+**注意：必须在 d.ts 中 import，因为 egg 插件大部分没有入口文件，如果在 ts 中 import 的话运行会出问题。**
 
 ### 在 tsconfig.json 中配置了 paths 无效
 


### PR DESCRIPTION
**1) typescript.md (English version):**
Use ` instead of '.

**2) loader.md (Chinese version):**
Translation 'loadUnit'.

**3) typescript.md (Chinese version):**
Remove duplicated space.

---
- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines