### PR TITLE
fix: remove clear timing && skip keep-alive after 12.19.0

### DIFF
--- a/app/middleware/meta.js
+++ b/app/middleware/meta.js
@@ -7,8 +7,8 @@
 const semver = require('semver');
 
 module.exports = options => {
-  // Node.js >=14.8.0 will set Keep-Alive Header, see https://github.com/nodejs/node/pull/34561
-  const shouldPatchKeepAliveHeader = semver.lt(process.version, '14.8.0');
+  // Node.js >=14.8.0 and >= 12.19.0 will set Keep-Alive Header, see https://github.com/nodejs/node/pull/34561
+  const shouldPatchKeepAliveHeader = !semver.satisfies(process.version, '>=14.8.0 || ^12.19.0');
 
   return async function meta(ctx, next) {
     if (options.logging) {

--- a/lib/egg.js
+++ b/lib/egg.js
@@ -411,8 +411,8 @@ class EggApplication extends EggCore {
       const rundir = this.config.rundir;
       const dumpFile = path.join(rundir, `${this.type}_timing_${process.pid}.json`);
       fs.writeFileSync(dumpFile, CircularJSON.stringify(json, null, 2));
+      // only disable, not clear bootstrap timing data.
       this.timing.disable();
-      setTimeout(() => this.timing.clear(), 5000);
     } catch (err) {
       this.coreLogger.warn(`dumpTiming error: ${err.message}`);
     }

--- a/lib/egg.js
+++ b/lib/egg.js
@@ -411,8 +411,8 @@ class EggApplication extends EggCore {
       const rundir = this.config.rundir;
       const dumpFile = path.join(rundir, `${this.type}_timing_${process.pid}.json`);
       fs.writeFileSync(dumpFile, CircularJSON.stringify(json, null, 2));
-      this.timing.clear();
       this.timing.disable();
+      setTimeout(() => this.timing.clear(), 5000);
     } catch (err) {
       this.coreLogger.warn(`dumpTiming error: ${err.message}`);
     }

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -146,17 +146,13 @@ describe('test/lib/egg.test.js', () => {
       assert(json[0].pid === process.pid);
     });
 
-    it('should disable & clear timing after ready', function* () {
+    it('should disable timing after ready', function* () {
       const json = app.timing.toJSON();
       const last = json[json.length - 1];
       app.timing.start('a');
       app.timing.end('a');
       const json2 = app.timing.toJSON();
       assert(json2[json.length - 1].name === last.name);
-
-      yield sleep('5s');
-      const json3 = app.timing.toJSON();
-      assert(json3.length === 0);
     });
 
     it('should ignore error when dumpTiming', done => {

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -148,11 +148,15 @@ describe('test/lib/egg.test.js', () => {
 
     it('should disable & clear timing after ready', function* () {
       const json = app.timing.toJSON();
-      assert(json.length === 0);
+      const last = json[json.length - 1];
       app.timing.start('a');
       app.timing.end('a');
       const json2 = app.timing.toJSON();
-      assert(json2.length === 0);
+      assert(json2[json.length - 1].name === last.name);
+
+      yield sleep('5s');
+      const json3 = app.timing.toJSON();
+      assert(json3.length === 0);
     });
 
     it('should ignore error when dumpTiming', done => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

- 仅在启动成功后禁止新增 timing，不清理启动的 timing，让一些采集 timing 的插件有机会获取 
- 12.19 的 keep-alive 处理