### PR TITLE
chore: remove circular dependencies

### DIFF
--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -67,7 +67,6 @@
     "@types/node": "catalog:",
     "address": "catalog:",
     "coffee": "catalog:",
-    "egg": "workspace:*",
     "egg-errors": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/packages/cluster/test/options.test.ts
+++ b/packages/cluster/test/options.test.ts
@@ -170,8 +170,8 @@ describe('test/options.test.ts', () => {
 
   describe('framework', () => {
     it('should get from absolute path', async () => {
-      let clusterPackagePath = path.join(__dirname, '..');
-      const frameworkPath = path.dirname(importResolve('egg', { paths: [clusterPackagePath] }));
+      let eggMockPackagePath = path.join(__dirname, '../../../plugins/mock');
+      const frameworkPath = path.dirname(importResolve('egg', { paths: [eggMockPackagePath] }));
       const options = await parseOptions({
         framework: frameworkPath,
       });

--- a/plugins/mock/package.json
+++ b/plugins/mock/package.json
@@ -99,7 +99,6 @@
     "node": ">= 20.19.0"
   },
   "dependencies": {
-    "@eggjs/core": "workspace:*",
     "@eggjs/extend2": "workspace:*",
     "@eggjs/supertest": "workspace:*",
     "@eggjs/utils": "workspace:*",

--- a/plugins/mock/src/lib/context.ts
+++ b/plugins/mock/src/lib/context.ts
@@ -1,8 +1,6 @@
-import { utils } from '@eggjs/core';
-
 export const context = {
   runInBackground(scope: any) {
-    const taskName = scope._name || scope.name || utils.getCalleeFromStack(true);
+    const taskName = scope._name || scope.name;
     if (taskName) {
       scope._name = taskName;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,9 +596,6 @@ importers:
       coffee:
         specifier: 'catalog:'
         version: 5.5.1
-      egg:
-        specifier: workspace:*
-        version: link:../egg
       egg-errors:
         specifier: 'catalog:'
         version: 2.3.2
@@ -1123,9 +1120,6 @@ importers:
 
   plugins/mock:
     dependencies:
-      '@eggjs/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       '@eggjs/extend2':
         specifier: workspace:*
         version: link:../../packages/extend2

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
-import { execSync } from 'child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
 import semver from 'semver';
-import { fileURLToPath } from 'url';
 import yaml from 'js-yaml';
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified task name resolution in mock plugin to rely only on explicit scope properties, removing stack-based fallback.

- Tests
  - Updated framework path resolution in cluster tests to use the mock plugin path.

- Chores
  - Removed an internal devDependency from the cluster package.
  - Dropped a direct dependency on @eggjs/core from the mock plugin.
  - Updated build script imports to use node: protocol for core modules (no functional changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->