### PR TITLE
chore: update packages,remove 'plugin' and validations of doc generation

### DIFF
--- a/docs/source/_data/guide_toc.yml
+++ b/docs/source/_data/guide_toc.yml
@@ -46,7 +46,6 @@ Advanced:
   View Plugin: /advanced/view-plugin.html
   Style Guide: /style-guide.html
 Community:
-  Plugin List: /plugins/
   Contributing: /contributing.html
   Resource: /resource.html
   # Member Guide: /member_guide.html

--- a/docs/source/en/plugins/index.md
+++ b/docs/source/en/plugins/index.md
@@ -1,3 +1,0 @@
-layout: plugin
-title: Plugin List
----

--- a/docs/source/zh-cn/plugins/index.md
+++ b/docs/source/zh-cn/plugins/index.md
@@ -1,3 +1,0 @@
-layout: plugin
-title: 内置插件列表
----

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "autod-egg": "^1.1.0",
     "coffee": "^5.2.1",
     "egg-alinode": "^1.0.3",
-    "egg-bin": "^4.11.0",
+    "egg-bin": "^4.12.3",
     "egg-doctools": "^2.8.3",
     "egg-mock": "^3.21.0",
     "egg-plugin-puml": "^2.4.0",

--- a/test/doc.test.js
+++ b/test/doc.test.js
@@ -7,7 +7,6 @@ const runscript = require('runscript');
 const utils = require('./utils');
 
 describe('test/doc.test.js', () => {
-  if (process.platform === 'win32') return;
 
   let app;
   before(async () => {


### PR DESCRIPTION
1. The 'plugin' folder in both 'en' and 'zh-CN' is replaced by a direct
on-line search, so we don't need it anymore.

2. Make the doc build do validations when running 'test/doc.test.js'：
![image](https://user-images.githubusercontent.com/40081831/56546839-16a2e580-65ae-11e9-95ca-2424dc30d3f6.png)


3. Update 'egg-bin' to '4.12.3'.

---

- [X] `npm test` passes
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message follows commit guidelines