### PR TITLE
fix: on-finished@2.4.0 is breaking API changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "koa-override": "^3.0.0",
     "ms": "^2.1.1",
     "mz": "^2.7.0",
-    "on-finished": "^2.3.0",
+    "on-finished": "2.3.0",
     "semver": "^7.3.2",
     "sendmessage": "^1.1.0",
     "urllib": "^2.33.0",


### PR DESCRIPTION
on-finished@2.4.0 has breaking API changes causes service unavailability
![image](https://user-images.githubusercontent.com/16618594/155078224-b51b7f3b-7772-4649-9312-0e82eb9cec5a.png)
