### PR TITLE
fix: validate plugin options for singleton

### DIFF
--- a/lib/core/singleton.js
+++ b/lib/core/singleton.js
@@ -26,11 +26,11 @@ class Singleton {
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
     assert((options.client || options.clients || options.default),
-      `egg:singleton ${this.name} can not be init due to BOTH options.client, options.clients, options.default empty`);
+      `egg:singleton ${this.name} can not be init due to options.client, options.clients, options.default empty`);
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
-      const client = this.createInstance(options.client);
+      const client = this.createInstance(options.client, options.name);
       this.app[this.name] = client;
       this._extendDynamicMethods(client);
       return;
@@ -39,7 +39,7 @@ class Singleton {
     // multi clent, use app[name].getInstance(id)
     if (options.clients) {
       Object.keys(options.clients).forEach(id => {
-        const client = this.createInstance(options.clients[id]);
+        const client = this.createInstance(options.clients[id], id);
         this.clients.set(id, client);
       });
       this.app[this.name] = this;
@@ -55,11 +55,11 @@ class Singleton {
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
     assert((options.client || options.clients || options.default),
-      `egg:singleton ${this.name} can not be init due to BOTH options.client, options.clients, options.default empty`);
+      `egg:singleton ${this.name} can not be init due to options.client, options.clients, options.default empty`);
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
-      const client = await this.createInstanceAsync(options.client);
+      const client = await this.createInstanceAsync(options.client, options.name);
       this.app[this.name] = client;
       this._extendDynamicMethods(client);
       return;
@@ -68,7 +68,7 @@ class Singleton {
     // multi clent, use app[name].getInstance(id)
     if (options.clients) {
       await Promise.all(Object.keys(options.clients).map(id => {
-        return this.createInstanceAsync(options.clients[id])
+        return this.createInstanceAsync(options.clients[id], id)
           .then(client => this.clients.set(id, client));
       }));
       this.app[this.name] = this;
@@ -83,19 +83,19 @@ class Singleton {
     return this.clients.get(id);
   }
 
-  createInstance(config) {
+  createInstance(config, clientName) {
     // async creator only support createInstanceAsync
     assert(!is.asyncFunction(this.create),
       `egg:singleton ${this.name} only support create asynchronous, please use createInstanceAsync`);
     // options.default will be merge in to options.clients[id]
     config = Object.assign({}, this.options.default, config);
-    return this.create(config, this.app);
+    return this.create(config, this.app, clientName);
   }
 
-  async createInstanceAsync(config) {
+  async createInstanceAsync(config, clientName) {
     // options.default will be merge in to options.clients[id]
     config = Object.assign({}, this.options.default, config);
-    return await this.create(config, this.app);
+    return await this.create(config, this.app, clientName);
   }
 
   _extendDynamicMethods(client) {

--- a/lib/core/singleton.js
+++ b/lib/core/singleton.js
@@ -25,8 +25,8 @@ class Singleton {
     const options = this.options;
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
-    assert((!options.client && !options.clients),
-      `egg:singleton ${this.name} can not be init due to BOTH options.client and options.clients empty`);
+    assert((options.client || options.clients || options.default),
+      `egg:singleton ${this.name} can not be init due to BOTH options.client, options.clients, options.default empty`);
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
@@ -54,8 +54,8 @@ class Singleton {
     const options = this.options;
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
-    assert((!options.client && !options.clients),
-      `egg:singleton ${this.name} can not be init due to BOTH options.client and options.clients empty`);
+    assert((options.client || options.clients || options.default),
+      `egg:singleton ${this.name} can not be init due to BOTH options.client, options.clients, options.default empty`);
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {

--- a/lib/core/singleton.js
+++ b/lib/core/singleton.js
@@ -25,6 +25,8 @@ class Singleton {
     const options = this.options;
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
+    assert((!options.client && !options.clients),
+      `egg:singleton ${this.name} can not be init due to BOTH options.client and options.clients empty`);
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
@@ -52,6 +54,8 @@ class Singleton {
     const options = this.options;
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
+    assert((!options.client && !options.clients),
+      `egg:singleton ${this.name} can not be init due to BOTH options.client and options.clients empty`);
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -157,7 +157,7 @@ describe('test/lib/core/singleton.test.js', () => {
     const singleton = new Singleton({
       name,
       app,
-      create: asyncCreate,
+      create,
     });
     singleton.init();
     assert(app.dataService === singleton);
@@ -235,7 +235,7 @@ describe('test/lib/core/singleton.test.js', () => {
     });
 
     try {
-      singleton.init();
+      await singleton.init();
       assert(false, 'should throw error but NOT');
     } catch (ex) {
       assert(ex.message && ex.message.includes('empty'));

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -157,7 +157,7 @@ describe('test/lib/core/singleton.test.js', () => {
     const singleton = new Singleton({
       name,
       app,
-      create,
+      create: asyncCreate,
     });
     singleton.init();
     assert(app.dataService === singleton);
@@ -195,7 +195,6 @@ describe('test/lib/core/singleton.test.js', () => {
     assert(dataService.config.foo1 === 'bar1');
     assert(dataService.config.foo === 'bar');
   });
-
 
   it('should createInstance without client,clients,default', async () => {
     const app = {
@@ -242,7 +241,6 @@ describe('test/lib/core/singleton.test.js', () => {
       assert(ex.message && ex.message.includes('empty'));
     }
   });
-
 
   it('should work with frozen', async () => {
     function create(config) {
@@ -307,6 +305,34 @@ describe('test/lib/core/singleton.test.js', () => {
     assert(!app.dataService.createInstance);
     assert(!app.dataService.createInstanceAsync);
     assert(warn);
+  });
+
+  it('should return client name when create', async () => {
+    let success = true;
+    const name = 'dataService';
+    const clientName = 'customClient';
+    function create(config, app, client) {
+      if (client !== clientName) {
+        success = false;
+      }
+    }
+    const app = {
+      config: {
+        dataService: {
+          clients: {
+            customClient: { foo: 'bar1' },
+          },
+        },
+      },
+    };
+    const singleton = new Singleton({
+      name,
+      app,
+      create,
+    });
+    singleton.init();
+
+    assert(success);
   });
 
   describe('async create', () => {
@@ -400,6 +426,34 @@ describe('test/lib/core/singleton.test.js', () => {
       } catch (err) {
         assert(err.message === 'egg:singleton dataService only support create asynchronous, please use createInstanceAsync');
       }
+    });
+
+    it('should return client name when create', async () => {
+      let success = true;
+      const name = 'dataService';
+      const clientName = 'customClient';
+      async function create(config, app, client) {
+        if (client !== clientName) {
+          success = false;
+        }
+      }
+      const app = {
+        config: {
+          dataService: {
+            clients: {
+              customClient: { foo: 'bar1' },
+            },
+          },
+        },
+      };
+      const singleton = new Singleton({
+        name,
+        app,
+        create,
+      });
+      await singleton.init();
+
+      assert(success);
     });
   });
 });

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -196,6 +196,54 @@ describe('test/lib/core/singleton.test.js', () => {
     assert(dataService.config.foo === 'bar');
   });
 
+
+  it('should createInstance without client,clients,default', async () => {
+    const app = {
+      config: {
+        dataService: {
+        },
+      },
+    };
+    const name = 'dataService';
+
+    const singleton = new Singleton({
+      name,
+      app,
+      create,
+    });
+
+    try {
+      singleton.init();
+      assert(false, 'should throw error but NOT');
+    } catch (ex) {
+      assert(ex.message && ex.message.includes('empty'));
+    }
+  });
+
+  it('should createInstanceAsync without client,clients,default', async () => {
+    const app = {
+      config: {
+        dataService: {
+        },
+      },
+    };
+    const name = 'dataService';
+
+    const singleton = new Singleton({
+      name,
+      app,
+      create,
+    });
+
+    try {
+      singleton.init();
+      assert(false, 'should throw error but NOT');
+    } catch (ex) {
+      assert(ex.message && ex.message.includes('empty'));
+    }
+  });
+
+
   it('should work with frozen', async () => {
     function create(config) {
       const d = new DataService(config);

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -50,7 +50,7 @@ describe('test/lib/core/singleton.test.js', () => {
     }
   });
 
-  it.only('should init with clients', async () => {
+  it('should init with clients', async () => {
     const name = 'dataService';
 
     const clients = {

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -50,7 +50,7 @@ describe('test/lib/core/singleton.test.js', () => {
     }
   });
 
-  it('should init with clients', async () => {
+  it.only('should init with clients', async () => {
     const name = 'dataService';
 
     const clients = {

--- a/test/lib/core/singleton.test.js
+++ b/test/lib/core/singleton.test.js
@@ -231,7 +231,7 @@ describe('test/lib/core/singleton.test.js', () => {
     const singleton = new Singleton({
       name,
       app,
-      create,
+      create: asyncCreate,
     });
 
     try {


### PR DESCRIPTION
One of `client` or `clients` must be available.
ref: https://eggjs.org/zh-cn/advanced/plugin.html#%E5%85%A8%E5%B1%80%E5%AE%9E%E4%BE%8B%E6%8F%92%E4%BB%B6%E7%9A%84%E6%9C%80%E4%BD%B3%E5%AE%9E%E8%B7%B5

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

插件，单例模式时，校验 `client` `clients` 不能同时为空。
