### PR TITLE
doc (typescript.md): Chinese translation for the beginning of TypeScript's Introduction

### DIFF
--- a/docs/source/zh-cn/tutorials/typescript.md
+++ b/docs/source/zh-cn/tutorials/typescript.md
@@ -1,7 +1,7 @@
 title: TypeScript
 ---
 
-> [TypeScript](https://www.typescriptlang.org/) is a typed superset of JavaScript that compiles to plain JavaScript.
+> [TypeScript](https://www.tslang.cn/) 是 JavaScript 类型的超集，它可以编译成纯 JavaScript。
 
 TypeScript 的静态类型检查，智能提示，IDE 友好性等特性，对于大规模企业级应用，是非常的有价值的。详见：[TypeScript体系调研报告](https://juejin.im/post/59c46bc86fb9a00a4636f939) 。
 

--- a/docs/source/zh-cn/tutorials/typescript.md
+++ b/docs/source/zh-cn/tutorials/typescript.md
@@ -1,9 +1,9 @@
 title: TypeScript
 ---
 
-> [TypeScript](https://www.tslang.cn/) 是 JavaScript 类型的超集，它可以编译成纯 JavaScript。
+> [TypeScript](https://www.typescriptlang.org/) 是 JavaScript 类型的超集，它可以编译成纯 JavaScript。
 
-TypeScript 的静态类型检查，智能提示，IDE 友好性等特性，对于大规模企业级应用，是非常的有价值的。详见：[TypeScript体系调研报告](https://juejin.im/post/59c46bc86fb9a00a4636f939) 。
+TypeScript 的静态类型检查，智能提示，IDE 友好性等特性，对于大规模企业级应用，是非常的有价值的。详见：[TypeScript 体系调研报告](https://juejin.im/post/59c46bc86fb9a00a4636f939) 。
 
 然而，此前使用 TypeScript 开发 Egg ，会遇到一些影响 **开发者体验** 问题：
 


### PR DESCRIPTION
Since we have a Chinese version of TypeScript, so we can directly refer it instead of referring an English introduction.

---
- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines