### PR TITLE
fix: ipc not work with worker_threads mode

### DIFF
--- a/lib/core/messenger/ipc.js
+++ b/lib/core/messenger/ipc.js
@@ -2,6 +2,7 @@
 
 const debug = require('util').debuglog('egg:util:messenger:ipc');
 const is = require('is-type-of');
+const workerThreads = require('worker_threads');
 const sendmessage = require('sendmessage');
 const EventEmitter = require('events');
 
@@ -22,6 +23,9 @@ class Messenger extends EventEmitter {
     });
     this._onMessage = this._onMessage.bind(this);
     process.on('message', this._onMessage);
+    if (!workerThreads.isMainThread) {
+      workerThreads.parentPort.on('message', this._onMessage);
+    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "koa-override": "^3.0.0",
     "ms": "^2.1.3",
     "on-finished": "^2.4.1",
-    "sendmessage": "^1.1.0",
+    "sendmessage": "^2.0.0",
     "urllib": "^2.33.0",
     "urllib-next": "^3.9.0",
     "utility": "^1.17.0",

--- a/test/lib/core/messenger/ipc.test.js
+++ b/test/lib/core/messenger/ipc.test.js
@@ -162,4 +162,31 @@ describe('test/lib/core/messenger/ipc.test.js', () => {
       }
     });
   });
+
+  describe('worker_threads mode', () => {
+    let app;
+    before(() => {
+      mm.env('default');
+      app = utils.cluster('apps/messenger-app-agent', { workers: 1, startMode: 'worker_threads' });
+      app.coverage(false);
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('app should accept agent message', done => {
+      setTimeout(() => {
+        assert(count(app.stdout, 'agent2app') === 1);
+        assert(count(app.stdout, 'app2app') === 1);
+        assert(count(app.stdout, 'agent2agent') === 1);
+        assert(count(app.stdout, 'app2agent') === 1);
+        done();
+      }, 500);
+
+      function count(data, key) {
+        return data.split('\n').filter(line => {
+          return line.indexOf(key) >= 0;
+        }).length;
+      }
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
`lib/core/messenger`

##### Description of change
<!-- Provide a description of the change below this comment. -->
Fix the issue where IPC does not work when startMode is set to 'worker_threads'.

This change depends on the modification made in "[sendmessage #3](https://github.com/node-modules/sendmessage/pull/3)". Please make sure that this change has taken effect before merging this one.
<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->