### PR TITLE
fix: set body parser error to status 400 by default

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,4 +14,3 @@ jobs:
     with:
       os: 'ubuntu-latest, macos-latest, windows-latest'
       version: '14, 16, 18, 20'
-      install: 'npm i -g npminstall && npminstall'

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -236,8 +236,15 @@ module.exports = appInfo => {
       depth: 5,
       parameterLimit: 1000,
     },
-    onerror(err) {
+    onerror(err, ctx) {
       err.message += ', check bodyParser config';
+      if (ctx.status === 404) {
+        // set default status to 400, meaning client bad request
+        ctx.status = 400;
+        if (!err.status) {
+          err.status = 400;
+        }
+      }
       throw err;
     },
   };

--- a/test/app/middleware/body_parser.test.js
+++ b/test/app/middleware/body_parser.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const querystring = require('querystring');
 const utils = require('../../utils');
@@ -80,6 +78,24 @@ describe('test/app/middleware/body_parser.test.js', () => {
       .send({ foo: 'a'.repeat(1024 * 200) })
       .expect(/request entity too large, check bodyParser config/)
       .expect(413);
+  });
+
+  it('should 400 when GET with invalid body', async () => {
+    app.mockCsrf();
+    await app.httpRequest()
+      .get('/test/body_parser/user')
+      .set('content-type', 'application/json')
+      .set('content-encoding', 'gzip')
+      .expect(/unexpected end of file, check bodyParser config/)
+      .expect(400);
+
+    await app.httpRequest()
+      .get('/test/body_parser/user')
+      .set('content-type', 'application/json')
+      .set('content-encoding', 'gzip')
+      .send({ foo: 'a'.repeat(1024) })
+      .expect(/incorrect header check, check bodyParser config/)
+      .expect(400);
   });
 
   it('should disable body parser', async () => {


### PR DESCRIPTION
closes https://github.com/eggjs/egg/issues/5261

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->