### PR TITLE
docs: add missing paramter "viewOptions" to meet the explaination

### DIFF
--- a/site/docs/advanced/view-plugin.md
+++ b/site/docs/advanced/view-plugin.md
@@ -60,10 +60,13 @@ The following is a simplified code that can be directly [view source](https://gi
 const ejs = require('ejs');
 
 Mmdule.exports = class EjsView {
-  render(filename, locals) {
+  render(filename, locals, viewOptions) {
+
+    const config = Object.assign({}, this.config, viewOptions, { filename });
+
     return new Promise((resolve, reject) => {
       // Asynchronous API call
-      ejs.renderFile(filename, locals, (err, result) => {
+      ejs.renderFile(filename, locals, config, (err, result) => {
         if (err) {
           reject(err);
         } else {
@@ -73,10 +76,11 @@ Mmdule.exports = class EjsView {
     });
   }
 
-  renderString(tpl, locals) {
+  renderString(tpl, locals, viewOptions) {
+    const config = Object.assign({}, this.config, viewOptions, { cache: null });
     try {
       // Synchronous API call
-      return Promise.resolve(ejs.render(tpl, locals));
+      return Promise.resolve(ejs.render(tpl, locals, config));
     } catch (err) {
       return Promise.reject(err);
     }
@@ -88,15 +92,15 @@ Mmdule.exports = class EjsView {
 
 The three parameters of the `render` method are:
 
-- filename: is the path to the complete file. The framework determines if the file exists when looking for the file. It does not need to be processed here.
-- locals: The data needs rendering. It comes from `app.locals`, `ctx.locals` and calls `render` methods. The framework also has built in `ctx`, `request`, `ctx.helper` objects.
-- viewOptions: The incoming configuration of the user, which can override the default configuration of the template engine. This can be considered based on the characteristics of the template engine. For example, the cache is enabled by default but a page does not need to be cached.
+- `filename`: is the path to the complete file. The framework determines if the file exists when looking for the file. It does not need to be processed here.
+- `locals`: The data needs rendering. It comes from `app.locals`, `ctx.locals` and calls `render` methods. The framework also has built in `ctx`, `request`, `ctx.helper` objects.
+- `viewOptions`: The incoming configuration of the user, which can override the default configuration of the template engine. This can be considered based on the characteristics of the template engine. For example, the cache is enabled by default but a page does not need to be cached.
 
 The three parameters of the `renderString` method:
 
-- tpl: template string, not file path.
-- locals: same with `render`.
-- viewOptions: same with `render`.
+- `tpl`: template string, not file path.
+- `locals`: same with `render`.
+- `viewOptions`: same with `render`.
 
 ## Plugin Configuration
 

--- a/site/docs/advanced/view-plugin.zh-CN.md
+++ b/site/docs/advanced/view-plugin.zh-CN.md
@@ -56,11 +56,14 @@ View 基类需要提供 `render` 和 `renderString` 两个方法，支持 genera
 ```js
 const ejs = require('ejs');
 
-class EjsView {
-  render(filename, locals) {
+Mmdule.exports = class EjsView {
+  render(filename, locals, viewOptions) {
+
+    const config = Object.assign({}, this.config, viewOptions, { filename });
+
     return new Promise((resolve, reject) => {
       // 异步调用 API
-      ejs.renderFile(filename, locals, function(err, result) {
+      ejs.renderFile(filename, locals, config, (err, result) => {
         if (err) {
           reject(err);
         } else {
@@ -70,28 +73,26 @@ class EjsView {
     });
   }
 
-  renderString(tpl, locals) {
+  renderString(tpl, locals, viewOptions) {
+    const config = Object.assign({}, this.config, viewOptions, { cache: null });
     try {
       // 同步调用 API
-      return Promise.resolve(ejs.render(tpl, locals));
+      return Promise.resolve(ejs.render(tpl, locals, config));
     } catch (err) {
       return Promise.reject(err);
     }
   }
-}
-
-module.exports = EjsView;
+};
 ```
 
 ### 参数
 
-- `render` 方法的参数：
+`render` 方法的参数：
   - `filename`：是完整文件路径，框架查找文件时已确认文件是否存在，因此这里不需要处理。
   - `locals`：渲染所需数据，来源包括 `app.locals`、`ctx.locals` 以及调用 `render` 方法传入的数据。框架还内置了 `ctx`、`request` 和 `ctx.helper` 这几个对象。
   - `viewOptions`：用户传入的配置，可以覆盖模板引擎的默认配置。这个可根据模板引擎的特征考虑是否支持。例如，默认开启了缓存，而某个页面不需要缓存。
 
-- `renderString` 方法的三个参数
-
+`renderString` 方法的三个参数：
   - `tpl`: 模板字符串，没有文件路径。
   - `locals`: 同 `render`。
   - `viewOptions`: 同 `render`。


### PR DESCRIPTION
"viewOptions" is the missing parameter of "render" and "renderString" functions, according to the explainations. So this is the fixture for it.

---

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines