### PR TITLE
test: add some missing unit tests for 'convertObject'

### DIFF
--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -20,18 +20,19 @@ function convertObject(obj, ignore) {
 function convertValue(key, value, ignore) {
   if (is.nullOrUndefined(value)) return value;
 
-  let hit;
+  let hit = false;
   for (const matchKey of ignore) {
     if (is.string(matchKey) && matchKey === key) {
       hit = true;
+      break;
     } else if (is.regExp(matchKey) && matchKey.test(key)) {
       hit = true;
+      break;
     }
   }
   if (!hit) {
     if (is.symbol(value) || is.regExp(value)) return value.toString();
-    if (is.primitive(value)) return value;
-    if (is.array(value)) return value;
+    if (is.primitive(value) || is.array(value)) return value;
   }
 
   // only convert recursively when it's a plain object,

--- a/test/lib/core/utils.test.js
+++ b/test/lib/core/utils.test.js
@@ -125,6 +125,35 @@ describe('test/lib/core/utils.test.js', () => {
       assert(obj.undefined$ === undefined);
       assert(obj.boolean$ === '<Boolean>');
       assert(obj.symbol$ === '<Symbol>');
+      assert(obj.regexp$ === '<RegExp>');
+    });
+
+    it('should convert a plain recursive object', () => {
+      const obj = {
+        plainObj: 'Plain',
+        Id: 1,
+        recurisiveObj: {
+          value1: 'string',
+          value2: 1,
+          ignoreValue: /^[a-z]/,
+        },
+      };
+      utils.convertObject(obj, [ 'ignoreValue' ]);
+      assert(obj.recurisiveObj.value1 === 'string');
+      assert(obj.recurisiveObj.value2 === 1);
+      assert(obj.recurisiveObj.ignoreValue === '<RegExp>');
+      assert(obj.plainObj === 'Plain');
+      assert(obj.Id === 1);
+    });
+
+    it('should convert an anonymous class', () => {
+      const obj = {
+        anonymousClassWithPropName: class { },
+        '': class { },
+      };
+      utils.convertObject(obj);
+      assert(obj.anonymousClassWithPropName === '<Class anonymousClassWithPropName>');
+      assert(obj[''] === '<Class anonymous>');
     });
   });
 


### PR DESCRIPTION
According to AI's suggestions at https://github.com/eggjs/egg/pull/5302, it seems there're some missing unit tests and here's the fix for it.

- [X] `npm test` passes
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message follows commit guidelines