### PR TITLE
fix: redefine urllib export types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ site/dist
 .umi-production
 .vercel
 package-lock.json
+.tshy*

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,9 +19,9 @@ import {
   HttpClientResponse as HttpClientResponseOld,
 } from 'urllib';
 import {
-  RequestURL as HttpClientRequestURL,
-  RequestOptions as HttpClientRequestOptions,
-  HttpClientResponse,
+  RequestURL,
+  RequestOptions,
+  HttpClientResponse as HttpClientResponseNext,
 } from 'urllib-next';
 import {
   EggCoreBase,
@@ -60,7 +60,9 @@ declare module 'egg' {
   //   return await app.httpclient.request(url, options);
   // }
   // ```
-  export { HttpClientRequestURL, HttpClientRequestOptions, HttpClientResponse };
+  export type HttpClientRequestURL = RequestURL;
+  export type HttpClientRequestOptions = RequestOptions;
+  export type HttpClientResponse<T = any> = HttpClientResponseNext<T>;
   // Compatible with both urllib@2 and urllib@3 RequestOptions to request
   export interface EggHttpClient extends EventEmitter {
     request<T = any>(url: HttpClientRequestURL): Promise<HttpClientResponseOld<T> | HttpClientResponse<T>>;

--- a/test/fixtures/apps/app-ts/app/controller/foo.ts
+++ b/test/fixtures/apps/app-ts/app/controller/foo.ts
@@ -6,8 +6,9 @@ import {
   EggLogger,
   EggHttpClient,
   EggContextHttpClient,
+  HttpClientRequestURL,
+  HttpClientRequestOptions as RequestOptionsNext,
 } from 'egg';
-import { RequestOptions as RequestOptionsNext } from 'urllib-next';
 import { RequestOptions2, RequestOptions } from 'urllib';
 
 // add user controller and service
@@ -59,8 +60,8 @@ export default class FooController extends Controller {
     }
   }
 
-  async requestWithHttpclientNext(request: RequestOptionsNext) {
-    let result = await this.app.curl('url', request);
+  async requestWithHttpclientNext(request: RequestOptionsNext, url?: HttpClientRequestURL) {
+    let result = await this.app.curl(url ?? 'url', request);
     result = await this.ctx.curl('url', request);
     result = await this.app.httpclient.curl('url', request);
     result = await this.app.httpclient.request('url', request);


### PR DESCRIPTION
```bash
node_modules/.store/egg@3.30.0/node_modules/egg/index.d.ts:63:3 - error TS2666: Exports and export assignments are not permitted in module augmentations.

63   export { HttpClientRequestURL, HttpClientRequestOptions, HttpClientResponse };
     ~~~~~~


Found 1 error in node_modules/.store/egg@3.30.0/node_modules/egg/index.d.ts:63
```