### PR TITLE
docs(deployment.md): modify hostname

### DIFF
--- a/docs/source/en/core/deployment.md
+++ b/docs/source/en/core/deployment.md
@@ -83,7 +83,7 @@ Arguments of dispatch can be configured in `config.{env}.js`.
 exports.cluster = {
   listen: {
     port: 7001,
-    hostname: '127.0.0.1',
+    hostname: '0.0.0.0',
     // path: '/var/run/egg.sock',
   }
 }

--- a/docs/source/zh-cn/core/deployment.md
+++ b/docs/source/zh-cn/core/deployment.md
@@ -85,7 +85,7 @@ $ egg-scripts start --port=7001 --daemon --title=egg-server-showcase
 exports.cluster = {
   listen: {
     port: 7001,
-    hostname: '127.0.0.1',
+    hostname: '0.0.0.0',
     // path: '/var/run/egg.sock',
   }
 }


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

  
抱歉没有认真阅读CONTRIBUTING和同时又新建了一个pull request。

#### 问题
按照部署文档所写的hostname部署到云服务器，无法被外网访问，需改成0.0.0.0。

```  
// config/config.default.js

exports.cluster = {
  listen: {
    port: 7001,
    hostname: '127.0.0.1',
    // path: '/var/run/egg.sock',
  }
}
```

#### 文档位置
[中文文档锚点](https://eggjs.org/zh-cn/core/deployment.html#%E5%90%AF%E5%8A%A8%E9%85%8D%E7%BD%AE%E9%A1%B9)  
[英文文档锚点](https://eggjs.org/en/core/deployment.html#dispatch-with-arguments)  
