### PR TITLE
fix: IMiddleware type is incompatible

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -466,7 +466,7 @@ declare module 'egg' {
     headers: { [key: string]: string };
   }
 
-  export interface Router extends KoaRouter {
+  export interface Router extends KoaRouter<any, Context> {
     /**
      * restful router api
      */

--- a/test/fixtures/apps/app-ts/app/middleware/index.d.ts
+++ b/test/fixtures/apps/app-ts/app/middleware/index.d.ts
@@ -1,0 +1,7 @@
+import TestMiddleware from './test';
+
+declare module 'egg' {
+  interface IMiddleware {
+    test: typeof TestMiddleware;
+  }
+}

--- a/test/fixtures/apps/app-ts/app/middleware/test.ts
+++ b/test/fixtures/apps/app-ts/app/middleware/test.ts
@@ -1,0 +1,8 @@
+import { Context } from 'egg';
+
+export default () => {
+  return async (ctx: Context, next: () => Promise<any>) => {
+    ctx.locals.url = ctx.url;
+    await next();
+  };
+}

--- a/test/fixtures/apps/app-ts/app/router.ts
+++ b/test/fixtures/apps/app-ts/app/router.ts
@@ -2,6 +2,7 @@ import { Application } from 'egg';
 
 export default (app: Application) => {
   const controller = app.controller;
-  app.get('/foo', app.middleware.test(), controller.foo.getData);
+  app.router.get('/test', app.middleware.test(), controller.foo.getData);
+  app.get('/foo', controller.foo.getData);
   app.post('/', controller.foo.getData);
 }

--- a/test/fixtures/apps/app-ts/app/router.ts
+++ b/test/fixtures/apps/app-ts/app/router.ts
@@ -2,6 +2,6 @@ import { Application } from 'egg';
 
 export default (app: Application) => {
   const controller = app.controller;
-  app.get('/foo', controller.foo.getData);
+  app.get('/foo', app.middleware.test(), controller.foo.getData);
   app.post('/', controller.foo.getData);
 }

--- a/test/ts/index.test.js
+++ b/test/ts/index.test.js
@@ -47,5 +47,13 @@ describe('test/ts/index.test.js', () => {
         .expect({ env: 'unittest' })
         .end(done);
     });
+
+    it('controller of app.router run ok', done => {
+      request(app.callback())
+        .get('/test')
+        .expect(200)
+        .expect({ env: 'unittest' })
+        .end(done);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

使用 `app.router.get` 等路由方法的时候，`KoaRouter` 中的 middleware 类型跟 `(ctx: Context, next: () => Promise<any>)` 这种写法的类型是不兼容的。因为其定义的类型是 `IRouterParamContext & T`。这个 T 默认是 `{}`。

所以改成 `Context` 从而兼容 egg 中 middleware 的写法