### PR TITLE
fix: fix gettext parameter error.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -902,8 +902,8 @@ declare module 'egg' {
      */
     curl<T = any>(url: string, opt?: RequestOptions): Promise<T>;
 
-    __(key: string, ...values: string[]): string;
-    gettext(key: string, ...values: string[]): string;
+    __(key: string, values?: string[]): string;
+    gettext(key: string, values?: string[]): string;
 
     /**
      * get upload file stream
@@ -1058,9 +1058,9 @@ declare module 'egg' {
     /** specify framework that can be absolute path or npm package */
     framework?: string;
     /** directory of application, default to `process.cwd()` */
-    baseDir?: string; 
+    baseDir?: string;
     /** ignore single process mode warning */
-    ignoreWarning? :boolean 
+    ignoreWarning? :boolean
   }
 
   export function start(options?:StartOptions):Promise<Application>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [] `npm test` passes
- [] tests and/or benchmarks are included
- [] documentation is changed or added
- [] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

Fix declaration file error: wrong parameter type.

Example code:

![image](https://user-images.githubusercontent.com/30958147/70438158-26812280-1ac8-11ea-95a0-53bafa6358d2.png)

Result:

![image](https://user-images.githubusercontent.com/30958147/70438197-431d5a80-1ac8-11ea-8082-1f05466be58d.png)

And according to koa/locales:

https://github.com/koajs/locales/blob/8963af3a0a90f66fa949353583f0172aa61e3b8e/index.js#L110

This problem can be reproduced through this repo: https://github.com/ranto2012/egg-fix

- System: win10 x64
- Node: 12.13.0
- Typescript: 3.7.3


