### PR TITLE
Fix(cluster-client.test.js)：Rollback 

### DIFF
--- a/test/lib/cluster/cluster-client.test.js
+++ b/test/lib/cluster/cluster-client.test.js
@@ -65,13 +65,8 @@ describe('test/lib/cluster/cluster-client.test.js', () => {
     });
     after(async () => {
       await app.close();
-
-      assert(app.registryClient.isClusterClientLeader);
-      assert(app.agent.registryClient.isClusterClientLeader);
-      assert(app.registryClient[innerClient] === app.agent.registryClient[innerClient]);
-
       const agentInnerClient = app.agent.registryClient[innerClient];
-      assert(agentInnerClient.closed === true);
+      assert(agentInnerClient._realClient.closed === true);
       mm.restore();
     });
 


### PR DESCRIPTION
Since 'cluster-client@3.0.1' has fixed something imcompatable, so we
should rollback this unit test.

---

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines