### PR TITLE
test: add "expect" to "development" plugin tests

### DIFF
--- a/test/lib/plugins/development.test.js
+++ b/test/lib/plugins/development.test.js
@@ -28,13 +28,16 @@ describe('test/lib/plugins/development.test.js', () => {
         .expect(200);
 
       await app.httpRequest()
-        .get('/public/hello');
+        .get('/public/hello')
+        .expect(404);
 
       await app.httpRequest()
-        .get('/assets/hello');
+        .get('/assets/hello')
+        .expect(404);
 
       await app.httpRequest()
-        .get('/__koa_mock_scene_toolbox/hello');
+        .get('/__koa_mock_scene_toolbox/hello')
+        .expect(404);
     });
   });
 


### PR DESCRIPTION
Refs: https://github.com/eggjs/egg/pull/5211.

---

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines