### PR TITLE
chore: package upgrade and unittest fixture

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 1
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ylru": "^1.2.1"
   },
   "devDependencies": {
-    "@umijs/preset-react": "^1.x",
+    "@umijs/preset-react": "^2.1.2",
     "address": "^1.0.3",
     "antd": "^4.18.6",
     "assert-extends": "^1.0.1",

--- a/test/fixtures/apps/response/app/router.js
+++ b/test/fixtures/apps/response/app/router.js
@@ -6,7 +6,7 @@ module.exports = app => {
   app.get('/', function* () {
       this.body = 'hello';
       assert.equal(this.response.length, 5);
-      this.body = new Buffer(3);
+      this.body = Buffer.alloc(3);
       assert.equal(this.response.length, 3);
       this.body = {};
       assert.equal(this.response.length, 2);


### PR DESCRIPTION
1. Upgrade @umijs/preset-react from 1.xx to 2.xx.
2. Use 'Buffer.alloc' instead of 'new Buffer()'.
3. Add 'dependabot.yml'to upgrade the related packages automatically.

---
- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines