### PR TITLE
test: mv assert to fixtures

### DIFF
--- a/test/fixtures/apps/dumpconfig/app.js
+++ b/test/fixtures/apps/dumpconfig/app.js
@@ -1,9 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
 const sleep = require('mz-modules/sleep');
 
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p));
+}
+
 module.exports = app => {
+  const baseDir = app.config.baseDir;
+  let json;
+
   app.config.dynamic = 1;
   app.beforeStart(function*() {
-    yield sleep(500);
+    // dumpConfig() dynamically
+    json = readJson(path.join(baseDir, 'run/application_config.json'));
+    assert(json.config.dynamic === 1, 'should dump in config');
+    json = readJson(path.join(baseDir, 'run/agent_config.json'));
+    assert(json.config.dynamic === 0, 'should dump in config');
+
+    yield sleep(2000);
     app.config.dynamic = 2;
   });
 };

--- a/test/fixtures/apps/dumpconfig/app.js
+++ b/test/fixtures/apps/dumpconfig/app.js
@@ -3,7 +3,7 @@ const path = require('path');
 const assert = require('assert');
 const sleep = require('mz-modules/sleep');
 
-function readJson(p) {
+function readJSON(p) {
   return JSON.parse(fs.readFileSync(p));
 }
 

--- a/test/fixtures/apps/dumpconfig/app.js
+++ b/test/fixtures/apps/dumpconfig/app.js
@@ -14,9 +14,9 @@ module.exports = app => {
   app.config.dynamic = 1;
   app.beforeStart(function*() {
     // dumpConfig() dynamically
-    json = readJson(path.join(baseDir, 'run/application_config.json'));
+    json = readJSON(path.join(baseDir, 'run/application_config.json'));
     assert(json.config.dynamic === 1, 'should dump in config');
-    json = readJson(path.join(baseDir, 'run/agent_config.json'));
+    json = readJSON(path.join(baseDir, 'run/agent_config.json'));
     assert(json.config.dynamic === 0, 'should dump in config');
 
     yield sleep(2000);

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -168,15 +168,8 @@ describe('test/lib/egg.test.js', () => {
       const baseDir = utils.getFilepath('apps/dumpconfig');
       let json;
 
-      await sleep(100);
-      json = readJson(path.join(baseDir, 'run/application_config.json'));
-      assert(json.config.dynamic === 1);
-      json = readJson(path.join(baseDir, 'run/agent_config.json'));
-      assert(json.config.dynamic === 0);
-
       await app.ready();
 
-      await sleep(100);
       json = readJson(path.join(baseDir, 'run/application_config.json'));
       assert(json.config.dynamic === 2);
       json = readJson(path.join(baseDir, 'run/agent_config.json'));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

由于 `dumpConfig` 在 `app.ready()` 前后各一次，且创建时间无法确定，通过 `sleep` 方法检测在 `win` 存在不确定性，将其移动到 `fixtures` 下 `app.js` 中使用文件读取的方式进行检测。

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->