### PR TITLE
fix: runInBackground always run after setImmediate

### DIFF
--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -223,7 +223,8 @@ const proto = module.exports = {
     /* istanbul ignore next */
     const taskName = scope._name || scope.name || eggUtils.getCalleeFromStack(true);
     // use app.toAsyncFunction to support both generator function and async function
-    return ctx.app.toAsyncFunction(scope)(ctx)
+    return new Promise(resolve => setImmediate(resolve))
+      .then(() => ctx.app.toAsyncFunction(scope)(ctx))
       .then(() => {
         ctx.coreLogger.info('[egg:background] task:%s success (%dms)', taskName, Date.now() - start);
       })

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -222,8 +222,9 @@ const proto = module.exports = {
     const start = Date.now();
     /* istanbul ignore next */
     const taskName = scope._name || scope.name || eggUtils.getCalleeFromStack(true);
-    // use app.toAsyncFunction to support both generator function and async function
+    // use setImmediate to ensure all sync logic will run async
     return new Promise(resolve => setImmediate(resolve))
+      // use app.toAsyncFunction to support both generator function and async function
       .then(() => ctx.app.toAsyncFunction(scope)(ctx))
       .then(() => {
         ctx.coreLogger.info('[egg:background] task:%s success (%dms)', taskName, Date.now() - start);

--- a/test/app/extend/context.test.js
+++ b/test/app/extend/context.test.js
@@ -302,6 +302,13 @@ describe('test/app/extend/context.test.js', () => {
         /\[egg:background] task:mockError fail \(\d+ms\)/.test(fs.readFileSync(path.join(logdir, 'egg-web.log'), 'utf8'))
       );
     });
+
+    it('should always execute after setImmediate', async () => {
+      const res = await app.httpRequest()
+        .get('/sync')
+        .expect(200);
+      assert(Number(res.text) < 99);
+    });
   });
 
   describe('ctx.runInBackground(scope) with single process mode', () => {

--- a/test/app/extend/context.test.js
+++ b/test/app/extend/context.test.js
@@ -252,7 +252,8 @@ describe('test/app/extend/context.test.js', () => {
         .get('/')
         .expect(200)
         .expect('hello');
-      await sleep(5000);
+      await app.backgroundTasksFinished();
+      await sleep(100);
       const logdir = app.config.logger.dir;
       const log = fs.readFileSync(path.join(logdir, 'ctx-background-web.log'), 'utf8');
       assert(/background run result file size: \d+/.test(log));
@@ -270,7 +271,8 @@ describe('test/app/extend/context.test.js', () => {
         .get('/custom')
         .expect(200)
         .expect('hello');
-      await sleep(5000);
+      await app.backgroundTasksFinished();
+      await sleep(100);
       const logdir = app.config.logger.dir;
       const log = fs.readFileSync(path.join(logdir, 'ctx-background-web.log'), 'utf8');
       assert(/background run result file size: \d+/.test(log));
@@ -293,7 +295,8 @@ describe('test/app/extend/context.test.js', () => {
         .get('/error')
         .expect(200)
         .expect('hello error');
-      await sleep(5000);
+      await app.backgroundTasksFinished();
+      await sleep(100);
       assert(errorHadEmit);
       const logdir = app.config.logger.dir;
       const log = fs.readFileSync(path.join(logdir, 'common-error.log'), 'utf8');
@@ -308,6 +311,7 @@ describe('test/app/extend/context.test.js', () => {
         .get('/sync')
         .expect(200);
       assert(Number(res.text) < 99);
+      await app.backgroundTasksFinished();
     });
   });
 

--- a/test/fixtures/apps/ctx-background/app/controller/sync.js
+++ b/test/fixtures/apps/ctx-background/app/controller/sync.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = async ctx => {
+  const start = Date.now();
+  ctx.runInBackground(async () => {
+    const start = Date.now();
+    while(Date.now() - start < 100) {
+    }
+  });
+  ctx.body = Date.now() - start;
+};

--- a/test/fixtures/apps/ctx-background/app/router.js
+++ b/test/fixtures/apps/ctx-background/app/router.js
@@ -5,4 +5,6 @@ module.exports = app => {
   app.get('/custom', app.controller.custom);
   app.get('/app_background', app.controller.app);
   app.get('/error', app.controller.error);
+  app.get('/sync', app.controller.sync);
+
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

runInBackground will run after setImmedate