### PR TITLE
chore: enable auto release on 3.x

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, 1.x ]
+    branches: [ master, 1.x, 3.x ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]

--- a/.github/workflows/release-3.x.yml
+++ b/.github/workflows/release-3.x.yml
@@ -1,0 +1,13 @@
+name: Release for 3.x
+
+on:
+  push:
+    branches: [ 3.x ]
+
+jobs:
+  release:
+    name: Node.js
+    uses: eggjs/github-actions/.github/workflows/node-release.yml@master
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GIT_TOKEN: ${{ secrets.GIT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ English | [简体中文](./README.zh-CN.md)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Feggjs%2Fegg.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Feggjs%2Fegg?ref=badge_shield)
 
 [![Continuous Integration](https://github.com/eggjs/egg/actions/workflows/nodejs-3.x.yml/badge.svg)](https://github.com/eggjs/egg/actions?query=branch%3A3.x)
-[![Test coverage](https://img.shields.io/codecov/c/github/eggjs/egg.svg?style=flat-square)](https://codecov.io/gh/eggjs/egg)
+[![codecov](https://codecov.io/gh/eggjs/egg/branch/3.x/graph/badge.svg?token=2sKMCDNkcl)](https://app.codecov.io/gh/eggjs/egg/tree/3.x)
 [![Known Vulnerabilities](https://snyk.io/test/npm/egg/badge.svg?style=flat-square)](https://snyk.io/test/npm/egg)
 [![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/eggjs?style=flat-square)](https://opencollective.com/eggjs)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 [![NPM download](https://img.shields.io/npm/dm/egg.svg?style=flat-square)](https://npmjs.org/package/egg)
 
 [![Continuous Integration](https://github.com/eggjs/egg/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/egg/actions?query=branch%3Amaster)
-[![Test coverage](https://img.shields.io/codecov/c/github/eggjs/egg.svg?style=flat-square)](https://codecov.io/gh/eggjs/egg)
+[![codecov](https://codecov.io/gh/eggjs/egg/branch/3.x/graph/badge.svg?token=2sKMCDNkcl)](https://app.codecov.io/gh/eggjs/egg/tree/3.x)
 [![Known Vulnerabilities](https://snyk.io/test/npm/egg/badge.svg?style=flat-square)](https://snyk.io/test/npm/egg)
 [![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/eggjs?style=flat-square)](https://opencollective.com/eggjs)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "egg",
   "version": "3.29.0",
   "publishConfig": {
-    "tag": "release-3.x",
+    "tag": "latest",
     "access": "public"
   },
   "description": "A web framework's framework for Node.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new GitHub Actions workflow for releases on the `3.x` branch.
  
- **Improvements**
	- Updated test coverage badges in both English and Chinese README files to reflect the `3.x` branch.

- **Chores**
	- Adjusted the tagging strategy in the package configuration to mark future releases as "latest" instead of "release-3.x".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->