### PR TITLE
chore: remove SingleProcess warnings

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -3,9 +3,6 @@
 const path = require('path');
 
 module.exports = async (options = {}) => {
-  if (!options.ignoreWarning) {
-    console.warn('single process mode is still in experiment, please don\'t use it in production environment');
-  }
 
   options.baseDir = options.baseDir || process.cwd();
   options.mode = 'single';

--- a/test/lib/start.test.js
+++ b/test/lib/start.test.js
@@ -46,10 +46,6 @@ describe('test/lib/start.test.js', () => {
       app = await utils.singleProcessApp('apps/demo', { env: 'prod' });
       assert(app.config.env === 'prod');
     });
-
-    it('should ignoreWarng work', async () => {
-      app = await utils.singleProcessApp('apps/demo', { ignoreWaring: true });
-    });
   });
 
   describe('custom framework work', () => {


### PR DESCRIPTION
Since we're now successfully using this feature for a long time without obvious bugs/errors, there's no need for us to make it as an "experinment" feature and now it's come to ture.

Ref: https://github.com/eggjs/egg/pull/3430

---

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines