### PR TITLE
fix: skip specified Node.js version to set keep-alive 

### DIFF
--- a/app/middleware/meta.js
+++ b/app/middleware/meta.js
@@ -7,8 +7,10 @@
 const semver = require('semver');
 
 module.exports = options => {
-  // Node.js >=14.8.0 and >= 12.19.0 will set Keep-Alive Header, see https://github.com/nodejs/node/pull/34561
-  const shouldPatchKeepAliveHeader = !semver.satisfies(process.version, '>=14.8.0 || ^12.19.0');
+  // Node.js >= 14.8.0 && < 14.12.0 and = 12.19.0 will set Keep-Alive Header
+  // Refs: https://github.com/nodejs/node/pull/34561 https://github.com/nodejs/node/pull/35138
+  
+  const shouldPatchKeepAliveHeader = !semver.satisfies(process.version, '>=14.8.0 <14.12.0 || =12.19.0');
 
   return async function meta(ctx, next) {
     if (options.logging) {
@@ -18,7 +20,6 @@ module.exports = options => {
     // total response time header
     ctx.set('x-readtime', Date.now() - ctx.starttime);
 
-    // try to support Keep-Alive Header when < 14.8.0
     const server = ctx.app.server;
     if (shouldPatchKeepAliveHeader && server && server.keepAliveTimeout && server.keepAliveTimeout >= 1000 && ctx.header.connection !== 'close') {
       /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change

Related-issues have been fixed and released in Node.js [v14.12.0](https://nodejs.org/zh-cn/blog/release/v14.12.0/) and [v12.20.0](https://nodejs.org/zh-cn/blog/release/v12.20.0/)

Refs: https://github.com/nodejs/node/pull/34561 https://github.com/nodejs/node/pull/35138
