### PR TITLE
feat: merge extend2 repository into monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ This is the **Eggjs** framework - a progressive Node.js framework for building e
 - **`packages/supertest/`** - HTTP testing utilities (merged from @eggjs/supertest)
   - `src/` - Supertest TypeScript source code
   - `test/` - Supertest test suite
+- **`packages/extend2/`** - Object extension utility (merged from extend2)
+  - `src/` - Extend2 TypeScript source code
+  - `test/` - Extend2 test suite
 - **`examples/`** - Example applications
   - `helloworld-commonjs/` - CommonJS example
   - `helloworld-typescript/` - TypeScript example
@@ -84,6 +87,7 @@ The framework follows a specific loading order:
 
 - `pnpm test` - Run tests in all packages
 - `pnpm --filter=egg run test` - Test main egg package
+- `pnpm --filter=@eggjs/extend2 test` - Test extend2 package with vitest
 
 ### Build & Lint
 
@@ -167,16 +171,26 @@ The framework extends Koa's context with Egg-specific features:
 
 1. Create new directory under `packages/`
 2. Add package.json with workspace dependencies using `workspace:*`
-3. Update root pnpm-workspace.yaml if needed
-4. Use `pnpm --filter=<package>` for package-specific commands
+3. Create tsconfig.json that extends from root: `"extends": "../../tsconfig.json"`
+4. Add package reference to root tsconfig.json `references` array
+5. Update root pnpm-workspace.yaml if needed
+6. Use `pnpm --filter=<package>` for package-specific commands
 
 ### Testing Strategy
 
+- **IMPORTANT: All new packages MUST use Vitest for testing** - this is the standard test runner for the monorepo
 - Use `pnpm --filter=egg run test` for framework tests
 - Test fixtures are in `packages/egg/test/fixtures/apps/`
 - Create apps in fixtures to test specific scenarios
 - Use `pnpm test` to run tests across all packages
 - Follow existing test patterns for consistency
+
+#### Vitest Configuration
+
+- Each package should include a `vitest.config.ts` file for test configuration
+- Import test functions from vitest: `import { describe, it } from 'vitest'`
+- Use standard assertions with Node.js built-in `assert` module
+- Test files should follow the pattern `test/**/*.test.ts`
 
 ### TypeScript Support
 
@@ -186,6 +200,14 @@ The framework extends Koa's context with Egg-specific features:
 - Type definitions are exported for framework users
 - Examples support both .js and .ts application files
 - Cross-package TypeScript references configured for proper module resolution
+
+#### TypeScript Configuration Requirements
+
+- **IMPORTANT: All sub-project tsconfig.json files MUST extend from the root project tsconfig.json**
+- Use `"extends": "../../tsconfig.json"` in package tsconfig.json files
+- Include `"baseUrl": "./"` in compilerOptions for proper path resolution
+- Root tsconfig.json must include all packages in the `references` array
+- This ensures consistent TypeScript configuration across the entire monorepo
 
 ### Documentation
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "@eggjs/utils": "workspace:*",
     "egg-logger": "catalog:",
     "egg-path-matching": "catalog:",
-    "extend2": "catalog:",
+    "@eggjs/extend2": "workspace:*",
     "get-ready": "catalog:",
     "globby": "catalog:",
     "is-type-of": "catalog:",

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -13,7 +13,7 @@ import {
 } from 'is-type-of';
 import type { Logger } from 'egg-logger';
 import { getParamNames, readJSONSync, readJSON, exists } from 'utility';
-import { extend } from 'extend2';
+import { extend } from '@eggjs/extend2';
 import {
   Request,
   Response,

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -134,7 +134,7 @@
     "cluster-client": "catalog:",
     "egg-errors": "catalog:",
     "egg-logger": "catalog:",
-    "extend2": "catalog:",
+    "@eggjs/extend2": "workspace:*",
     "graceful": "catalog:",
     "humanize-ms": "catalog:",
     "is-type-of": "catalog:",

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -23,7 +23,7 @@ import { utils as eggUtils } from '@eggjs/core';
 import createClusterClient, {
   close as closeClusterClient,
 } from 'cluster-client';
-import { extend } from 'extend2';
+import { extend } from '@eggjs/extend2';
 import {
   EggContextLogger as ContextLogger,
   EggLoggers,

--- a/packages/extend2/.gitignore
+++ b/packages/extend2/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.tshy*
+coverage
+dist

--- a/packages/extend2/CHANGELOG.md
+++ b/packages/extend2/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [4.0.0](https://github.com/eggjs/extend2/compare/v3.0.0...v4.0.0) (2024-06-15)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 18.7.0 support
+
+https://github.com/eggjs/egg/issues/5257
+
+### Features
+
+* override array as primitive when deep merge ([#1](https://github.com/eggjs/extend2/issues/1)) ([00c66c0](https://github.com/eggjs/extend2/commit/00c66c07b331063a8edde66b046a5fde12a47cdc))
+* support cjs and esm both ([#4](https://github.com/eggjs/extend2/issues/4)) ([378e295](https://github.com/eggjs/extend2/commit/378e295b49ff60010740aa6c01046117144a7c79))
+
+
+### Bug Fixes
+
+* __proto__ copy ([#2](https://github.com/eggjs/extend2/issues/2)) ([aa332a5](https://github.com/eggjs/extend2/commit/aa332a59116c8398976434b57ea477c6823054f8))
+
+1.0.1 / 2021-12-31
+==================
+
+**fixes**
+  * [[`aa332a5`](http://github.com/eggjs/extend2/commit/aa332a59116c8398976434b57ea477c6823054f8)] - fix: __proto__ copy (#2) (Haoliang Gao <<sakura9515@gmail.com>>)
+
+1.0.0 / 2017-03-06
+==================
+  * Initial commit

--- a/packages/extend2/LICENSE
+++ b/packages/extend2/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-present eggjs and other contributors.
+Copyright (c) 2014 Stefan Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/extend2/README.md
+++ b/packages/extend2/README.md
@@ -1,0 +1,55 @@
+# extend2
+
+Forked from [node-extend], the difference is overriding array as primitive when deep clone.
+
+[![NPM version][npm-image]][npm-url]
+[![Node.js CI](https://github.com/eggjs/extend2/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/extend2/actions/workflows/nodejs.yml)
+[![Test coverage][codecov-image]][codecov-url]
+[![Known Vulnerabilities][snyk-image]][snyk-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/extend2.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/extend2
+[codecov-image]: https://codecov.io/gh/eggjs/extend2/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/eggjs/extend2
+[snyk-image]: https://snyk.io/test/npm/extend2/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/extend2
+[download-image]: https://img.shields.io/npm/dm/extend2.svg?style=flat-square
+[download-url]: https://npmjs.org/package/extend2
+
+## Usage
+
+```ts
+import { extend } from 'extend2';
+
+// for deep clone
+extend(true, {}, object1, objectN);
+```
+
+## License
+
+`extend2` is licensed under the [MIT License](LICENSE).
+
+## Acknowledgements
+
+All credit to the jQuery authors for perfecting this amazing utility.
+
+Ported to Node.js by [Stefan Thomas][github-justmoon] with contributions by [Jonathan Buchanan][github-insin] and [Jordan Harband][github-ljharb].
+
+<!-- GITCONTRIBUTOR_START -->
+
+## Contributors
+
+|    [<img src="https://avatars.githubusercontent.com/u/45469?v=4" width="100px;"/><br/><sub><b>ljharb</b></sub>](https://github.com/ljharb)<br/>     | [<img src="https://avatars.githubusercontent.com/u/53233?v=4" width="100px;"/><br/><sub><b>justmoon</b></sub>](https://github.com/justmoon)<br/> | [<img src="https://avatars.githubusercontent.com/u/1557266?v=4" width="100px;"/><br/><sub><b>jonmorehouse</b></sub>](https://github.com/jonmorehouse)<br/> | [<img src="https://avatars.githubusercontent.com/u/360661?v=4" width="100px;"/><br/><sub><b>popomore</b></sub>](https://github.com/popomore)<br/> | [<img src="https://avatars.githubusercontent.com/u/2396468?v=4" width="100px;"/><br/><sub><b>greelgorke</b></sub>](https://github.com/greelgorke)<br/> | [<img src="https://avatars.githubusercontent.com/u/273857?v=4" width="100px;"/><br/><sub><b>andyburke</b></sub>](https://github.com/andyburke)<br/> |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------: |
+| [<img src="https://avatars.githubusercontent.com/u/788368?v=4" width="100px;"/><br/><sub><b>blaise-io</b></sub>](https://github.com/blaise-io)<br/> | [<img src="https://avatars.githubusercontent.com/u/680696?v=4" width="100px;"/><br/><sub><b>danbell</b></sub>](https://github.com/danbell)<br/>  |   [<img src="https://avatars.githubusercontent.com/u/2598089?v=4" width="100px;"/><br/><sub><b>jamielinux</b></sub>](https://github.com/jamielinux)<br/>   |    [<img src="https://avatars.githubusercontent.com/u/226692?v=4" width="100px;"/><br/><sub><b>insin</b></sub>](https://github.com/insin)<br/>    |   [<img src="https://avatars.githubusercontent.com/u/152407?v=4" width="100px;"/><br/><sub><b>madarche</b></sub>](https://github.com/madarche)<br/>    |  [<img src="https://avatars.githubusercontent.com/u/1088720?v=4" width="100px;"/><br/><sub><b>Mithgol</b></sub>](https://github.com/Mithgol)<br/>   |
+|   [<img src="https://avatars.githubusercontent.com/u/156269?v=4" width="100px;"/><br/><sub><b>fengmk2</b></sub>](https://github.com/fengmk2)<br/>   |   [<img src="https://avatars.githubusercontent.com/u/5362563?v=4" width="100px;"/><br/><sub><b>2hu12</b></sub>](https://github.com/2hu12)<br/>   |
+
+This project follows the git-contributor [spec](https://github.com/xudafeng/git-contributor), auto updated at `Sat Jun 15 2024 10:08:30 GMT+0800`.
+
+<!-- GITCONTRIBUTOR_END -->
+
+[github-justmoon]: https://github.com/justmoon
+[github-insin]: https://github.com/insin
+[github-ljharb]: https://github.com/ljharb
+[node-extend]: https://github.com/justmoon/node-extend

--- a/packages/extend2/package.json
+++ b/packages/extend2/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@eggjs/extend2",
+  "author": "popomore <sakura9515@gmail.com>",
+  "version": "4.0.0",
+  "engines": {
+    "node": ">=18.7.0"
+  },
+  "publishConfig": {
+    "tag": "latest",
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "description": "Port of jQuery.extend for Node.js",
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rimraf dist",
+    "lint": "oxlint",
+    "test": "vitest run",
+    "prepublishOnly": "pnpm run build"
+  },
+  "keywords": [
+    "extend",
+    "clone",
+    "merge"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eggjs/egg.git",
+    "directory": "packages/extend2"
+  },
+  "devDependencies": {
+    "@eggjs/tsconfig": "catalog:",
+    "@types/node": "catalog:",
+    "oxlint": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "module": "./dist/index.js"
+}

--- a/packages/extend2/src/index.ts
+++ b/packages/extend2/src/index.ts
@@ -1,0 +1,87 @@
+const hasOwn = Object.prototype.hasOwnProperty;
+const toStr = Object.prototype.toString;
+
+function isPlainObject(obj: unknown) {
+  if (!obj || toStr.call(obj) !== '[object Object]') {
+    return false;
+  }
+
+  const hasOwnConstructor = hasOwn.call(obj, 'constructor');
+  const hasIsPrototypeOf =
+    obj.constructor &&
+    obj.constructor.prototype &&
+    hasOwn.call(obj.constructor.prototype, 'isPrototypeOf');
+  // Not own constructor property must be Object
+  if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
+    return false;
+  }
+
+  // Own properties are enumerated firstly, so to speed up,
+  // if last one is own, then all properties are own.
+  let key: string | undefined;
+  for (key in obj) {
+    /**/
+  }
+
+  return typeof key === 'undefined' || hasOwn.call(obj, key);
+}
+
+export function extend<T = Record<string, any>>(
+  deepOrTarget?: unknown,
+  ...objects: unknown[]
+): T {
+  // extend(deep, target, obj1, obj2, ...)
+  // extend(target, obj1, obj2, ...)
+  let target = deepOrTarget as any;
+  let i = 0;
+  const length = objects.length;
+  let deep = false;
+
+  // Handle a deep copy situation
+  if (typeof target === 'boolean') {
+    // extend(deep, target, obj1, obj2, ...)
+    deep = target;
+    target = objects[0] || {};
+    // skip the boolean and the target
+    i = 1;
+  } else if (
+    (typeof target !== 'object' && typeof target !== 'function') ||
+    target == null
+  ) {
+    // extend(null, obj1, obj2, ...)
+    target = {};
+  }
+
+  for (; i < length; ++i) {
+    const options = objects[i] as any;
+    // Only deal with non-null/undefined values
+    if (options === null || options === undefined) continue;
+
+    // Extend the base object
+    for (const name in options) {
+      if (name === '__proto__') continue;
+
+      const src = target[name];
+      const copy = options[name];
+
+      // Prevent never-ending loop
+      if (target === copy) continue;
+
+      // Recurse if we're merging plain objects
+      if (deep && copy && isPlainObject(copy)) {
+        const clone = src && isPlainObject(src) ? src : {};
+        // Never move original objects, clone them
+        target[name] = extend(deep, clone, copy);
+
+        // Don't bring in undefined values
+      } else if (typeof copy !== 'undefined') {
+        target[name] = copy;
+      }
+    }
+  }
+
+  // Return the modified object
+  return target as T;
+}
+
+export default extend;

--- a/packages/extend2/test/index.test.ts
+++ b/packages/extend2/test/index.test.ts
@@ -1,0 +1,667 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+import extend from '../src/index.js';
+
+const str = 'me a test';
+const integer = 10;
+const arr = [1, 'what', new Date(81, 8, 4)];
+const date = new Date(81, 4, 13);
+
+class Foo {}
+
+const obj = {
+  str,
+  integer,
+  arr,
+  date,
+  constructor: 'fake',
+  isPrototypeOf: 'not a function',
+  foo: new Foo(),
+};
+
+const deep = {
+  ori: obj,
+  layer: {
+    integer: 10,
+    str: 'str',
+    date: new Date(84, 5, 12),
+    arr: [101, 'dude', new Date(82, 10, 4)],
+    deep: {
+      str: obj.str,
+      integer,
+      arr: obj.arr,
+      date: new Date(81, 7, 4),
+    },
+  },
+};
+
+describe('test/index.test.ts', () => {
+  it('missing arguments', () => {
+    assert.deepEqual(
+      extend(undefined, { a: 1 }),
+      { a: 1 },
+      'missing first argument is second argument'
+    );
+    assert.deepEqual(
+      extend({ a: 1 }),
+      { a: 1 },
+      'missing second argument is first argument'
+    );
+    assert.deepEqual(
+      extend(true, undefined, { a: 1 }),
+      { a: 1 },
+      'deep: missing first argument is second argument'
+    );
+    assert.deepEqual(
+      extend(true, { a: 1 }),
+      { a: 1 },
+      'deep: missing second argument is first argument'
+    );
+    assert.deepEqual(extend(), {}, 'no arguments is object');
+  });
+
+  it('merge string with string', () => {
+    const ori = 'what u gonna say';
+    const target = extend(ori, str);
+    const expectedTarget = {
+      0: 'm',
+      1: 'e',
+      2: ' ',
+      3: 'a',
+      4: ' ',
+      5: 't',
+      6: 'e',
+      7: 's',
+      8: 't',
+    };
+
+    assert.equal(ori, 'what u gonna say', 'original string 1 is unchanged');
+    assert.equal(str, 'me a test', 'original string 2 is unchanged');
+    assert.deepEqual(
+      target,
+      expectedTarget,
+      'string + string is merged object form of string'
+    );
+  });
+
+  it('merge string with number', () => {
+    const ori = 'what u gonna say';
+    const target = extend(ori, 10);
+
+    assert.equal(ori, 'what u gonna say', 'original string is unchanged');
+    assert.deepEqual(target, {}, 'string + number is empty object');
+  });
+
+  it('merge string with array', () => {
+    const ori = 'what u gonna say';
+    const target = extend(ori, arr);
+
+    assert.equal(ori, 'what u gonna say', 'original string is unchanged');
+    assert.deepEqual(
+      arr,
+      [1, 'what', new Date(81, 8, 4)],
+      'array is unchanged'
+    );
+    assert.deepEqual(
+      target,
+      {
+        0: 1,
+        1: 'what',
+        2: new Date(81, 8, 4),
+      },
+      'string + array is array'
+    );
+  });
+
+  it('merge string with date', () => {
+    const ori = 'what u gonna say';
+    const target = extend(ori, date);
+
+    const testDate = new Date(81, 4, 13);
+    assert.equal(ori, 'what u gonna say', 'original string is unchanged');
+    assert.deepEqual(date, testDate, 'date is unchanged');
+    assert.equal(target instanceof Date, false);
+    assert.deepEqual(target, {}, 'string + date is object');
+  });
+
+  it('merge string with obj', () => {
+    const ori = 'what u gonna say';
+    const target = extend(ori, obj);
+
+    assert.equal(ori, 'what u gonna say', 'original string is unchanged');
+    const testObj = {
+      str: 'me a test',
+      integer: 10,
+      arr: [1, 'what', new Date(81, 8, 4)],
+      date: new Date(81, 4, 13),
+      constructor: 'fake',
+      isPrototypeOf: 'not a function',
+      foo: new Foo(),
+    };
+    assert.deepEqual(obj, testObj, 'original obj is unchanged');
+    assert.deepEqual(target, testObj, 'string + obj is obj');
+  });
+
+  it('merge number with string', () => {
+    const ori = 20;
+    const target = extend(ori, str);
+
+    assert.equal(ori, 20, 'number is unchanged');
+    assert.equal(str, 'me a test', 'string is unchanged');
+    assert.deepEqual(
+      target,
+      {
+        0: 'm',
+        1: 'e',
+        2: ' ',
+        3: 'a',
+        4: ' ',
+        5: 't',
+        6: 'e',
+        7: 's',
+        8: 't',
+      },
+      'number + string is object form of string'
+    );
+  });
+
+  it('merge number with number', () => {
+    assert.deepEqual(extend(20, 10), {}, 'number + number is empty object');
+  });
+
+  it('merge number with array', () => {
+    const target = extend(20, arr);
+
+    assert.deepEqual(
+      arr,
+      [1, 'what', new Date(81, 8, 4)],
+      'array is unchanged'
+    );
+    assert.deepEqual(
+      target,
+      {
+        0: 1,
+        1: 'what',
+        2: new Date(81, 8, 4),
+      },
+      'number + arr is object with array contents'
+    );
+  });
+
+  it('merge number with date', () => {
+    const target = extend(20, date);
+    const testDate = new Date(81, 4, 13);
+
+    assert.deepEqual(date, testDate, 'original date is unchanged');
+    assert.deepEqual(target, {}, 'number + date is object');
+  });
+
+  it('merge number with object', () => {
+    const target = extend(20, obj);
+    const testObj = {
+      str: 'me a test',
+      integer: 10,
+      arr: [1, 'what', new Date(81, 8, 4)],
+      date: new Date(81, 4, 13),
+      constructor: 'fake',
+      isPrototypeOf: 'not a function',
+      foo: new Foo(),
+    };
+
+    assert.deepEqual(obj, testObj, 'obj is unchanged');
+    assert.deepEqual(target, testObj, 'number + obj is obj');
+  });
+
+  it('merge array with string', () => {
+    const ori = [1, 2, 3, 4, 5, 6];
+    const target = extend(ori, str);
+
+    assert.deepEqual(
+      ori,
+      str.split(''),
+      'array is changed to be an array of string chars'
+    );
+    assert.equal(str, 'me a test', 'string is unchanged');
+    assert.equal(target[0], 'm');
+    assert.equal(target['0'], 'm');
+    assert(Array.isArray(target));
+    assert.deepEqual(target, ['m', 'e', ' ', 'a', ' ', 't', 'e', 's', 't']);
+  });
+
+  it('merge array with number', () => {
+    const ori = [1, 2, 3, 4, 5, 6];
+    const target = extend(ori, 10);
+
+    assert.deepEqual(ori, [1, 2, 3, 4, 5, 6], 'array is unchanged');
+    assert.deepEqual(target, ori, 'array + number is array');
+  });
+
+  it('merge array with array', () => {
+    const ori = [1, 2, 3, 4, 5, 6];
+    const target = extend(ori, arr);
+    const testDate = new Date(81, 8, 4);
+    const expectedTarget = [1, 'what', testDate, 4, 5, 6];
+
+    assert.deepEqual(
+      ori,
+      expectedTarget,
+      'array + array merges arrays; changes first array'
+    );
+    assert.deepEqual(arr, [1, 'what', testDate], 'second array is unchanged');
+    assert.deepEqual(target, expectedTarget, 'array + array is merged array');
+  });
+
+  it('merge array with date', () => {
+    const ori = [1, 2, 3, 4, 5, 6];
+    const target = extend(ori, date);
+    const testDate = new Date(81, 4, 13);
+    const testArray = [1, 2, 3, 4, 5, 6];
+
+    assert.deepEqual(ori, testArray, 'array is unchanged');
+    assert.deepEqual(date, testDate, 'date is unchanged');
+    assert.deepEqual(target, testArray, 'array + date is array');
+  });
+
+  it('merge array with object', () => {
+    const ori: any = [1, 2, 3, 4, 5, 6];
+    const target = extend(ori, obj);
+    const testObject: any = {
+      str: 'me a test',
+      integer: 10,
+      arr: [1, 'what', new Date(81, 8, 4)],
+      date: new Date(81, 4, 13),
+      constructor: 'fake',
+      isPrototypeOf: 'not a function',
+      foo: new Foo(),
+    };
+
+    assert.deepEqual(obj, testObject, 'obj is unchanged');
+    assert.equal(ori.length, 6, 'array has proper length');
+    assert.equal(ori.str, obj.str, 'array has obj.str property');
+    assert.equal(ori.integer, obj.integer, 'array has obj.integer property');
+    assert.deepEqual(ori.arr, obj.arr, 'array has obj.arr property');
+    assert.equal(ori.date, obj.date, 'array has obj.date property');
+
+    assert.equal(target.length, 6, 'target has proper length');
+    assert.equal(target.str, obj.str, 'target has obj.str property');
+    assert.equal(
+      target.integer,
+      obj.integer,
+      'target has obj.integer property'
+    );
+    assert.deepEqual(target.arr, obj.arr, 'target has obj.arr property');
+    assert.equal(target.date, obj.date, 'target has obj.date property');
+  });
+
+  it('merge date with string', () => {
+    const ori = new Date(81, 9, 20);
+    const target = extend(ori, str);
+
+    assert(ori instanceof Date);
+    assert.equal(Reflect.get(ori, '0'), 'm');
+    assert.equal(str, 'me a test', 'string is unchanged');
+    assert.deepEqual(Reflect.get(target, '0'), 'm');
+    assert.equal(target, ori);
+  });
+
+  it('merge date with number', () => {
+    const ori = new Date(81, 9, 20);
+    const target = extend(ori, 10);
+
+    assert(ori instanceof Date);
+    assert.equal(target, ori);
+  });
+
+  it('merge date with array', () => {
+    const ori = new Date(81, 9, 20);
+    const target = extend(ori, arr);
+    const testDate = new Date(81, 9, 20);
+    const testArray = [1, 'what', new Date(81, 8, 4)];
+
+    assert.equal(ori.getTime(), testDate.getTime());
+    assert.equal(Reflect.get(ori, '1'), 'what');
+    assert.deepEqual(arr, testArray, 'array is unchanged');
+    assert.equal(target, ori);
+  });
+
+  it('merge date with date', () => {
+    const ori = new Date(81, 9, 20);
+    const target = extend(ori, date);
+
+    assert.equal(ori, target);
+  });
+
+  it('merge date with object', () => {
+    const ori = new Date(81, 9, 20);
+    const target = extend(ori, obj);
+    const testDate = new Date(81, 8, 4);
+    const testObject = {
+      str: 'me a test',
+      integer: 10,
+      arr: [1, 'what', testDate],
+      date: new Date(81, 4, 13),
+      constructor: 'fake',
+      isPrototypeOf: 'not a function',
+      foo: new Foo(),
+    };
+
+    assert.deepEqual(obj, testObject, 'original object is unchanged');
+    assert.deepEqual(ori, target);
+    assert.equal(target.getTime(), ori.getTime());
+    assert.equal(Reflect.get(ori, 'str'), 'me a test');
+    assert.equal(Reflect.get(target, 'constructor'), 'fake');
+  });
+
+  it('merge object with string', () => {
+    const testDate = new Date(81, 7, 26);
+    const ori = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: testDate,
+    };
+    const target = extend(ori, str);
+    const testObj = {
+      0: 'm',
+      1: 'e',
+      2: ' ',
+      3: 'a',
+      4: ' ',
+      5: 't',
+      6: 'e',
+      7: 's',
+      8: 't',
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: testDate,
+    };
+
+    assert.deepEqual(ori, testObj, 'original object updated');
+    assert.equal(str, 'me a test', 'string is unchanged');
+    assert.deepEqual(
+      target,
+      testObj,
+      'object + string is object + object form of string'
+    );
+  });
+
+  it('merge object with number', () => {
+    const ori = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+    };
+    const testObject = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+    };
+    const target = extend(ori, 10);
+    assert.deepEqual(ori, testObject, 'object is unchanged');
+    assert.deepEqual(target, testObject, 'object + number is object');
+  });
+
+  it('merge object with array', () => {
+    const ori = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+    };
+    const target = extend(ori, arr);
+    const testObject = {
+      0: 1,
+      1: 'what',
+      2: new Date(81, 8, 4),
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+    };
+
+    assert.deepEqual(ori, testObject, 'original object is merged');
+    assert.deepEqual(arr, [1, 'what', testObject[2]], 'array is unchanged');
+    assert.deepEqual(target, testObject, 'object + array is merged object');
+  });
+
+  it('merge object with date', () => {
+    const ori = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+    };
+    const target = extend(ori, date);
+    const testObject = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+    };
+
+    assert.deepEqual(ori, testObject, 'original object is unchanged');
+    assert.deepEqual(date, new Date(81, 4, 13), 'date is unchanged');
+    assert.deepEqual(target, testObject, 'object + date is object');
+  });
+
+  it('merge object with object', () => {
+    const ori = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+      foo: 'bar',
+    };
+    const target = extend(ori, obj);
+    const expectedObj = {
+      str: 'me a test',
+      integer: 10,
+      arr: [1, 'what', new Date(81, 8, 4)],
+      date: new Date(81, 4, 13),
+      constructor: 'fake',
+      isPrototypeOf: 'not a function',
+      foo: new Foo(),
+    };
+    const expectedTarget = {
+      str: 'me a test',
+      integer: 10,
+      arr: [1, 'what', new Date(81, 8, 4)],
+      date: new Date(81, 4, 13),
+      constructor: 'fake',
+      isPrototypeOf: 'not a function',
+      foo: new Foo(),
+    };
+
+    assert.deepEqual(obj, expectedObj, 'obj is unchanged');
+    assert.deepEqual(ori, expectedTarget, 'original has been merged');
+    assert.deepEqual(
+      target,
+      expectedTarget,
+      'object + object is merged object'
+    );
+  });
+
+  it('deep clone', () => {
+    const ori = {
+      str: 'no shit',
+      integer: 76,
+      arr: [1, 2, 3, 4],
+      date: new Date(81, 7, 26),
+      layer: { deep: { integer: 42 } },
+    };
+    const target = extend(true, ori, deep);
+
+    assert.deepEqual(
+      ori,
+      {
+        str: 'no shit',
+        integer: 76,
+        arr: [1, 2, 3, 4],
+        date: new Date(81, 7, 26),
+        ori: {
+          str: 'me a test',
+          integer: 10,
+          arr: [1, 'what', new Date(81, 8, 4)],
+          date: new Date(81, 4, 13),
+          constructor: 'fake',
+          isPrototypeOf: 'not a function',
+          foo: new Foo(),
+        },
+        layer: {
+          integer: 10,
+          str: 'str',
+          date: new Date(84, 5, 12),
+          arr: [101, 'dude', new Date(82, 10, 4)],
+          deep: {
+            str: 'me a test',
+            integer: 10,
+            arr: [1, 'what', new Date(81, 8, 4)],
+            date: new Date(81, 7, 4),
+          },
+        },
+      },
+      'original object is merged'
+    );
+    assert.deepEqual(
+      deep,
+      {
+        ori: {
+          str: 'me a test',
+          integer: 10,
+          arr: [1, 'what', new Date(81, 8, 4)],
+          date: new Date(81, 4, 13),
+          constructor: 'fake',
+          isPrototypeOf: 'not a function',
+          foo: new Foo(),
+        },
+        layer: {
+          integer: 10,
+          str: 'str',
+          date: new Date(84, 5, 12),
+          arr: [101, 'dude', new Date(82, 10, 4)],
+          deep: {
+            str: 'me a test',
+            integer: 10,
+            arr: [1, 'what', new Date(81, 8, 4)],
+            date: new Date(81, 7, 4),
+          },
+        },
+      },
+      'deep is unchanged'
+    );
+    assert.deepEqual(
+      target,
+      {
+        str: 'no shit',
+        integer: 76,
+        arr: [1, 2, 3, 4],
+        date: new Date(81, 7, 26),
+        ori: {
+          str: 'me a test',
+          integer: 10,
+          arr: [1, 'what', new Date(81, 8, 4)],
+          date: new Date(81, 4, 13),
+          constructor: 'fake',
+          isPrototypeOf: 'not a function',
+          foo: new Foo(),
+        },
+        layer: {
+          integer: 10,
+          str: 'str',
+          date: new Date(84, 5, 12),
+          arr: [101, 'dude', new Date(82, 10, 4)],
+          deep: {
+            str: 'me a test',
+            integer: 10,
+            arr: [1, 'what', new Date(81, 8, 4)],
+            date: new Date(81, 7, 4),
+          },
+        },
+      },
+      'deep + object + object is deeply merged object'
+    );
+
+    (target.layer as any).deep = 339;
+    assert.deepEqual(
+      deep,
+      {
+        ori: {
+          str: 'me a test',
+          integer: 10,
+          arr: [1, 'what', new Date(81, 8, 4)],
+          date: new Date(81, 4, 13),
+          constructor: 'fake',
+          isPrototypeOf: 'not a function',
+          foo: new Foo(),
+        },
+        layer: {
+          integer: 10,
+          str: 'str',
+          date: new Date(84, 5, 12),
+          arr: [101, 'dude', new Date(82, 10, 4)],
+          deep: {
+            str: 'me a test',
+            integer: 10,
+            arr: [1, 'what', new Date(81, 8, 4)],
+            date: new Date(81, 7, 4),
+          },
+        },
+      },
+      'deep is unchanged after setting target property'
+    );
+    // ----- NEVER USE EXTEND WITH THE ABOVE SITUATION ------------------------------
+  });
+
+  it('deep clone; arrays are override', () => {
+    const defaults = { arr: [1, 2, 3] };
+    const override = { arr: ['x'] };
+    const expectedTarget = { arr: ['x'] };
+
+    const target = extend(true, defaults, override);
+
+    assert.deepEqual(target, expectedTarget, 'arrays are merged');
+  });
+
+  it('deep clone === false; objects merged normally', () => {
+    const defaults = { a: 1 };
+    const override = { a: 2 };
+    const target = extend(false, defaults, override);
+    assert.deepEqual(target, override, 'deep === false handled normally');
+  });
+
+  it('pass in null; should create a valid object', () => {
+    const override = { a: 1 };
+    const target = extend(null, override);
+    assert.deepEqual(target, override, 'null object handled normally');
+  });
+
+  it('works without Array.isArray', () => {
+    const savedIsArray = Array.isArray;
+    (Array as any).isArray = false; // don't delete, to preserve enumerability
+    const target: any[] = [];
+    const source = [1, [2], { 3: true }];
+    assert.deepEqual(
+      extend(true, target, source),
+      [1, [2], { 3: true }],
+      'It works without Array.isArray'
+    );
+    Array.isArray = savedIsArray;
+  });
+
+  it('fix __proto__ copy', () => {
+    const r = extend(
+      true,
+      {},
+      JSON.parse('{"__proto__": {"polluted": "yes"}}')
+    );
+    assert.deepEqual(JSON.stringify(r), '{}', 'It should not copy __proto__');
+    assert.deepEqual(
+      ('' as any).polluted,
+      undefined,
+      'It should not affect object prototype'
+    );
+  });
+});

--- a/packages/extend2/tsconfig.json
+++ b/packages/extend2/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  }
+}

--- a/packages/extend2/tsdown.config.ts
+++ b/packages/extend2/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  unbundle: true,
+  dts: true,
+  exports: {
+    devExports: true,
+  },
+});

--- a/packages/extend2/vitest.config.ts
+++ b/packages/extend2/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  test: {
+    include: ['test/**/*.test.ts'],
+    exclude: [
+      'test/fixtures/**',
+      'test/benchmark/**',
+      '**/node_modules/**',
+      '**/dist/**',
+    ],
+  },
+});

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -103,7 +103,7 @@
     "coffee": "catalog:",
     "detect-port": "catalog:",
     "egg-logger": "catalog:",
-    "extend2": "catalog:",
+    "@eggjs/extend2": "workspace:*",
     "get-ready": "catalog:",
     "globby": "catalog:",
     "is-type-of": "catalog:",

--- a/packages/mock/src/lib/mock_httpclient.ts
+++ b/packages/mock/src/lib/mock_httpclient.ts
@@ -1,5 +1,5 @@
 import { mm } from 'mm';
-import { extend } from 'extend2';
+import { extend } from '@eggjs/extend2';
 import type { Dispatcher, Headers, BodyInit } from 'urllib';
 
 import { getMockAgent } from './mock_agent.ts';
@@ -39,8 +39,10 @@ export interface MockResponseCallbackOptions {
   maxRedirections?: number;
 }
 
-export type MockResultFunction =
-  (url: string, options: MockResponseCallbackOptions) => MockResultOptions | string;
+export type MockResultFunction = (
+  url: string,
+  options: MockResponseCallbackOptions
+) => MockResultOptions | string;
 
 function normalizeResult(result: string | MockResultOptions) {
   if (typeof result === 'string') {
@@ -84,15 +86,19 @@ export function createMockHttpClient(app: any) {
    *   - persist - any matching request will always reply with the defined response indefinitely, default is true
    *   - repeats - number, any matching request will reply with the defined response a fixed amount of times
    */
-  return function mockHttpClient(mockUrl: string | RegExp, mockMethod: string | string[] | MockResultOptions | MockResultFunction, mockResult?: MockResultOptions | MockResultFunction | string) {
+  return function mockHttpClient(
+    mockUrl: string | RegExp,
+    mockMethod: string | string[] | MockResultOptions | MockResultFunction,
+    mockResult?: MockResultOptions | MockResultFunction | string
+  ) {
     let mockMethods = mockMethod as string[];
     if (!mockResult) {
       // app.mockHttpclient(mockUrl, mockResult)
       mockResult = mockMethod as MockResultOptions;
-      mockMethods = [ '*' ];
+      mockMethods = ['*'];
     }
     if (!Array.isArray(mockMethods)) {
-      mockMethods = [ mockMethods ];
+      mockMethods = [mockMethods];
     }
     mockMethods = mockMethods.map(method => (method || 'GET').toUpperCase());
 
@@ -138,35 +144,46 @@ export function createMockHttpClient(app: any) {
     }
     const mockPool = originMethod
       ? getMockAgent(app).get(originMethod)
-      : getMockAgent(app).get(originMethod ?? origin as string);
+      : getMockAgent(app).get(originMethod ?? (origin as string));
     // persist default is true
     let persist = true;
-    if (typeof mockResult === 'object' && typeof mockResult.persist === 'boolean') {
+    if (
+      typeof mockResult === 'object' &&
+      typeof mockResult.persist === 'boolean'
+    ) {
       persist = mockResult.persist;
     }
-    mockMethods.forEach(function(method) {
-      const mockScope = mockPool.intercept({
-        path: pathMethod ?? pathname,
-        method: method === '*' ? () => true : method,
-      }).reply(options => {
-        // not support mockResult as an async function
-        const requestUrl = `${options.origin}${options.path}`;
-        let mockRequestResult;
-        if (mockConfigIndex >= 0) {
-          mockResult = mockConfigs[app[MOCK_CONFIG_INDEX]].mockResult;
-          mockRequestResult = typeof mockResult === 'function' ? mockResult(requestUrl, options) : mockResult;
-        } else {
-          mockRequestResult = typeof mockResult === 'function' ? mockResult(requestUrl, options) : mockResult;
-        }
-        const result = extend(true, {}, normalizeResult(mockRequestResult!));
-        return {
-          statusCode: result.status,
-          data: result.data,
-          responseOptions: {
-            headers: result.headers,
-          },
-        };
-      });
+    mockMethods.forEach(function (method) {
+      const mockScope = mockPool
+        .intercept({
+          path: pathMethod ?? pathname,
+          method: method === '*' ? () => true : method,
+        })
+        .reply(options => {
+          // not support mockResult as an async function
+          const requestUrl = `${options.origin}${options.path}`;
+          let mockRequestResult;
+          if (mockConfigIndex >= 0) {
+            mockResult = mockConfigs[app[MOCK_CONFIG_INDEX]].mockResult;
+            mockRequestResult =
+              typeof mockResult === 'function'
+                ? mockResult(requestUrl, options)
+                : mockResult;
+          } else {
+            mockRequestResult =
+              typeof mockResult === 'function'
+                ? mockResult(requestUrl, options)
+                : mockResult;
+          }
+          const result = extend(true, {}, normalizeResult(mockRequestResult!));
+          return {
+            statusCode: result.status,
+            data: result.data,
+            responseOptions: {
+              headers: result.headers,
+            },
+          };
+        });
       if (typeof mockResult === 'object') {
         if (mockResult.delay && mockResult.delay > 0) {
           mockScope.delay(mockResult.delay);
@@ -174,7 +191,11 @@ export function createMockHttpClient(app: any) {
       }
       if (persist) {
         mockScope.persist();
-      } else if (typeof mockResult === 'object' && mockResult.repeats && mockResult.repeats > 0) {
+      } else if (
+        typeof mockResult === 'object' &&
+        mockResult.repeats &&
+        mockResult.repeats > 0
+      ) {
         mockScope.times(mockResult.repeats);
       }
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,9 +228,6 @@ catalogs:
     express:
       specifier: ^4.18.2
       version: 4.21.2
-    extend2:
-      specifier: ^4.0.0
-      version: 4.0.0
     formstream:
       specifier: ^1.5.1
       version: 1.5.2
@@ -512,6 +509,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@eggjs/extend2':
+        specifier: workspace:*
+        version: link:../extend2
       '@eggjs/koa':
         specifier: workspace:*
         version: link:../koa
@@ -527,9 +527,6 @@ importers:
       egg-path-matching:
         specifier: 'catalog:'
         version: 2.1.0
-      extend2:
-        specifier: 'catalog:'
-        version: 4.0.0
       get-ready:
         specifier: 'catalog:'
         version: 3.4.0
@@ -618,6 +615,9 @@ importers:
       '@eggjs/development':
         specifier: 'catalog:'
         version: 4.0.0
+      '@eggjs/extend2':
+        specifier: workspace:*
+        version: link:../extend2
       '@eggjs/i18n':
         specifier: 'catalog:'
         version: 3.0.1
@@ -666,9 +666,6 @@ importers:
       egg-logger:
         specifier: 'catalog:'
         version: 3.6.1
-      extend2:
-        specifier: 'catalog:'
-        version: 4.0.0
       graceful:
         specifier: 'catalog:'
         version: 2.0.0
@@ -763,6 +760,27 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+
+  packages/extend2:
+    devDependencies:
+      '@eggjs/tsconfig':
+        specifier: 'catalog:'
+        version: 2.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.3.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.14.0(oxlint-tsgolint@0.2.0)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.14.2(typescript@5.9.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.11(@types/debug@4.1.12)(@types/node@24.3.0)(@vitest/ui@4.0.0-beta.11)(jiti@2.5.1)(less@4.4.1)(lightningcss@1.22.1)(sass@1.91.0)(terser@5.43.1)(yaml@2.8.1)
 
   packages/koa:
     dependencies:
@@ -890,6 +908,9 @@ importers:
       '@eggjs/core':
         specifier: workspace:*
         version: link:../core
+      '@eggjs/extend2':
+        specifier: workspace:*
+        version: link:../extend2
       '@eggjs/supertest':
         specifier: 'workspace:'
         version: link:../supertest
@@ -905,9 +926,6 @@ importers:
       egg-logger:
         specifier: 'catalog:'
         version: 3.6.1
-      extend2:
-        specifier: 'catalog:'
-        version: 4.0.0
       get-ready:
         specifier: 'catalog:'
         version: 3.4.0
@@ -18939,7 +18957,7 @@ snapshots:
       rolldown-plugin-dts: 0.15.10(rolldown@1.0.0-beta.37)(typescript@5.9.2)
       semver: 7.7.2
       tinyexec: 1.0.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tree-kill: 1.2.2
       unconfig: 7.3.3
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,6 @@ catalog:
   egg-plugin-puml: ^2.4.0
   egg-tracer: ^2.1.0
   egg-view-nunjucks: ^2.3.0
-  extend2: ^4.0.0
   formstream: ^1.5.1
   gals: '1'
   get-ready: ^3.1.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,9 @@
     },
     {
       "path": "./packages/supertest"
+    },
+    {
+      "path": "./packages/extend2"
     }
   ]
 }


### PR DESCRIPTION
- Add @eggjs/extend2 package at packages/extend2/
- Update package.json for monorepo structure with catalog dependencies
- Configure tsdown build system and vitest testing
- Add TypeScript configuration extending from root tsconfig.json
- Update pnpm-workspace.yaml with workspace reference
- Update CLAUDE.md with extend2 package documentation and TypeScript rules
- All tests passing (32 tests) with vitest integration

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new utility package providing robust object merging with shallow/deep modes, safe prototype handling, and predictable array behavior.
- Documentation
  - Expanded guidelines for creating/testing packages, TypeScript configuration requirements, and package documentation (README, CHANGELOG, LICENSE).
- Tests
  - Introduced per-package Vitest setup with comprehensive test coverage for the new utility.
- Chores
  - Migrated dependencies to a local workspace package, updated workspace configuration, and added TypeScript project references and build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->