### PR TITLE
test: remove useless "async" support check

### DIFF
--- a/test/async/index.test.js
+++ b/test/async/index.test.js
@@ -1,7 +1,0 @@
-'use strict';
-
-const nodeVersion = Number(process.version.match(/^v(\d+\.\d+)\./)[1]);
-// only node >= 7.6 supports async function without flags
-if (nodeVersion >= 7.6) {
-  require('./_async');
-}

--- a/test/asyncSupport.test.js
+++ b/test/asyncSupport.test.js
@@ -2,9 +2,9 @@
 
 const assert = require('assert');
 const mm = require('egg-mock');
-const utils = require('../utils');
+const utils = require('./utils');
 
-describe('test/async.test.js', () => {
+describe('test/asyncSupport.test.js', () => {
   afterEach(mm.restore);
   let app;
   before(async () => {
@@ -18,7 +18,7 @@ describe('test/async.test.js', () => {
     assert(app.beforeCloseExecuted);
   });
 
-  it('middleware, controller and service support async functions', async () => {
+  it('middleware, controller and service should support async functions', async () => {
     await app.httpRequest()
       .get('/api')
       .expect(200)


### PR DESCRIPTION
Our current nodejs version MUST BE >=14.20.0, no need to check whether the current version satisfies the test env.

---

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines