### PR TITLE
feat: app.httpClient alias to app.httpclient

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -305,6 +305,14 @@ class EggApplication extends EggCore {
   }
 
   /**
+   * @alias httpclient
+   * @member {HttpClient}
+   */
+  get httpClient() {
+    return this.httpclient;
+  }
+
+  /**
    *  All loggers contain logger, coreLogger and customLogger
    * @member {Object}
    * @since 1.0.0

--- a/test/lib/core/httpclient.test.js
+++ b/test/lib/core/httpclient.test.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const assert = require('assert');
+const assert = require('node:assert');
 const mm = require('egg-mock');
 const urllib = require('urllib');
 const Httpclient = require('../../../lib/core/httpclient');
@@ -268,6 +266,9 @@ describe('test/lib/core/httpclient.test.js', () => {
 
     it('should app request auto set tracer', async () => {
       const httpclient = app.httpclient;
+      // httpClient alias to httpclient
+      assert(app.httpClient);
+      assert.equal(app.httpClient, app.httpclient);
 
       let reqTracer;
       let resTracer;


### PR DESCRIPTION
let `@Inject() httpClient` work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new alias for `httpClient` to improve accessibility and usage within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->