### PR TITLE
fix: improve ts definition for egg-static

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -468,7 +468,7 @@ declare module 'egg' {
 
     static: {
       prefix: string;
-      dir: string | string[];
+      dir: string | Array<string | { prefix: string, dir: string}>;
       // support lazy load
       dynamic: boolean;
       preload: boolean;


### PR DESCRIPTION

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] commit message follows commit guidelines


##### Description of change

Support array usage of egg-static: 

> multiple directory by use dir: `[dir1, dir2, ...]` or dir: `[dir1, { prefix: '/static2', dir: dir2 }]`, static server will use all these directories.