### PR TITLE
feat: use urllib@4.5.0

### DIFF
--- a/.github/workflows/nodejs-3.x.yml
+++ b/.github/workflows/nodejs-3.x.yml
@@ -12,7 +12,7 @@ jobs:
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest, macos-latest, windows-latest'
-      version: '14, 16, 18, 20, 22'
+      version: '14, 16, 18, 20, 22, 23'
       install: 'npm i -g npminstall && npminstall'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/lib/core/httpclient_next.js
+++ b/lib/core/httpclient_next.js
@@ -1,3 +1,4 @@
+const debug = require('util').debuglog('egg:lib:core:httpclient_next');
 const ms = require('humanize-ms');
 
 const SSRF_HTTPCLIENT = Symbol('SSRF_HTTPCLIENT');
@@ -6,9 +7,17 @@ const mainNodejsVersion = parseInt(process.versions.node.split('.')[0]);
 let HttpClient;
 if (mainNodejsVersion >= 18) {
   // urllib@4 only works on Node.js >= 18
-  HttpClient = require('urllib4').HttpClient;
-} else {
+  try {
+    HttpClient = require('urllib4').HttpClient;
+    debug('urllib4 enable');
+  } catch (err) {
+    debug('require urllib4 error: %s', err);
+  }
+}
+if (!HttpClient) {
+  // fallback to urllib@3
   HttpClient = require('urllib-next').HttpClient;
+  debug('urllib3 enable');
 }
 
 class HttpClientNext extends HttpClient {
@@ -26,6 +35,7 @@ class HttpClientNext extends HttpClient {
       // use on egg-security ssrf
       // https://github.com/eggjs/egg-security/blob/master/lib/extend/safe_curl.js#L11
       checkAddress: options.checkAddress,
+      connect: options.connect,
     });
     this.app = app;
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "sendmessage": "^2.0.0",
     "urllib": "^2.33.0",
     "urllib-next": "npm:urllib@^3.27.1",
-    "urllib4": "npm:urllib@^4.3.0",
+    "urllib4": "npm:urllib@^4.5.0",
     "utility": "^2.1.0",
     "ylru": "^1.3.2"
   },
@@ -79,6 +79,7 @@
     "eslint": "^8.23.1",
     "eslint-config-egg": "^12.0.0",
     "formstream": "^1.1.1",
+    "https-pem": "^3.0.0",
     "jsdoc": "^3.6.11",
     "koa": "^2.13.4",
     "koa-static": "^5.0.0",

--- a/test/fixtures/apps/httpclient-allowH2/config/config.default.js
+++ b/test/fixtures/apps/httpclient-allowH2/config/config.default.js
@@ -3,4 +3,7 @@ exports.httpclient = {
   request: {
     timeout: 99,
   },
+  connect: {
+    rejectUnauthorized: false,
+  },
 };


### PR DESCRIPTION
auto fallback to urllib@3 when require urllib4 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded CI workflow to include Node.js version 23 for testing.
	- Enhanced `HttpClientNext` class with improved error handling and configuration management.
	- Added support for HTTP/2 functionality in the test suite, including self-signed certificate handling.

- **Bug Fixes**
	- Improved error handling for library imports based on Node.js versions.

- **Chores**
	- Updated dependency versions in `package.json`. 
	- Modified HTTP client configuration to include a new `connect` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->