### PR TITLE
chore: remove @types/urllib

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/accepts": "^1.3.5",
     "@types/koa": "^2.0.48",
     "@types/koa-router": "^7.0.40",
-    "@types/urllib": "^2.28.1",
     "accepts": "^1.3.5",
     "agentkeepalive": "^4.0.2",
     "cache-content-type": "^1.0.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

```bash
npm WARN deprecated @types/urllib@2.33.0: This is a stub types definition. urllib provides its own type definitions, so you do not need this installed.
```