### PR TITLE
test: fix and enable 'egg.test.js'

### DIFF
--- a/test/fixtures/apps/demo/app.js
+++ b/test/fixtures/apps/demo/app.js
@@ -1,9 +1,31 @@
 'use strict';
+const mm = require('egg-mock');
+const assert = require('assert');
+const utils = require('../../../utils');
 
-module.exports = app => {
-  app.ready(() => {
-    app.config.tips = 'hello egg started';
+class DemoAppTest {
+
+  constructor(app) {
+    this.app = app;
+
+    // Add an attached variable exposed to the unit test
+    this.app.triggerCount = 0;
+
+    // Mock "lifecycle" function with a counter
+    // Before calling "ready()"
+    mm(this.app.lifecycle, 'triggerServerDidReady', () => {
+      this.app.triggerCount++;
+    });
+  }
+
+  configWillLoad() {
+    this.app.config.tips = 'hello egg started';
+  }
+
+  async didReady() {
     // dynamic router
-    app.all('/all', app.controller.home);
-  });
-};
+    this.app.all('/all', this.app.controller.home);
+  }
+}
+
+module.exports = DemoAppTest;

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -419,23 +419,25 @@ describe('test/lib/egg.test.js', () => {
     });
   });
 
-  describe.skip('egg-ready', () => {
-    let app;
+  describe('egg-ready', () => {
+
+    let app = null;
+
     before(() => {
       app = utils.app('apps/demo');
     });
+
     after(() => app.close());
 
     it('should only trigger once', async () => {
-      let triggerCount = 0;
-      mm(app.lifecycle, 'triggerServerDidReady', () => {
-        triggerCount++;
-      });
+
       await app.ready();
+
       app.messenger.emit('egg-ready');
       app.messenger.emit('egg-ready');
       app.messenger.emit('egg-ready');
-      assert(triggerCount === 1);
+
+      assert(app.triggerCount === 1);
     });
   });
 


### PR DESCRIPTION
Bug Reasons:

1. We cannot get "messenger" and "lifecycle" instances belonging to "app" itself before "ready()" function, a "cannot get xxx property" will be raised.

2. We CANNOT use "mm(……)" to replace "triggerServerDidReady" function, after "app.ready()" in the unit test case, bcoz it WON'T be triggered if we do that. The only solution is to replace it in the constructor.

---
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
