### PR TITLE
feat: set default body-parser limitation to 1mb

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -186,8 +186,9 @@ module.exports = appInfo => {
    * @property {String | RegExp | Function | Array} ignore - won't parse request body when url path hit ignore pattern, can not set `ignore` when `match` presented
    * @property {String | RegExp | Function | Array} match - will parse request body only when url path hit match pattern
    * @property {String} encoding - body's encoding type，default is utf8
-   * @property {String} formLimit - limit of the urlencoded body. If the body ends up being larger than this limit, a 413 error code is returned. Default is 100kb
-   * @property {String} jsonLimit - limit of the json body, default is 100kb
+   * @property {String} formLimit - limit of the urlencoded body. If the body ends up being larger than this limit, a 413 error code is returned. Default is 1mb
+   * @property {String} jsonLimit - limit of the json body, default is 1mb
+   * @property {String} textLimit - limit of the text body, default is 1mb
    * @property {Boolean} strict - when set to true, JSON parser will only accept arrays and objects. Default is true
    * @property {Number} queryString.arrayLimit - urlencoded body array's max length, default is 100
    * @property {Number} queryString.depth - urlencoded body object's max depth, default is 5
@@ -196,8 +197,9 @@ module.exports = appInfo => {
   config.bodyParser = {
     enable: true,
     encoding: 'utf8',
-    formLimit: '100kb',
-    jsonLimit: '100kb',
+    formLimit: '1mb',
+    jsonLimit: '1mb',
+    textLimit: '1mb',
     strict: true,
     // @see https://github.com/hapijs/qs/blob/master/lib/parse.js#L8 for more options
     queryString: {

--- a/test/app/middleware/body_parser.test.js
+++ b/test/app/middleware/body_parser.test.js
@@ -49,13 +49,13 @@ describe('test/app/middleware/body_parser.test.js', () => {
       .expect(200, done);
   });
 
-  it('should 413 when post json body over the limit', () => {
+  it('should 413 when post json body over the limit', done => {
     app.mockCsrf();
-    return app.httpRequest()
+    app.httpRequest()
       .post('/test/body_parser/user')
       .send({ foo: 'a'.repeat(1024 * 200) })
       .expect(/request entity too large, check bodyParser config/)
-      .expect(413);
+      .expect(413, done);
   });
 
   it('should disable body parser', async () => {

--- a/test/fixtures/apps/body_parser_testapp/config/config.default.js
+++ b/test/fixtures/apps/body_parser_testapp/config/config.default.js
@@ -1,4 +1,7 @@
 exports.bodyParser = {
+  formLimit: '100kb',
+  jsonLimit: '100kb',
+  textLimit: '100kb',
   queryString: {
     arrayLimit: 5
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

- set `formLimit` to `1mb`
- set `jsonLimit` to `1mb`
- add `textLimit` config and set it to `1mb`

##### Description of change
<!-- Provide a description of the change below this comment. -->

单测配置为 `100kb`，因为在测试用例中 console 方式输出 `1mb` 内容会导致测试用例异常。

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->