### PR TITLE
docs (sequelize): Changed 'config' to 'exports' in configuration part

### DIFF
--- a/docs/source/en/tutorials/sequelize.md
+++ b/docs/source/en/tutorials/sequelize.md
@@ -44,7 +44,7 @@ exports.sequelize = {
 - Write the sequelize configuration in `config/config.default.js`
 
 ```js
-config.sequelize = {
+exports.sequelize = {
   dialect: 'mysql',
   host: '127.0.0.1',
   port: 3306,

--- a/docs/source/zh-cn/tutorials/sequelize.md
+++ b/docs/source/zh-cn/tutorials/sequelize.md
@@ -44,7 +44,7 @@ exports.sequelize = {
 - 在 `config/config.default.js` 中编写 sequelize 配置
 
 ```js
-config.sequelize = {
+exports.sequelize = {
   dialect: 'mysql',
   host: '127.0.0.1',
   port: 3306,


### PR DESCRIPTION
##### Checklist

- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
N/A

##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->
It should be `exports.sequelize` instead of `config.sequelize` in `config/config.${env}.js` .
Changed both English & Chinese documentation.