### PR TITLE
feat: should log unfinished timing item

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,7 +24,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
-      run: npm i -g npminstall && npminstall
+      run: npm i -g npminstall@5 && npminstall
 
     - name: Continuous integration
       run: npm run ci

--- a/lib/egg.js
+++ b/lib/egg.js
@@ -426,6 +426,13 @@ class EggApplication extends EggCore {
   _setupTimeoutTimer() {
     const startTimeoutTimer = setTimeout(() => {
       this.coreLogger.error(`${this.type} still doesn't ready after ${this.config.workerStartTimeout} ms.`);
+      // log unfinished
+      const json = this.timing.toJSON();
+      for (const item of json) {
+        if (item.end) continue;
+        this.coreLogger.error(`unfinished timing item: ${CircularJSON.stringify(item)}`);
+      }
+      this.coreLogger.error(`check run/${this.type}_timing_${process.pid}.json for more details.`);
       this.emit('startTimeout');
     }, this.config.workerStartTimeout);
     this.ready(() => clearTimeout(startTimeoutTimer));

--- a/test/fixtures/apps/dumptiming-timeout/app.js
+++ b/test/fixtures/apps/dumptiming-timeout/app.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = class {
+  constructor(app) {
+    this.app = app;
+  }
+
+  async didLoad() {
+    this.app.coreLogger.info('start doing sth in didLoad');
+    return new Promise(resolve => {
+      setTimeout(() => {
+        this.app.coreLogger.info('end doing sth in didLoad');
+        resolve();
+      }, 1500);
+    });
+  }
+}

--- a/test/fixtures/apps/dumptiming-timeout/config/config.default.js
+++ b/test/fixtures/apps/dumptiming-timeout/config/config.default.js
@@ -1,0 +1,2 @@
+exports.keys = 'test key';
+exports.workerStartTimeout = 1000;

--- a/test/fixtures/apps/dumptiming-timeout/config/plugin.js
+++ b/test/fixtures/apps/dumptiming-timeout/config/plugin.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.static = false;

--- a/test/fixtures/apps/dumptiming-timeout/package.json
+++ b/test/fixtures/apps/dumptiming-timeout/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "dumptiming-timeout"
+}

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -168,6 +168,16 @@ describe('test/lib/egg.test.js', () => {
       });
       app.dumpTiming();
     });
+
+    it('should dumpTiming when timeout', async () => {
+      const baseDir = utils.getFilepath('apps/dumptiming-timeout');
+      await rimraf(path.join(baseDir, 'run'));
+      await rimraf(path.join(baseDir, 'logs'));
+      const app = utils.app(baseDir);
+      await app.ready();
+      assertFile(path.join(baseDir, `run/application_timing_${process.pid}.json`));
+      assertFile(path.join(baseDir, 'logs/dumptiming-timeout/common-error.log'), /unfinished timing item: {"name":"Did Load in app.js:didLoad"/);
+    });
   });
 
   describe('dump disabled plugin', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

```bash
2022-06-17 10:50:12,770 ERROR 69291 application still doesn't ready after 1000 ms.
2022-06-17 10:50:12,770 ERROR 69291 unfinished timing item: {"name":"Application Start","start":1655434211766,"pid":69291,"index":1}
2022-06-17 10:50:12,771 ERROR 69291 unfinished timing item: {"name":"Did Load in app.js:didLoad","start":1655434211778,"pid":69291,"index":52}
2022-06-17 10:50:12,771 ERROR 69291 check run/application_timing_69291.json for more details.
```