### PR TITLE
feat: support disableDNSCache by request args handle

### DIFF
--- a/lib/core/dnscache_httpclient.js
+++ b/lib/core/dnscache_httpclient.js
@@ -27,6 +27,11 @@ class DNSCacheHttpClient extends HttpClient {
     // the callback style
     if (callback) {
       this.app.deprecate('[dnscache_httpclient] We now support async for this function, so callback isn\'t recommended.');
+      // disable dns cache in request by args handle
+      if (args && args.enableDNSCache === false) {
+        super.request(url, args, callback);
+        return;
+      }
       this[DNSLOOKUP](url, args)
         .then(result => {
           return super.request(result.url, result.args);
@@ -38,6 +43,10 @@ class DNSCacheHttpClient extends HttpClient {
 
     // the Promise style
     return (async () => {
+      // disable dns cache in request by args handle
+      if (args && args.enableDNSCache === false) {
+        return super.request(url, args);
+      }
       const result = await this[DNSLOOKUP](url, args);
       return super.request(result.url, result.args);
     })();

--- a/test/fixtures/apps/dnscache_httpclient/app/controller/home.js
+++ b/test/fixtures/apps/dnscache_httpclient/app/controller/home.js
@@ -10,6 +10,9 @@ module.exports = function* () {
     args = {};
     args.headers = { Host: this.query.Host };
   }
+  if (this.query.disableDNSCache) {
+    args = { enableDNSCache: false };
+  }
   const result = yield this.curl(this.query.url, args);
   this.status = result.status;
   this.set(result.headers);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change

can handle not use DNSCache in one request even though config set to `enableDNSCache: true`

sometime SDK should not want to use DNSCache by disaster retry，then it can handle not cache by itself