### PR TITLE
ci: upgrade the nodejs version for 'gh-pages'

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        node-version: [ 16 ]
+        node-version: [ 18 ]
     steps:
     - name: Checkout Git Source
       uses: actions/checkout@master


### PR DESCRIPTION
Now the stable version of nodejs is v18, upgrade it to the latest version to fix the bug of '--openssl-legacy-provider is not allowed in NODE_OPTIONS' in node v16.