### PR TITLE
improve: add a warning to notify users when all clients are empty

### DIFF
--- a/lib/core/singleton.js
+++ b/lib/core/singleton.js
@@ -26,6 +26,9 @@ class Singleton {
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
 
+    if (!options.client && !options.clients && !options.default) {
+      this.app.logger.warn(`egg:singleton ${this.name} initSync(): At least one of 'options.client','options.clients','options.default' should have a value.`);
+    }
     // alias app[name] as client, but still support createInstance method
     if (options.client) {
       const client = this.createInstance(options.client, options.name);
@@ -52,6 +55,10 @@ class Singleton {
     const options = this.options;
     assert(!(options.client && options.clients),
       `egg:singleton ${this.name} can not set options.client and options.clients both`);
+
+    if (!options.client && !options.clients && !options.default) {
+      this.app.logger.warn(`egg:singleton ${this.name} initAsync(): At least one of 'options.client','options.clients','options.default' should have a value.`);
+    }
 
     // alias app[name] as client, but still support createInstance method
     if (options.client) {


### PR DESCRIPTION
1. According to Egg.js doc and a known issue (See: https://github.com/eggjs/egg/pull/3981 ), it seems we don't
allow 'option.client', 'option.clients' and 'option.default' (all are null). But in order NOT to break down the released version, a warning is added there to notify the users.

2. Remove "async" in the sync block tests, and move "async" tests into the async block test part.

---

- [X] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines