### PR TITLE
docs: use egg brand color for site

### DIFF
--- a/site/config/config.ts
+++ b/site/config/config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
   //   indexName: 'eggjs',
   // },
 
+  theme: {
+    '@c-primary': '#22ab28',
+  },
+
   exportStatic: {},
 
   sitemap: {


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Description of change

Use Egg brand color (#22ab28) as the primary color of doc site