### PR TITLE
docs: add details for "pulling code" and "install dependencies"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,30 @@ All features must be submitted along with documentations. The documentations sho
 All demos should be compiled at [eggjs/examples](https://github.com/eggjs/examples) repository.
 - Please provide essential urls, such as application process, terminology explainations and references.
 
-## Submitting Code
+## Pulling and Submitting Code
+
+### Pulling Code
+
+Please click the "Fork" button in the main page of [Egg](https://github.com/eggjs/egg) to
+fork the latest code into your own repository. Then clone yours to your local machine with
+the help of [git](https://git-scm.com/download/) and work on that.
+
+### Install Dependencies
+
+You can install all the dependencies listed in `package.json` with `npm`:
+
+```bash
+npm i
+```
+> If there's something wrong related to dependencies happending during the installation,
+you can temporarily solve it by adding `--legacy-peer-deps` when your npm version >= 7.X,
+and you can submit a PR directly in the "Issues" list to notify the author.
+
+Otherwise, you can install dependencies with the following command:
+
+```bash
+npm i --legacy-peer-deps
+```
 
 ### Pull Request Guide
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -40,7 +40,26 @@
 - 提供必要的链接，如申请流程，术语解释和参考文档等。
 - 同步修改中英文文档，或者在 PR 里面说明。
 
-## 提交代码
+## 下拉与提交代码
+
+### 下拉代码
+
+请现在 GitHub 上点击 [Egg 项目](https://github.com/eggjs/egg)的“Fork”按钮，将 Egg 项目克隆到自己的仓库中，然后借助 [git](https://git-scm.com/download/) 将代码克隆到本地，以后的开发都在本地进行。
+
+### 安装依赖
+
+你可使用 Node 自带的 `npm` 包管理工具命令安装所有在“package.json”上的必备依赖：
+
+```bash
+npm i
+```
+
+> 请注意: 如你安装过程中看到依赖性相关的错误，而导致安装失败，且你的 npm 版本 >=7.X，临时
+解决方案是加上 `--legacy-peer-deps`，然后请及时在 Issues 里边提 PR，告知开发者。
+
+```bash
+npm i --legacy-peer-deps
+```
 
 ### 提交 Pull Request
 


### PR DESCRIPTION
Make that '--legacy-peer-deps' is a optional choice to temporarily solve the dependencies problem, it shouldn't be a real solution.

Refs：https://github.com/eggjs/egg/pull/5193