### PR TITLE
chore: lock @types/minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@eggjs/supertest": "^8.2.0",
     "@eggjs/tsconfig": "1",
     "@types/koa-bodyparser": "^4.3.12",
+    "@types/minimatch": "^5.1.2",
     "@types/mocha": "^10.0.10",
     "@types/node": "22",
     "address": "2",


### PR DESCRIPTION
error TS2688: Cannot find type definition file for 'minimatch'.

@types/minimatch@6 has been deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new development dependency to improve type support during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->