### PR TITLE
fix: don't require inspector module on production env

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -3,7 +3,6 @@ const path = require('path');
 const fs = require('fs');
 const ms = require('ms');
 const http = require('http');
-const inspector = require('inspector');
 const EggCore = require('egg-core').EggCore;
 const cluster = require('cluster-client');
 const extend = require('extend2');
@@ -115,7 +114,7 @@ class EggApplication extends EggCore {
         isLeader: this.type === 'agent',
         logger: this.coreLogger,
         // debug mode does not check heartbeat
-        isCheckHeartbeat: inspector.url() === undefined,
+        isCheckHeartbeat: this.config.env === 'prod' ? true : require('inspector').url() === undefined,
       });
       const client = cluster(clientClass, options);
       this._patchClusterClient(client);


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
because of   production env shouldn't use inspector module and such as vercel/pkg custom node runtime remove it. so we hope egg disable inspector on production env.

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->

closes https://github.com/eggjs/egg/issues/5226