### PR TITLE
docs: fix typo of socket.io

### DIFF
--- a/docs/source/zh-cn/tutorials/socketio.md
+++ b/docs/source/zh-cn/tutorials/socketio.md
@@ -198,7 +198,7 @@ const tick = (id, msg) => {
 module.exports = app => {
   return async (ctx, next) => {
     if (true) {
-      ctx.socket.disconnet();
+      ctx.socket.disconnect();
       return;
     }
     await next();


### PR DESCRIPTION
### socket Api docs
https://socket.io/docs/client-api/#socket-disconnect

### EN 英文文档是正确的
https://github.com/eggjs/egg/blob/master/docs/source/en/tutorials/socketio.md#197

### 这个 issues 也提到了
https://github.com/eggjs/egg/pull/2167#discussion_r172859975

