### PR TITLE
fix: handleRequest method should return a promise

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -198,9 +198,8 @@ class Application extends EggApplication {
 
   handleRequest(ctx, fnMiddleware) {
     this.emit('request', ctx);
-    const promise = super.handleRequest(ctx, fnMiddleware);
     onFinished(ctx.res, () => this.emit('response', ctx));
-    return promise;
+    return super.handleRequest(ctx, fnMiddleware);
   }
 
   /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -198,8 +198,9 @@ class Application extends EggApplication {
 
   handleRequest(ctx, fnMiddleware) {
     this.emit('request', ctx);
-    super.handleRequest(ctx, fnMiddleware);
+    const promise = super.handleRequest(ctx, fnMiddleware);
     onFinished(ctx.res, () => this.emit('response', ctx));
+    return promise;
   }
 
   /**

--- a/test/app/extend/application.test.js
+++ b/test/app/extend/application.test.js
@@ -191,4 +191,22 @@ describe('test/app/extend/application.test.js', () => {
       );
     });
   });
+
+  describe('app.handleRequest(ctx, fnMiddleware)', () => {
+    let app;
+    before(() => {
+      app = utils.app('apps/demo');
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('should wait for middleware resolution', async () => {
+      const ctx = app.createAnonymousContext();
+      await app.handleRequest(ctx, async ctx => {
+        await sleep(100);
+        ctx.body = 'middleware resolution';
+      });
+      assert(ctx.body === 'middleware resolution');
+    });
+  });
 });


### PR DESCRIPTION
The `handleRequest` method, which is inherited from `koa.Application`, The original method have a return value, it is a promise.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->