### PR TITLE
fix(types): array supporting for config.static.dir

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -428,7 +428,7 @@ declare module 'egg' {
 
     static: {
       prefix: string;
-      dir: string;
+      dir: string | string[];
       // support lazy load
       dynamic: boolean;
       preload: boolean;


### PR DESCRIPTION
egg-static plugin supports array of paths for the config property `dir`.

fix type defined in `index.d.ts`.

##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines