### PR TITLE
feat: allow to httpClient use HTTP2 first

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -304,6 +304,7 @@ module.exports = appInfo => {
    * @property {Number} httpsAgent.maxSockets - https agent max socket number of one host, default is `Number.MAX_SAFE_INTEGER` @ses https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
    * @property {Number} httpsAgent.maxFreeSockets - https agent max free socket number of one host, default is 256.
    * @property {Boolean} useHttpClientNext - use urllib@3 HttpClient
+   * @property {Boolean} allowH2 - Allow to use HTTP2 first, only work on `useHttpClientNext = true`
    */
   config.httpclient = {
     enableDNSCache: false,
@@ -326,6 +327,7 @@ module.exports = appInfo => {
       maxFreeSockets: 256,
     },
     useHttpClientNext: false,
+    // allowH2: false,
   };
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -296,16 +296,18 @@ declare module 'egg' {
     request?: HttpClientRequestOptions | RequestOptionsOld;
     /** Whether enable dns cache */
     enableDNSCache?: boolean;
-    /** Enable proxy request, default is false. */
+    /** Enable proxy request. Default is `false`. */
     enableProxy?: boolean;
-    /** proxy agent uri or options, default is null. */
+    /** proxy agent uri or options. Default is `null`. */
     proxy?: string | { [key: string]: any };
     /** DNS cache lookup interval */
     dnsCacheLookupInterval?: number;
     /** DNS cache max age */
     dnsCacheMaxLength?: number;
-    /** use urllib@3 HttpClient */
+    /** use urllib@3 HttpClient. Default is `false`  */
     useHttpClientNext?: boolean;
+    /** Allow to use HTTP2 first, only work on `useHttpClientNext = true`. Default is `false` */
+    allowH2?: boolean;
   }
 
   export interface EggAppConfig {

--- a/lib/core/httpclient_next.js
+++ b/lib/core/httpclient_next.js
@@ -8,6 +8,7 @@ class HttpClientNext extends HttpClient {
     super({
       app,
       defaultArgs: config.request,
+      allowH2: config.allowH2,
     });
     this.app = app;
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "onelogger": "^1.0.0",
     "sendmessage": "^2.0.0",
     "urllib": "^2.33.0",
-    "urllib-next": "npm:urllib@^3.22.4",
+    "urllib-next": "npm:urllib@^3.26.0",
     "utility": "^2.1.0",
     "ylru": "^1.3.2"
   },

--- a/test/fixtures/apps/httpclient-http2/app.js
+++ b/test/fixtures/apps/httpclient-http2/app.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+
+module.exports = app => {
+  class CustomHttpClient extends app.HttpClientNext {
+    request(url, opt) {
+      return new Promise(resolve => {
+        assert(/^http/.test(url), 'url should start with http, but got ' + url);
+        resolve();
+      }).then(() => {
+        return super.request(url, opt);
+      });
+    }
+
+    curl(url, opt) {
+      return this.request(url, opt);
+    }
+  }
+  app.HttpClientNext = CustomHttpClient;
+};

--- a/test/fixtures/apps/httpclient-http2/config/config.default.js
+++ b/test/fixtures/apps/httpclient-http2/config/config.default.js
@@ -1,0 +1,4 @@
+exports.httpclient = {
+  useHttpClientNext: true,
+  allowH2: true,
+};

--- a/test/fixtures/apps/httpclient-http2/package.json
+++ b/test/fixtures/apps/httpclient-http2/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "httpclient-overwrite"
+}


### PR DESCRIPTION
base on https://github.com/node-modules/urllib/pull/516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to enable HTTP/2 support through the `allowH2` property when using the next-generation HTTP client.
  
- **Bug Fixes**
  - Enhanced clarity and accuracy of comments for HTTP client configuration properties.

- **Improvements**
  - Updated `urllib-next` dependency to version `^3.26.0` for better performance and stability.
  - Added tests to verify HTTP/2 functionality and custom HTTP client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->