### PR TITLE
feat:Singleton returns client name when create client

### DIFF
--- a/lib/core/singleton.js
+++ b/lib/core/singleton.js
@@ -28,7 +28,7 @@ class Singleton {
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
-      const client = this.createInstance(options.client);
+      const client = this.createInstance(options.client, options.name);
       this.app[this.name] = client;
       this._extendDynamicMethods(client);
       return;
@@ -37,7 +37,7 @@ class Singleton {
     // multi clent, use app[name].getInstance(id)
     if (options.clients) {
       Object.keys(options.clients).forEach(id => {
-        const client = this.createInstance(options.clients[id]);
+        const client = this.createInstance(options.clients[id], id);
         this.clients.set(id, client);
       });
       this.app[this.name] = this;
@@ -55,7 +55,7 @@ class Singleton {
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
-      const client = await this.createInstanceAsync(options.client);
+      const client = await this.createInstanceAsync(options.client, options.name);
       this.app[this.name] = client;
       this._extendDynamicMethods(client);
       return;
@@ -64,7 +64,7 @@ class Singleton {
     // multi clent, use app[name].getInstance(id)
     if (options.clients) {
       await Promise.all(Object.keys(options.clients).map(id => {
-        return this.createInstanceAsync(options.clients[id])
+        return this.createInstanceAsync(options.clients[id], id)
           .then(client => this.clients.set(id, client));
       }));
       this.app[this.name] = this;
@@ -79,19 +79,19 @@ class Singleton {
     return this.clients.get(id);
   }
 
-  createInstance(config) {
+  createInstance(config, clientName) {
     // async creator only support createInstanceAsync
     assert(!is.asyncFunction(this.create),
       `egg:singleton ${this.name} only support create asynchronous, please use createInstanceAsync`);
     // options.default will be merge in to options.clients[id]
     config = Object.assign({}, this.options.default, config);
-    return this.create(config, this.app);
+    return this.create(config, this.app, clientName);
   }
 
-  async createInstanceAsync(config) {
+  async createInstanceAsync(config, clientName) {
     // options.default will be merge in to options.clients[id]
     config = Object.assign({}, this.options.default, config);
-    return await this.create(config, this.app);
+    return await this.create(config, this.app, clientName);
   }
 
   _extendDynamicMethods(client) {

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -261,6 +261,34 @@ describe('test/lib/core/singleton.test.js', () => {
     assert(warn);
   });
 
+  it('should return client name when create', async () => {
+    let success = true;
+    const name = 'dataService';
+    const clientName = 'customClient';
+    function create(config, app, client) {
+      if (client !== clientName) {
+        success = false;
+      }
+    }
+    const app = {
+      config: {
+        dataService: {
+          clients: {
+            customClient: { foo: 'bar1' },
+          },
+        },
+      },
+    };
+    const singleton = new Singleton({
+      name,
+      app,
+      create,
+    });
+    singleton.init();
+
+    assert(success);
+  });
+
   describe('async create', () => {
     it('should init with client', async () => {
       const name = 'dataService';
@@ -352,6 +380,34 @@ describe('test/lib/core/singleton.test.js', () => {
       } catch (err) {
         assert(err.message === 'egg:singleton dataService only support create asynchronous, please use createInstanceAsync');
       }
+    });
+
+    it('should return client name when create', async () => {
+      let success = true;
+      const name = 'dataService';
+      const clientName = 'customClient';
+      async function create(config, app, client) {
+        if (client !== clientName) {
+          success = false;
+        }
+      }
+      const app = {
+        config: {
+          dataService: {
+            clients: {
+              customClient: { foo: 'bar1' },
+            },
+          },
+        },
+      };
+      const singleton = new Singleton({
+        name,
+        app,
+        create,
+      });
+      await singleton.init();
+
+      assert(success);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
Singleton在调用插件的create方法时，返回相应的配置中的实例名，用于插件内部判断是哪个实例化发生了错误。
相关issue：https://github.com/eggjs/egg/issues/3648
<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->