### PR TITLE
doc: Typo fixture:「登陆」->「登录」

### DIFF
--- a/docs/source/zh-cn/core/cookie-and-session.md
+++ b/docs/source/zh-cn/core/cookie-and-session.md
@@ -204,7 +204,7 @@ exports.sessionRedis = {
 
 #### 修改用户 Session 失效时间
 
-虽然在 Session 的配置中有一项是 maxAge，但是它只能全局设置 Session 的有效期，我们经常可以在一些网站的登陆页上看到有 **记住我** 的选项框，勾选之后可以让登陆用户的 Session 有效期更长。这种针对特定用户的 Session 有效时间设置我们可以通过 `ctx.session.maxAge=` 来实现。
+虽然在 Session 的配置中有一项是 maxAge，但是它只能全局设置 Session 的有效期，我们经常可以在一些网站的登录页上看到有 **记住我** 的选项框，勾选之后可以让登录用户的 Session 有效期更长。这种针对特定用户的 Session 有效时间设置我们可以通过 `ctx.session.maxAge=` 来实现。
 
 ```js
 const ms = require('ms');


### PR DESCRIPTION
Hey guys,

Just fix a petite typo, modified `登陆` to`登录`

##### Checklist
No need to check this.

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
Nope

##### Description of change
fix typo on doc