### PR TITLE
fix: helper type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,27 +44,27 @@ declare module 'egg' {
     /**
      * request context
      */
-    ctx: Context;
+    protected ctx: Context;
 
     /**
      * Application
      */
-    app: Application;
+    protected app: Application;
 
     /**
      * Application config object
      */
-    config: EggAppConfig;
+    protected config: EggAppConfig;
 
     /**
      * service
      */
-    service: IService;
+    protected service: IService;
 
     /**
      * logger
      */
-    logger: EggLogger;
+    protected logger: EggLogger;
 
     constructor(ctx: Context);
   }
@@ -937,7 +937,7 @@ declare module 'egg' {
 
   export interface IMiddleware extends PlainObject { } // tslint:disable-line
 
-  export interface IHelper extends PlainObject {
+  export interface IHelper extends PlainObject, BaseContextClass {
     /**
      * Generate URL path(without host) for route. Takes the route name and a map of named params.
      * @method Helper#pathFor

--- a/test/fixtures/apps/app-ts/app/controller/foo.ts
+++ b/test/fixtures/apps/app-ts/app/controller/foo.ts
@@ -12,6 +12,7 @@ export default class FooController extends Controller {
   async getData() {
     try {
       this.ctx.logger.info('getData');
+      this.ctx.helper.test();
       this.ctx.body = await this.ctx.service.foo.bar();
       this.ctx.proxy.foo.bar();
     } catch (e) {

--- a/test/fixtures/apps/app-ts/app/extend/context.ts
+++ b/test/fixtures/apps/app-ts/app/extend/context.ts
@@ -1,0 +1,7 @@
+import { Context } from 'egg';
+
+export default {
+  test(this: Context) {
+    return this.url;
+  },
+}

--- a/test/fixtures/apps/app-ts/app/extend/helper.ts
+++ b/test/fixtures/apps/app-ts/app/extend/helper.ts
@@ -1,0 +1,11 @@
+import { IHelper } from 'egg';
+
+export default {
+  test(this: IHelper) {
+    this.test2();
+  },
+
+  test2(this: IHelper) {
+    this.ctx.logger.info(this.ctx.test());
+  }
+}

--- a/test/fixtures/apps/app-ts/app/extend/index.d.ts
+++ b/test/fixtures/apps/app-ts/app/extend/index.d.ts
@@ -1,0 +1,9 @@
+import ExtendHelper from './helper';
+import ExtendContext from './context';
+
+declare module 'egg' {
+  type ExtendHelperType = typeof ExtendHelper;
+  type ExtendContextType = typeof ExtendContext;
+  interface IHelper extends ExtendHelperType { }
+  interface Context extends ExtendContextType { }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

将 IHelper 改成继承 BaseContextClass ，在写 helper 的 extend 的时候，将 this type 指定为 IHelper 才能拿到 `this.ctx` ，顺便将 BaseContextClass 里的 ctx、app 等改成 protected ，在外部使用的时候就不会出现这些干扰类型。
