### PR TITLE
fix: support send without to argument

### DIFF
--- a/lib/core/messenger/local.js
+++ b/lib/core/messenger/local.js
@@ -88,29 +88,31 @@ class Messenger extends EventEmitter {
    * @return {Messenger} this
    */
   send(action, data, to) {
-    const { egg } = this;
-    let application;
-    let agent;
-    let opposite;
-    if (egg.type === 'application') {
-      application = egg;
-      agent = egg.agent;
-      opposite = agent;
-    } else {
-      agent = egg;
-      application = egg.application;
-      opposite = application;
-    }
-
     // use nextTick to keep it async as IPC messenger
     process.nextTick(() => {
-      if (application.messenger && (to === 'application' || to === 'both')) {
+      const { egg } = this;
+      let application;
+      let agent;
+      let opposite;
+
+      if (egg.type === 'application') {
+        application = egg;
+        agent = egg.agent;
+        opposite = agent;
+      } else {
+        agent = egg;
+        application = egg.application;
+        opposite = application;
+      }
+      if (!to) to = egg.type === 'application' ? 'agent' : 'application';
+
+      if (application && application.messenger && (to === 'application' || to === 'both')) {
         application.messenger._onMessage({ action, data });
       }
-      if (agent.messenger && (to === 'agent' || to === 'both')) {
+      if (agent && agent.messenger && (to === 'agent' || to === 'both')) {
         agent.messenger._onMessage({ action, data });
       }
-      if (opposite.messenger && to === 'opposite') {
+      if (opposite && opposite.messenger && to === 'opposite') {
         opposite.messenger._onMessage({ action, data });
       }
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

fix local messenger:

- `send()` support without `to`
- `send()` don't throw before app/agent ready and assigned