### PR TITLE
doc (socketio): fix packet middleware bug

### DIFF
--- a/docs/source/en/tutorials/socketio.md
+++ b/docs/source/en/tutorials/socketio.md
@@ -212,7 +212,7 @@ Acts on each data packet (each message). In the production environment, it is us
 module.exports = app => {
   return async (ctx, next) => {
     ctx.socket.emit('res', 'packet received!');
-    console.log('packet:', this.packet);
+    console.log('packet:', ctx.packet);
     await next();
   };
 };

--- a/docs/source/zh-cn/tutorials/socketio.md
+++ b/docs/source/zh-cn/tutorials/socketio.md
@@ -216,7 +216,7 @@ module.exports = app => {
 module.exports = app => {
   return async (ctx, next) => {
     ctx.socket.emit('res', 'packet received!');
-    console.log('packet:', this.packet);
+    console.log('packet:', ctx.packet);
     await next();
   };
 };


### PR DESCRIPTION
this.packet is undefined, data in ctx.packet

https://github.com/eggjs/egg-socket.io/blob/576578ac6324580150af2c4e2cb67ac31d8d7dea/lib/packetMiddlewareInit.js#L15

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines