### PR TITLE
docs: update the version of the required Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm run dev
 $ open http://localhost:7001
 ```
 
-> Node.js >= 8.5.0 required.
+> Node.js >= 14.20.0 required.
 
 ## Documentations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 - 深度框架定制
 - 丰富的[插件](https://github.com/search?q=topic%3Aegg-plugin&type=Repositories)
 
-> 支持 Node.js 8.5.x 及以上版本。
+> 支持 Node.js 14.20.0 及以上版本。
 
 ## 快速开始
 


### PR DESCRIPTION
Upgrading the version for Egg3.0 by referring Node's 14.20.x or above.