### PR TITLE
fix: serverTimeout default to 0 (no timeout)

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -359,7 +359,7 @@ module.exports = appInfo => {
   config.workerStartTimeout = 10 * 60 * 1000;
 
   /**
-   * server timeout in milliseconds, default to 2 minutes.
+   * server timeout in milliseconds, default to 0 (no timeout).
    *
    * for special request, just use `ctx.req.setTimeout(ms)`
    *

--- a/index.d.ts
+++ b/index.d.ts
@@ -330,7 +330,7 @@ declare module 'egg' {
      * @property {Number} queryString.parameterLimit - parameter number limit, default 1000
      * @property {String[]} enableTypes - parser will only parse when request type hits enableTypes, default is ['json', 'form']
      * @property {Object} extendTypes - support extend types
-     * @property {String} onProtoPoisoning - Defines what action must take when parsing a JSON object with `__proto__`. Possible values are `'error'`, `'remove'` and `'ignore'`. Default is `'error'`, it will return `403` response when `Prototype-Poisoning` happen.
+     * @property {String} onProtoPoisoning - Defines what action must take when parsing a JSON object with `__proto__`. Possible values are `'error'`, `'remove'` and `'ignore'`. Default is `'error'`, it will return `400` response when `Prototype-Poisoning` happen.
      */
     bodyParser: {
       enable: boolean;
@@ -352,7 +352,7 @@ declare module 'egg' {
         form: string[];
         text: string[];
       };
-      /** Default is `'error'`, it will return `403` response when `Prototype-Poisoning` happen. */
+      /** Default is `'error'`, it will return `400` response when `Prototype-Poisoning` happen. */
       onProtoPoisoning: 'error' | 'remove' | 'ignore';
     };
 
@@ -532,7 +532,7 @@ declare module 'egg' {
     onClientError(err: Error, socket: Socket, app: EggApplication): ClientErrorResponse | Promise<ClientErrorResponse>;
 
     /**
-     * server timeout in milliseconds, default to 2 minutes.
+     * server timeout in milliseconds, default to 0 (no timeout).
      *
      * for special request, just use `ctx.req.setTimeout(ms)`
      *


### PR DESCRIPTION
typo fix on onProtoPoisoning, should be 400 response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the response code for `Prototype-Poisoning` from `403` to `400`.

- **Configuration Changes**
  - Changed the default server timeout setting to 0 (no timeout).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->