### PR TITLE
docs: add details for "pulling code" and "install dependencies"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ the help of [git](https://git-scm.com/download/) and work on that.
 
 ### Install Dependencies
 
-You can install all the dependencies listed in `package.json` with `npm`，
+You can install all the dependencies listed in `package.json` with `npm`,
 when your npm version is 7.X or higher:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,30 @@ All features must be submitted along with documentations. The documentations sho
 All demos should be compiled at [eggjs/examples](https://github.com/eggjs/examples) repository.
 - Please provide essential urls, such as application process, terminology explainations and references.
 
-## Submitting Code
+## Pulling and Submitting Code
+
+### Pulling Code
+
+Please click the "Fork" button in the main page of [Egg](https://github.com/eggjs/egg) to
+fork the latest code into your own repository. Then clone yours to your local machine with
+the help of [git](https://git-scm.com/download/) and work on that.
+
+### Install Dependencies
+
+You can install all the dependencies listed in `package.json` with `npm`，
+when your npm version is 7.X or higher:
+
+```bash
+npm i --legacy-peer-deps
+```
+> Note: If you DON'T ADD `--legacy-peer-deps`, maybe dependency errors will occur
+  during installation.
+
+Otherwise, you can install dependencies with the following command:
+
+```bash
+npm i
+```
 
 ### Pull Request Guide
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -40,7 +40,28 @@
 - 提供必要的链接，如申请流程，术语解释和参考文档等。
 - 同步修改中英文文档，或者在 PR 里面说明。
 
-## 提交代码
+## 下拉与提交代码
+
+### 下拉代码
+
+请现在 GitHub 上点击 [Egg 项目](https://github.com/eggjs/egg)的“Fork”按钮，将 Egg 项目克隆到自己的仓库中，然后借助 [git](https://git-scm.com/download/) 将代码克隆到本地，以后的开发都在本地进行。
+
+### 安装依赖
+
+你可使用 Node 自带的 `npm` 包管理工具命令安装所有在“package.json”上的必备依赖，
+当你的 npm 版本高于等于 7.X 时，你可以使用以下命令：
+
+```bash
+npm i --legacy-peer-deps
+```
+
+> 请注意: 如果你不添加 `--legacy-peer-deps`, 安装过程中可能会出现与依赖性相关的错误。
+
+否则可以直接使用以下命令：
+
+```bash
+npm i
+```
 
 ### 提交 Pull Request
 


### PR DESCRIPTION
Add necessary detailled information for "Pulling code" and "Install Dependencies", especially for when npm's version >= 7.x, '--legacy-peer-deps' is always ignored by new comers, which will raise installation problems.

---

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines