### PR TITLE
test: fix the testcase error of load_boot.test.js

### DIFF
--- a/test/lib/core/loader/load_boot.test.js
+++ b/test/lib/core/loader/load_boot.test.js
@@ -14,7 +14,6 @@ describe('test/lib/core/loader/load_boot.test.js', () => {
   });
 
   it('should load app.js', async () => {
-    app.mockLog(app.coreLogger);
     await app.close();
     app.expectLog('app is ready');
 

--- a/test/lib/core/loader/load_boot.test.js
+++ b/test/lib/core/loader/load_boot.test.js
@@ -14,7 +14,7 @@ describe('test/lib/core/loader/load_boot.test.js', () => {
   });
 
   it('should load app.js', async () => {
-    app.mockLog();
+    app.mockLog(app.coreLogger);
     await app.close();
     app.expectLog('app is ready');
 


### PR DESCRIPTION
…in issue #4040

The 'app.mockLog' function in 'test/lib/core/loader/load_boot.test.js' should use 'app.coreLogger'
instead of the default 'app.logger', otherwise the 'app.expectLog' cannot get the contents in log
files.

fix #4040

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
Testcase 'should load app.js' in 'test/lib/core/loader/load_boot.test.js'

##### Description of change
<!-- Provide a description of the change below this comment. -->
The 'app.mockLog' function in 'test/lib/core/loader/load_boot.test.js' should use 'app.coreLogger'
instead of the default 'app.logger', otherwise the 'app.expectLog' cannot get the expected content in log
files.
<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->