### PR TITLE
fix: getFileStream options types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -678,24 +678,24 @@ declare module 'egg' {
   }
                    
   interface GetFileStreamOptions {
-    requireFile?: boolean // required file submit, default is true
-    defCharset?: string
+    requireFile?: boolean; // required file submit, default is true
+    defCharset?: string;
     limits?: {
-      fieldNameSize: number
-      fieldSize: number
-      fields: number
-      fileSize: number
-      files: number
-      parts: number
-      headerPairs: number
-    }
+      fieldNameSize?: number;
+      fieldSize?: number;
+      fields?: number;
+      fileSize?: number;
+      files?: number;
+      parts?: number;
+      headerPairs?: number;
+    };
     checkFile?(
       fieldname: string,
       file: any,
       filename: string,
       encoding: string,
       mimetype: string
-    ): void | Error
+    ): void | Error;
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -676,6 +676,19 @@ declare module 'egg' {
 
     truncated: boolean;
   }
+                   
+  interface GetFileStreamOptions {
+    requireFile?: boolean // required file submit, default is true
+    defCharset?: string
+    limits?: any
+    checkFile?(
+      fieldname: string,
+      file: any,
+      filename: string,
+      encoding: string,
+      mimetype: string
+    ): any
+  }
 
   /**
   * KoaApplication's Context will carry the default 'cookie' property in
@@ -893,10 +906,11 @@ declare module 'egg' {
      * console.log(stream.fields);
      * ```
      * @method Context#getFileStream
+     * @param {Object} options
      * @return {ReadStream} stream
      * @since 1.0.0
      */
-    getFileStream(): Promise<FileStream>;
+    getFileStream(options: GetFileStreamOptions): Promise<FileStream>;
 
     /**
      * @see Responce.redirect

--- a/index.d.ts
+++ b/index.d.ts
@@ -681,16 +681,16 @@ declare module 'egg' {
     requireFile?: boolean // required file submit, default is true
     defCharset?: string
     limits?: {
-      fieldNameSize: number,
-      fieldSize: number,
-      fields: number,
-      fileSize: number,
-      files: number,
-      parts: number,
+      fieldNameSize: number
+      fieldSize: number
+      fields: number
+      fileSize: number
+      files: number
+      parts: number
       headerPairs: number
     }
     checkFile?(
-      fieldname: string;
+      fieldname: string,
       file: any,
       filename: string,
       encoding: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -680,14 +680,22 @@ declare module 'egg' {
   interface GetFileStreamOptions {
     requireFile?: boolean // required file submit, default is true
     defCharset?: string
-    limits?: any
+    limits?: {
+      fieldNameSize: number,
+      fieldSize: number,
+      fields: number,
+      fileSize: number,
+      files: number,
+      parts: number,
+      headerPairs: number
+    }
     checkFile?(
-      fieldname: string,
+      fieldname: string;
       file: any,
       filename: string,
       encoding: string,
       mimetype: string
-    ): any
+    ): void | Error
   }
 
   /**
@@ -910,7 +918,7 @@ declare module 'egg' {
      * @return {ReadStream} stream
      * @since 1.0.0
      */
-    getFileStream(options: GetFileStreamOptions): Promise<FileStream>;
+    getFileStream(options?: GetFileStreamOptions): Promise<FileStream>;
 
     /**
      * @see Responce.redirect


### PR DESCRIPTION
fix: method getFileStream is lack of parameter types

##### Checklist
* [x] `npm test` passes
* [x] commit message follows commit guidelines

##### Description of change
line: 679 add interface GetFileStreamOptions
line: 909 add '@param {Object} options'
line: 913 modify getFileStream() to getFileStream(options:GetFileStreamOptions)