### PR TITLE
fix: some test methods failed on windows platform

### DIFF
--- a/test/app/middleware/site_file.test.js
+++ b/test/app/middleware/site_file.test.js
@@ -28,7 +28,8 @@ describe('test/app/middleware/site_file.test.js', () => {
   it('should 200 when accessing /robots.txt', () => {
     return app.httpRequest()
       .get('/robots.txt')
-      .expect('User-agent: Baiduspider\nDisallow: /\n\nUser-agent: baiduspider\nDisallow: /')
+      .expect(res => assert.equal(String(res.text)
+        .replace(/\r/g, ''), 'User-agent: Baiduspider\nDisallow: /\n\nUser-agent: baiduspider\nDisallow: /'))
       .expect(200);
   });
 
@@ -40,6 +41,14 @@ describe('test/app/middleware/site_file.test.js', () => {
   });
 
   it('should support HEAD', () => {
+    if (process.platform === 'win32') {
+      return app.httpRequest()
+        .head('/robots.txt')
+        .expect('content-length', '76')
+        // body must be empty for HEAD
+        .expect(res => assert.equal(res.text, undefined))
+        .expect(200);
+    }
     return app.httpRequest()
       .head('/robots.txt')
       .expect('content-length', '72')

--- a/test/app/middleware/site_file.test.js
+++ b/test/app/middleware/site_file.test.js
@@ -28,8 +28,7 @@ describe('test/app/middleware/site_file.test.js', () => {
   it('should 200 when accessing /robots.txt', () => {
     return app.httpRequest()
       .get('/robots.txt')
-      .expect(res => assert.equal(String(res.text)
-        .replace(/\r/g, ''), 'User-agent: Baiduspider\nDisallow: /\n\nUser-agent: baiduspider\nDisallow: /'))
+      .expect(/^User-agent: Baiduspider\r?\nDisallow: \/\r?\n\r?\nUser-agent: baiduspider\r?\nDisallow: \/$/)
       .expect(200);
   });
 

--- a/test/app/middleware/site_file.test.js
+++ b/test/app/middleware/site_file.test.js
@@ -42,7 +42,7 @@ describe('test/app/middleware/site_file.test.js', () => {
   it('should support HEAD', () => {
     return app.httpRequest()
       .head('/robots.txt')
-      .expect(res => Number(res.header['content-length']) > 0)
+      .expect(res => assert(Number(res.header['content-length']) > 0))
       // body must be empty for HEAD
       .expect(res => assert.equal(res.text, undefined))
       .expect(200);

--- a/test/app/middleware/site_file.test.js
+++ b/test/app/middleware/site_file.test.js
@@ -40,17 +40,9 @@ describe('test/app/middleware/site_file.test.js', () => {
   });
 
   it('should support HEAD', () => {
-    if (process.platform === 'win32') {
-      return app.httpRequest()
-        .head('/robots.txt')
-        .expect('content-length', '76')
-        // body must be empty for HEAD
-        .expect(res => assert.equal(res.text, undefined))
-        .expect(200);
-    }
     return app.httpRequest()
       .head('/robots.txt')
-      .expect('content-length', '72')
+      .expect(res => Number(res.header['content-length']) > 0)
       // body must be empty for HEAD
       .expect(res => assert.equal(res.text, undefined))
       .expect(200);

--- a/test/lib/core/view.test.js
+++ b/test/lib/core/view.test.js
@@ -96,14 +96,19 @@ describe('test/lib/core/view.test.js', () => {
       app.httpRequest()
         .get('/')
         .expect(200)
-        .expect(`Hi, mk・2\ntest-app-helper: test-bar@${app.config.baseDir}\nraw: <div>dar</div>\n2014 @ mk2 &lt;br&gt;\n`, done);
+        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), `Hi, mk・2\ntest-app-helper: test-bar@${app.config.baseDir}\nraw: <div>dar</div>\n2014 @ mk2 &lt;br&gt;\n`))
+        .end(done)
+
+      ;
     });
 
     it('should render with async function controller', function(done) {
       app.httpRequest()
         .get('/async')
         .expect(200)
-        .expect(`Hi, mk・2\ntest-app-helper: test-bar@${app.config.baseDir}\nraw: <div>dar</div>\n2014 @ mk2 &lt;br&gt;\n`, done);
+        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), `Hi, mk・2\ntest-app-helper: test-bar@${app.config.baseDir}\nraw: <div>dar</div>\n2014 @ mk2 &lt;br&gt;\n`))
+        .end(done)
+      ;
     });
 
     it('should render have helper instance', function(done) {
@@ -116,7 +121,10 @@ describe('test/lib/core/view.test.js', () => {
       app.httpRequest()
         .get('/empty')
         .expect(200)
-        .expect(`Hi, \ntest-app-helper: test-bar@${app.config.baseDir}\nraw: <div>dar</div>\n2014 @ mk2 &lt;br&gt;\n`, done);
+        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), `Hi, \ntest-app-helper: test-bar@${app.config.baseDir}\nraw: <div>dar</div>\n2014 @ mk2 &lt;br&gt;\n`))
+
+        .end(done)
+      ;
     });
 
     it('should render template string', function(done) {

--- a/test/lib/plugins/i18n.test.js
+++ b/test/lib/plugins/i18n.test.js
@@ -1,5 +1,4 @@
 'use strict';
-const assert = require('assert');
 const utils = require('../../utils');
 
 describe('test/lib/plugins/i18n.test.js', () => {
@@ -37,7 +36,7 @@ describe('test/lib/plugins/i18n.test.js', () => {
         .get('/')
         .expect(200)
         .expect('Set-Cookie', /locale=en-us; path=\/; expires=[^;]+ GMT/)
-        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), '<li>Email: </li>\n<li>Hello fengmk2, how are you today?</li>\n<li>foo bar</li>\n'));
+        .expect(/^<li>Email: <\/li>\r?\n<li>Hello fengmk2, how are you today\?<\/li>\r?\n<li>foo bar<\/li>\r?\n$/);
     });
 
     it('should render with query locale: zh_CN', () => {
@@ -46,7 +45,7 @@ describe('test/lib/plugins/i18n.test.js', () => {
         .set('Host', 'foo.example.com')
         .expect(200)
         .expect('Set-Cookie', /locale=zh-cn; path=\/; expires=[^;]+ GMT/)
-        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), '<li>邮箱: </li>\n<li>fengmk2，今天过得如何？</li>\n<li>foo bar</li>\n'));
+        .expect(/^<li>邮箱: <\/li>\r?\n<li>fengmk2，今天过得如何？<\/li>\r?\n<li>foo bar<\/li>\r?\n$/);
     });
   });
 });

--- a/test/lib/plugins/i18n.test.js
+++ b/test/lib/plugins/i18n.test.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const assert = require('assert');
 const utils = require('../../utils');
 
 describe('test/lib/plugins/i18n.test.js', () => {
@@ -37,7 +37,7 @@ describe('test/lib/plugins/i18n.test.js', () => {
         .get('/')
         .expect(200)
         .expect('Set-Cookie', /locale=en-us; path=\/; expires=[^;]+ GMT/)
-        .expect('<li>Email: </li>\n<li>Hello fengmk2, how are you today?</li>\n<li>foo bar</li>\n');
+        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), '<li>Email: </li>\n<li>Hello fengmk2, how are you today?</li>\n<li>foo bar</li>\n'));
     });
 
     it('should render with query locale: zh_CN', () => {
@@ -46,7 +46,7 @@ describe('test/lib/plugins/i18n.test.js', () => {
         .set('Host', 'foo.example.com')
         .expect(200)
         .expect('Set-Cookie', /locale=zh-cn; path=\/; expires=[^;]+ GMT/)
-        .expect('<li>邮箱: </li>\n<li>fengmk2，今天过得如何？</li>\n<li>foo bar</li>\n');
+        .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), '<li>邮箱: </li>\n<li>fengmk2，今天过得如何？</li>\n<li>foo bar</li>\n'));
     });
   });
 });

--- a/test/lib/plugins/static.test.js
+++ b/test/lib/plugins/static.test.js
@@ -1,5 +1,4 @@
 'use strict';
-const assert = require('assert');
 const utils = require('../../utils');
 
 describe('test/lib/plugins/static.test.js', () => {
@@ -12,7 +11,7 @@ describe('test/lib/plugins/static.test.js', () => {
   it('should get exists js file', () => {
     return app.httpRequest()
       .get('/public/foo.js')
-      .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), 'alert(\'bar\');\n'))
+      .expect(/alert\(\'bar\'\);\r?\n/)
       .expect(200);
   });
 });

--- a/test/lib/plugins/static.test.js
+++ b/test/lib/plugins/static.test.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const assert = require('assert');
 const utils = require('../../utils');
 
 describe('test/lib/plugins/static.test.js', () => {
@@ -12,7 +12,7 @@ describe('test/lib/plugins/static.test.js', () => {
   it('should get exists js file', () => {
     return app.httpRequest()
       .get('/public/foo.js')
-      .expect('alert(\'bar\');\n')
+      .expect(res => assert.equal(String(res.text).replace(/\r/g, ''), 'alert(\'bar\');\n'))
       .expect(200);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
on window platform, file content contains \r character.so some test failed on window platform.this pr fix it.so when developer work on it ,npm run test-local will  work better.
<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->