### PR TITLE
test: add new test case for runInAnonymousContextScope

### DIFF
--- a/test/app/extend/application.test.js
+++ b/test/app/extend/application.test.js
@@ -208,6 +208,21 @@ describe('test/app/extend/application.test.js', () => {
     });
   });
 
+  describe('app.runInAnonymousContextScope(scope,request)', () => {
+    it('should run task in anonymous context scope with req success', async () => {
+      const app = utils.app('apps/app-runInAnonymousContextScope-withRequest');
+      await app.ready();
+      await app.close();
+      await utils.sleep(2100);
+      const logdir = app.config.logger.dir;
+      const logs = fs.readFileSync(path.join(logdir, 'app-runInAnonymousContextScope-withRequest-web.log'), { encoding: 'utf8' }).split('\n');
+
+      assert.match(logs[0], / INFO \d+ \[-\/127.0.0.2\/-\/\d+ms GET \/] inside before close on ctx logger/);
+      assert.match(logs[1], / INFO \d+ \[-\/127.0.0.2\/-\/\d+ms GET \/] inside before close on app logger/);
+      assert.match(logs[2], / INFO \d+ outside before close on app logger/);
+    });
+  });
+
   describe('app.handleRequest(ctx, fnMiddleware)', () => {
     let app;
     before(() => {

--- a/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/app.js
+++ b/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/app.js
@@ -1,0 +1,33 @@
+module.exports = class Boot {
+  constructor(app) {
+    this.app = app;
+  }
+
+  async beforeClose() {
+
+    const request = {
+      headers: {
+        host: '127.0.0.2',
+        'x-forwarded-for': '127.0.0.2',
+      },
+      querystring: 'Testing',
+      host: '127.0.0.2',
+      hostname: '127.0.0.2',
+      protocol: 'http',
+      secure: 'false',
+      method: 'GET',
+      url: '/',
+      path: '/',
+      socket: {
+        remoteAddress: '127.0.0.2',
+        remotePort: 7001,
+      },
+    };
+
+    await this.app.runInAnonymousContextScope(async ctx => {
+      ctx.logger.info('inside before close on ctx logger');
+      this.app.logger.info('inside before close on app logger');
+    }, request);
+    this.app.logger.info('outside before close on app logger');
+  }
+}

--- a/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/config/config.default.js
+++ b/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/config/config.default.js
@@ -1,0 +1,1 @@
+exports.keys = 'foo';

--- a/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/config/config.unittest.js
+++ b/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/config/config.unittest.js
@@ -1,0 +1,3 @@
+exports.logger = {
+  consoleLevel: 'NONE',
+};

--- a/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/package.json
+++ b/test/fixtures/apps/app-runInAnonymousContextScope-withRequest/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "app-runInAnonymousContextScope-withRequest"
+}

--- a/test/lib/cluster/app_worker.test.js
+++ b/test/lib/cluster/app_worker.test.js
@@ -101,7 +101,7 @@ describe('test/lib/cluster/app_worker.test.js', () => {
         version[0] > 9) {
         html = new RegExp(
           'GET /foo bar HTTP/1.1\r\nHost: 127.0.0.1:\\d+\r\nAccept-Encoding: gzip, ' +
-          'deflate\r\nConnection: close\r\n\r\n');
+          'deflate\r\nuser-agent: egg-mock/\\d+.\\d+.\\d+\r\nConnection: close\r\n\r\n');
       }
 
       // customized client error response
@@ -109,7 +109,7 @@ describe('test/lib/cluster/app_worker.test.js', () => {
       test1.request().path = '/foo bar';
       await test1.expect(html)
         .expect('foo', 'bar')
-        .expect('content-length', '99')
+        .expect('content-length', '128')
         .expect(418);
 
       // customized client error handle function throws


### PR DESCRIPTION
Since 'runInAnoymousContextScope' now has a new feature with a request as a parameter, it lacks a new test case, this is the test case for it.

Refs：https://github.com/eggjs/egg/pull/5134

---
- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines
