### PR TITLE
update deploy doc

### DIFF
--- a/docs/source/en/core/deployment.md
+++ b/docs/source/en/core/deployment.md
@@ -83,7 +83,7 @@ Arguments of dispatch can be configured in `config.{env}.js`.
 exports.cluster = {
   listen: {
     port: 7001,
-    hostname: '127.0.0.1',
+    hostname: '0.0.0.0',
     // path: '/var/run/egg.sock',
   }
 }

--- a/docs/source/zh-cn/core/deployment.md
+++ b/docs/source/zh-cn/core/deployment.md
@@ -85,7 +85,7 @@ $ egg-scripts start --port=7001 --daemon --title=egg-server-showcase
 exports.cluster = {
   listen: {
     port: 7001,
-    hostname: '127.0.0.1',
+    hostname: '0.0.0.0',
     // path: '/var/run/egg.sock',
   }
 }


### PR DESCRIPTION
https://eggjs.org/zh-cn/core/deployment.html#%E5%90%AF%E5%8A%A8%E9%85%8D%E7%BD%AE%E9%A1%B9

egg文档 - 应用部署 - 启动配置项 
```  
// config/config.default.js

exports.cluster = {
  listen: {
    port: 7001,
    hostname: '127.0.0.1',
    // path: '/var/run/egg.sock',
  }
}
```  

按照以上文档部署到云服务器 (egg start)，hostname为127.0.0.1，无法正常访问服务器，需改成0.0.0.0。

