### PR TITLE
chore(deps): replace supertest with @eggjs/supertest

### DIFF
--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -80,11 +80,10 @@
     "@types/on-finished": "catalog:",
     "@types/parseurl": "catalog:",
     "@types/statuses": "catalog:",
-    "@types/supertest": "catalog:",
+    "@eggjs/supertest": "workspace:*",
     "@types/type-is": "catalog:",
     "@types/vary": "catalog:",
     "mm": "catalog:",
-    "supertest": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/koa/test/application/context.test.ts
+++ b/packages/koa/test/application/context.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import { Application, Context } from '../../src/index.ts';
 

--- a/packages/koa/test/application/currentContext.test.ts
+++ b/packages/koa/test/application/currentContext.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 import Koa from '../../src/index.ts';
 
 describe('app.currentContext', () => {

--- a/packages/koa/test/application/index.test.ts
+++ b/packages/koa/test/application/index.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'vitest';
 import type { ServerResponse, IncomingMessage } from 'node:http';
 import { once } from 'node:events';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 import createHttpError, { HttpError } from 'http-errors';
 
 import Koa from '../../src/index.ts';

--- a/packages/koa/test/application/request.test.ts
+++ b/packages/koa/test/application/request.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa from '../../src/index.ts';
 

--- a/packages/koa/test/application/respond.test.ts
+++ b/packages/koa/test/application/respond.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'vitest';
 import fs from 'node:fs';
 import { scheduler } from 'node:timers/promises';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 import statuses from 'statuses';
 
 import Koa from '../../src/index.ts';

--- a/packages/koa/test/application/response.test.ts
+++ b/packages/koa/test/application/response.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa from '../../src/index.ts';
 

--- a/packages/koa/test/application/use.test.ts
+++ b/packages/koa/test/application/use.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa, { type MiddlewareFunc } from '../../src/index.ts';
 

--- a/packages/koa/test/context/cookies.test.ts
+++ b/packages/koa/test/context/cookies.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa, { type Context } from '../../src/index.ts';
 

--- a/packages/koa/test/context/onerror.test.ts
+++ b/packages/koa/test/context/onerror.test.ts
@@ -5,7 +5,7 @@ import { once } from 'node:events';
 
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa, { type Context } from '../../src/index.ts';
 import context from '../test-helpers/context.ts';

--- a/packages/koa/test/context/state.test.ts
+++ b/packages/koa/test/context/state.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa from '../../src/index.ts';
 

--- a/packages/koa/test/response/attachment.test.ts
+++ b/packages/koa/test/response/attachment.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import context from '../test-helpers/context.ts';
 import Koa from '../../src/index.ts';

--- a/packages/koa/test/response/flushHeaders.test.ts
+++ b/packages/koa/test/response/flushHeaders.test.ts
@@ -5,7 +5,7 @@ import { describe, it } from 'vitest';
 import { once } from 'node:events';
 import { PassThrough } from 'node:stream';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import Koa, { type Context } from '../../src/index.ts';
 

--- a/packages/koa/test/response/header.test.ts
+++ b/packages/koa/test/response/header.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import { response } from '../test-helpers/context.ts';
 import Koa from '../../src/index.ts';

--- a/packages/koa/test/response/redirect.test.ts
+++ b/packages/koa/test/response/redirect.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 import context from '../test-helpers/context.ts';
 import Koa from '../../src/index.ts';

--- a/packages/koa/test/response/status.test.ts
+++ b/packages/koa/test/response/status.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it, beforeEach } from 'vitest';
 
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 import statuses from 'statuses';
 
 import { response } from '../test-helpers/context.ts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ catalogs:
     '@types/superagent':
       specifier: ^8.1.9
       version: 8.1.9
-    '@types/supertest':
-      specifier: ^6.0.2
-      version: 6.0.3
     '@types/type-is':
       specifier: ^1.6.6
       version: 1.6.7
@@ -381,9 +378,6 @@ catalogs:
     superagent:
       specifier: ^9.0.1
       version: 9.0.2
-    supertest:
-      specifier: ^3.1.0
-      version: 3.4.2
     terminal-link:
       specifier: ^2.1.1
       version: 2.1.1
@@ -905,6 +899,9 @@ importers:
         specifier: 'catalog:'
         version: 1.1.2
     devDependencies:
+      '@eggjs/supertest':
+        specifier: workspace:*
+        version: link:../supertest
       '@types/accepts':
         specifier: 'catalog:'
         version: 1.3.7
@@ -944,9 +941,6 @@ importers:
       '@types/statuses':
         specifier: 'catalog:'
         version: 2.0.6
-      '@types/supertest':
-        specifier: 'catalog:'
-        version: 6.0.3
       '@types/type-is':
         specifier: 'catalog:'
         version: 1.6.7
@@ -956,9 +950,6 @@ importers:
       mm:
         specifier: 'catalog:'
         version: 4.0.2
-      supertest:
-        specifier: 'catalog:'
-        version: 3.4.2
       tsdown:
         specifier: 'catalog:'
         version: 0.15.1(oxc-resolver@11.7.2)(typescript@5.9.2)
@@ -1148,6 +1139,9 @@ importers:
 
   tools/egg-bin:
     dependencies:
+      '@eggjs/supertest':
+        specifier: workspace:*
+        version: link:../../packages/supertest
       '@eggjs/utils':
         specifier: workspace:*
         version: link:../../packages/utils
@@ -1157,9 +1151,6 @@ importers:
       '@types/mocha':
         specifier: 'catalog:'
         version: 10.0.10
-      '@types/supertest':
-        specifier: 'catalog:'
-        version: 6.0.3
       c8:
         specifier: 'catalog:'
         version: 10.1.3
@@ -1242,9 +1233,6 @@ importers:
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
-      supertest:
-        specifier: 'catalog:'
-        version: 3.4.2
       tsdown:
         specifier: 'catalog:'
         version: 0.15.1(oxc-resolver@11.7.2)(typescript@5.9.2)
@@ -3608,9 +3596,6 @@ packages:
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
-
-  '@types/supertest@6.0.3':
-    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/type-is@1.6.7':
     resolution: {integrity: sha512-gEsh7n8824nusZ2Sidh6POxNsIdTSvIAl5gXbeFj+TUaD1CO2r4i7MQYNMfEQkChU42s2bVWAda6x6BzIhtFbQ==}
@@ -6021,10 +6006,6 @@ packages:
   form-data-encoder@1.9.0:
     resolution: {integrity: sha512-rahaRMkN8P8d/tgK/BLPX+WBVM27NbvdXBxqQujBtkDAIFspaRqN7Od7lfdGQA6KAD+f82fYCLBq1ipvcu8qLw==}
 
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
-    engines: {node: '>= 0.12'}
-
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
@@ -6040,10 +6021,6 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
-
-  formidable@1.2.6:
-    resolution: {integrity: sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==}
-    deprecated: 'Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau'
 
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
@@ -10015,20 +9992,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  superagent@3.8.3:
-    resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
-    engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
-
   superagent@9.0.2:
     resolution: {integrity: sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==}
     engines: {node: '>=14.18.0'}
     deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
-
-  supertest@3.4.2:
-    resolution: {integrity: sha512-WZWbwceHUo2P36RoEIdXvmqfs47idNNZjCuJOqDz6rvtkk8ym56aU5oglORCpPeXGxT7l9rkJ41+O1lffQXYSA==}
-    engines: {node: '>=6.0.0'}
-    deprecated: Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -13378,11 +13345,6 @@ snapshots:
       '@types/node': 24.3.3
       form-data: 4.0.4
 
-  '@types/supertest@6.0.3':
-    dependencies:
-      '@types/methods': 1.1.4
-      '@types/superagent': 8.1.9
-
   '@types/type-is@1.6.7':
     dependencies:
       '@types/node': 24.3.3
@@ -16677,15 +16639,6 @@ snapshots:
 
   form-data-encoder@1.9.0: {}
 
-  form-data@2.5.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-      safe-buffer: 5.2.1
-
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -16704,8 +16657,6 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
-
-  formidable@1.2.6: {}
 
   formidable@3.5.4:
     dependencies:
@@ -21459,21 +21410,6 @@ snapshots:
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
 
-  superagent@3.8.3:
-    dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 3.2.7
-      extend: 3.0.2
-      form-data: 2.5.5
-      formidable: 1.2.6
-      methods: 1.1.2
-      mime: 1.6.0
-      qs: 6.14.0
-      readable-stream: 2.3.8
-    transitivePeerDependencies:
-      - supports-color
-
   superagent@9.0.2:
     dependencies:
       component-emitter: 1.3.1
@@ -21485,13 +21421,6 @@ snapshots:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.14.0
-    transitivePeerDependencies:
-      - supports-color
-
-  supertest@3.4.2:
-    dependencies:
-      methods: 1.1.2
-      superagent: 3.8.3
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,6 @@ catalog:
   '@types/parseurl': ^1.3.3
   '@types/statuses': ^2.0.5
   '@types/superagent': ^8.1.9
-  '@types/supertest': ^6.0.2
   '@types/type-is': ^1.6.6
   '@types/vary': ^1.1.3
   '@vitest/coverage-v8': beta
@@ -131,7 +130,6 @@ catalog:
   spy: ^1.0.0
   statuses: ^2.0.1
   superagent: ^9.0.1
-  supertest: ^3.1.0
   terminal-link: ^2.1.1
   ts-node: ^10.9.2
   tsconfig-paths: ^4.2.0

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -25,7 +25,7 @@
     "@eggjs/utils": "workspace:*",
     "@oclif/core": "catalog:",
     "@types/mocha": "catalog:",
-    "@types/supertest": "catalog:",
+    "@eggjs/supertest": "workspace:*",
     "c8": "catalog:",
     "ci-parallel-vars": "catalog:",
     "detect-port": "catalog:",
@@ -63,7 +63,6 @@
     "esbuild-register": "catalog:",
     "npminstall": "catalog:",
     "rimraf": "catalog:",
-    "supertest": "catalog:",
     "typescript": "catalog:",
     "tsdown": "catalog:"
   },

--- a/tools/egg-bin/test/fixtures/example-ts-cluster/test/index.test.ts
+++ b/tools/egg-bin/test/fixtures/example-ts-cluster/test/index.test.ts
@@ -1,6 +1,6 @@
 import { scheduler } from 'node:timers/promises';
 import mm, { MockOption } from '@eggjs/mock';
-import request from 'supertest';
+import { request } from '@eggjs/supertest';
 
 describe('example-ts-cluster/test/index.test.ts', () => {
   let app: any;


### PR DESCRIPTION
Replace the external supertest dependency with the internal @eggjs/supertest package across the monorepo. This change uses the workspace's own supertest implementation instead of the external package.

- Remove supertest and @types/supertest from pnpm catalog
- Update package.json files in koa and egg-bin packages
- Update all import statements from 'supertest' to '@eggjs/supertest'

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Migrated HTTP testing client to the internal @eggjs/supertest across the workspace.
  - Removed external supertest and its type definitions from workspace configuration and package dependencies.

- Tests
  - Updated test suites to import the request helper from @eggjs/supertest.
  - No changes to test behavior, assertions, or execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->