### PR TITLE
test: stable some unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "egg-view-nunjucks": "^2.3.0",
     "eslint": "^8.23.1",
     "eslint-config-egg": "^12.0.0",
-    "findlinks": "^2.1.0",
+    "findlinks": "^2.2.0",
     "formstream": "^1.1.1",
     "jsdoc": "^3.6.11",
     "koa": "^2.13.4",

--- a/test/doc.test.js
+++ b/test/doc.test.js
@@ -14,7 +14,7 @@ describe('test/doc.test.js', () => {
    * to generate the whole doc. We only need some of the test cases to check
    * whether the links inside the doc gets fine or not.
    */
-  it('should have no broken urls', async () => {
+  it('should have no broken urls (based on non-windows platform and node\'s version >=18)', async function() {
 
     const mainNodejsVersion = parseInt(process.versions.node.split('.')[0]);
 
@@ -35,7 +35,7 @@ describe('test/doc.test.js', () => {
       assert(result.fail === 0);
       app.close();
     } else {
-      console.log('Skip Doc test for this version of nodejs or this platform.');
+      this.skip();
     }
   }).timeout(10 * 60 * 1000);
 });

--- a/test/lib/core/logger.test.js
+++ b/test/lib/core/logger.test.js
@@ -214,7 +214,7 @@ describe('test/lib/core/logger.test.js', () => {
     assert(app.agent.logger.options.file === app.agent.coreLogger.options.file);
   });
 
-  it('should config.logger.enableFastContextLogger = true work', async () => {
+  it('should `config.logger.enableFastContextLogger` = true work', async () => {
     app = utils.app('apps/app-enableFastContextLogger');
     await app.ready();
     app.mockContext({
@@ -222,13 +222,13 @@ describe('test/lib/core/logger.test.js', () => {
         traceId: 'mock-trace-id-123',
       },
     });
-    if (process.platform === 'win32') await utils.sleep(2000);
     await app.httpRequest()
       .get('/')
       .expect(200)
       .expect({
         enableFastContextLogger: true,
       });
+    await utils.sleep(1000);
     app.expectLog(/ INFO \d+ \[-\/127\.0\.0\.1\/mock-trace-id-123\/\d+ms GET \/] enableFastContextLogger: true/);
   });
 

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -276,12 +276,17 @@ describe('test/lib/egg.test.js', () => {
       app = utils.app('apps/config-env');
       await app.ready();
     });
-    after(async () => {
-      await Promise.all([ app.close(), utils.rimraf(runDir), utils.rimraf(logDir) ]);
+    after(() => {
+      app.close();
+      utils.rimraf(runDir);
+      utils.rimraf(logDir);
+      utils.rimraf(path.join(baseDir, 'logs'));
+      utils.rimraf(path.join(baseDir, 'run'));
     });
     afterEach(mm.restore);
 
     it('should custom dir', async () => {
+      await utils.sleep(1000);
       assertFile(path.join(runDir, 'application_config.json'));
       assertFile(path.join(logDir, 'egg-web.log'));
       assertFile.fail(path.join(baseDir, 'run/application_config.json'));


### PR DESCRIPTION
1. Update "findlinks" to make the "doc.test.js" stable when rendering documents of Egg.js (Refs: https://github.com/popomore/findlinks/pull/9).

2. Adjust the "utils.sleep()" to make sure the "test/lib/core/logger.test.js" on non-windows platform stable.

---

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines