### PR TITLE
fix: typo on index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -449,7 +449,7 @@ declare module 'egg' {
       /**
        * i18n resource file dir, not recommend to change default value
        */
-      dir: string;
+      dirs: string[];
       /**
        * custom the locale value field, default `query.locale`, you can modify this config, such as `query.lang`
        */


### PR DESCRIPTION
`i18n.dir` should be `i18n.dirs`
