### PR TITLE
docs: cleanup the document

### DIFF
--- a/docs/source/en/basics/env.md
+++ b/docs/source/en/basics/env.md
@@ -8,10 +8,13 @@ An web application itself should be stateless and has the ability to set its own
 
 Egg has two ways to configure runtime environment:
 
-1. Use `config/env` file, usually we use the build tools to generate this file, the content of this file is just the env value, such as `prod`.
-2. use `EGG_SERVER_ENV` environment variable to configure.
+1. Use `config/env` file, usually we use the build tools to generate this file, the content of this file is just an env value, such as `prod`.
+```
+// config/env
+prod
+```
 
- The second way will be more commonly used, defining the runtime environment via `EGG_SERVER_ENV` when you start the application is more convenient, for example, use the code below to start the application in the production environment.
+Defining the runtime environment via `EGG_SERVER_ENV` when you start the application is more convenient, for example, use the code below to start the application in the production environment.
 
 ```shell
 EGG_SERVER_ENV=prod npm start

--- a/docs/source/zh-cn/basics/env.md
+++ b/docs/source/zh-cn/basics/env.md
@@ -8,9 +8,12 @@ title: 运行环境
 框架有两种方式指定运行环境：
 
 1. 通过 `config/env` 文件指定，该文件的内容就是运行环境，如 `prod`。一般通过构建工具来生成这个文件。
-2. 通过 `EGG_SERVER_ENV` 环境变量指定。
+```
+// config/env
+prod
+```
 
-其中，方式 2 比较常用，因为通过 `EGG_SERVER_ENV` 环境变量指定运行环境更加方便，比如在生产环境启动应用：
+通过 `EGG_SERVER_ENV` 环境变量指定运行环境更加方便，比如在生产环境启动应用：
 
 ```shell
 EGG_SERVER_ENV=prod npm start


### PR DESCRIPTION
documentation cleanup. I think using `config/env` is confusing for new learners. It actually represents the running mode as It only contains a single line.

I need to use `dotenv` in order to read env from a file.

What do u think?

- [x] documentation is changed or added
- [x] commit message follows commit guidelines