### PR TITLE
feat(cookies): migrate cookies package into monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,9 @@ This is the **Eggjs** framework - a progressive Node.js framework for building e
 - **`packages/cluster/`** - Cluster management (merged from @eggjs/cluster)
   - `src/` - Cluster TypeScript source code
   - `test/` - Cluster test suite
+- **`packages/cookies/`** - Cookie handling utilities (merged from @eggjs/cookies)
+  - `src/` - Cookies TypeScript source code
+  - `test/` - Cookies test suite with Mocha
 - **`packages/koa/`** - Koa web framework (merged from @eggjs/koa)
   - `src/` - Koa TypeScript source code
   - `test/` - Koa test suite
@@ -105,7 +108,9 @@ The framework follows a specific loading order:
 
 - `pnpm -r run build` - Build all packages
 - `pnpm -r run clean` - Clean dist directories in all packages
-- `pnpm lint` - Run ESLint in all packages
+- `pnpm -r run typecheck` - Run TypeScript type checking with `tsc --noEmit`
+- `pnpm lint` - Run oxlint with type-aware checking in all packages
+- `pnpm lint:fix` - Auto-fix linting issues with oxlint
 
 ### Examples
 
@@ -256,6 +261,10 @@ Plugins should configure their package.json following this pattern:
   "scripts": {
     "build": "tsdown",
     "clean": "rimraf dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint --type-aware",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "npm run lint:fix && vitest",
     "prepublishOnly": "npm run build"
   }
 }
@@ -281,12 +290,23 @@ Tool packages (like egg-bin) should be placed in the `tools/` directory:
 ### Testing Strategy
 
 - **IMPORTANT: All new packages MUST use Vitest for testing** - this is the standard test runner for the monorepo
-- **Exception: egg-bin uses Mocha** - the CLI tool package uses Mocha for consistency with CLI testing patterns
+- **Exception: egg-bin and cookies use Mocha** - these packages use Mocha for consistency with their testing patterns
 - Use `pnpm --filter=egg run test` for framework tests
 - Test fixtures are in `packages/egg/test/fixtures/apps/`
 - Create apps in fixtures to test specific scenarios
 - Use `pnpm test` to run tests across all packages
 - Follow existing test patterns for consistency
+
+#### Linting and Type Checking Strategy
+
+- **All packages must include TypeScript type checking** - Use `tsc --noEmit` in `typecheck` script
+- **All packages use oxlint for linting** - No ESLint configurations should be present
+- Use `oxlint --type-aware` for enhanced TypeScript checking
+- oxlint automatically respects `.gitignore` patterns for file exclusion
+- Package-specific scripts:
+  - `"typecheck": "tsc --noEmit"` - Pure TypeScript type checking
+  - `"lint": "oxlint --type-aware"` - Linting with type awareness
+- Remove any `.eslintrc` or `.eslintrc.js` files when migrating packages
 
 #### Vitest Configuration
 
@@ -345,11 +365,17 @@ Tool packages (like egg-bin) should be placed in the `tools/` directory:
 
 ### Linting and Formatting
 
-- **ESLint** - Used for code linting across all packages
+- **TypeScript Compiler (tsc)** - Type checking with `tsc --noEmit`
+  - Ensures type safety without generating output files
+  - Run `pnpm -r run typecheck` for all packages
+- **oxlint** - Fast, type-aware linter used across all packages
+  - Provides additional linting rules beyond TypeScript checking
+  - Significantly faster than ESLint with comparable rules
+  - Uses `--type-aware` flag for enhanced TypeScript analysis
 - **Prettier** - Code formatting (primarily for documentation)
-- Run `pnpm lint` to check code quality
+- Run `pnpm lint` to check code quality with oxlint
 - Run `pnpm lint:fix` to auto-fix linting issues
-- Each package has its own `.eslintrc.js` extending from root configuration
+- Each package uses oxlint which automatically respects `.gitignore` patterns
 
 ### TypeScript Best Practices
 
@@ -477,11 +503,14 @@ pnpm install
 # Clean all build artifacts
 pnpm -r run clean
 
+# Check TypeScript types across all packages
+pnpm -r run typecheck
+
+# Check TypeScript configuration for specific package
+pnpm --filter=<package> run typecheck
+
 # Rebuild TypeScript references
 pnpm run build:ts
-
-# Check TypeScript configuration
-pnpm --filter=<package> run tsc --noEmit
 ```
 
 #### Test Failures
@@ -523,6 +552,21 @@ NODE_OPTIONS='--inspect-brk' pnpm --filter=egg run test
 - Regular dependency updates via `pnpm update`
 
 ## Migration Guide
+
+### Migrating from ESLint to oxlint
+
+1. Remove ESLint dependencies from package.json:
+   - Remove `eslint`, `eslint-config-egg`, and any ESLint plugins
+   - Add `"oxlint": "catalog:"` to devDependencies
+2. Delete `.eslintrc`, `.eslintrc.js`, or `.eslintrc.json` files
+3. Update scripts in package.json:
+   - Add `"typecheck": "tsc --noEmit"` for TypeScript type checking
+   - Change `"lint": "eslint ..."` to `"lint": "oxlint --type-aware"`
+   - Add `"lint:fix": "npm run lint -- --fix"`
+4. Ensure both type checking and linting are run:
+   - Use `tsc --noEmit` for pure TypeScript type checking
+   - Use `oxlint --type-aware` for additional linting rules
+5. Run `pnpm install` to update dependencies
 
 ### Migrating from Egg v2 to v3
 

--- a/packages/cookies/.gitignore
+++ b/packages/cookies/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+coverage
+test/ts/report
+package-lock.json
+.tshy*
+.eslintcache
+dist

--- a/packages/cookies/CHANGELOG.md
+++ b/packages/cookies/CHANGELOG.md
@@ -1,0 +1,304 @@
+# Changelog
+
+> [!IMPORTANT]
+> Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
+
+---
+
+## 4.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 20.19.0 support
+
+
+## [3.1.0](https://github.com/eggjs/egg-cookies/compare/v3.0.1...v3.1.0) (2024-12-26)
+
+
+### Features
+
+* support ignoring secure error ([#58](https://github.com/eggjs/egg-cookies/issues/58)) ([38f98d1](https://github.com/eggjs/egg-cookies/commit/38f98d12922571f6195121500002bd8d2da4be50))
+
+## [3.0.1](https://github.com/eggjs/egg-cookies/compare/v3.0.0...v3.0.1) (2024-07-06)
+
+
+### Bug Fixes
+
+* partitioned and autoChips should support different paths ([#55](https://github.com/eggjs/egg-cookies/issues/55)) ([50b1313](https://github.com/eggjs/egg-cookies/commit/50b1313172d1180569c556f3ab05448ab3bb3100))
+
+## [3.0.0](https://github.com/eggjs/egg-cookies/compare/v2.10.0...v3.0.0) (2024-06-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 18.19.0 support
+
+part of https://github.com/eggjs/egg/issues/3644
+
+<!-- This is an auto-generated comment: release notes by coderabbit.ai
+-->
+
+## Summary by CodeRabbit
+
+- **New Features**
+- Introduced comprehensive support for TypeScript in project
+configurations.
+- Added new cookie management functionalities, including setting,
+encryption, and validation.
+  - Added support for `Keygrip` class for cryptographic operations.
+
+- **Documentation**
+- Updated package name in README files from `egg-cookies` to
+`@eggjs/cookies`.
+- Adjusted code snippets and URLs in documentation to reflect the new
+package name.
+
+- **Tests**
+- Enhanced test suite with additional test cases for cookie encryption,
+caching, and error handling.
+  - Added new test files for `Keygrip` and cookie functionalities.
+  
+- **Chores**
+  - Updated `.gitignore` to include new patterns for ignoring files.
+- Improved CI workflow with updated Node.js versions and Codecov token
+integration.
+- Updated dependencies and scripts in `package.json` to align with the
+new package structure and TypeScript support.
+
+<!-- end of auto-generated comment: release notes by coderabbit.ai -->
+
+### Features
+
+* support cjs and esm both by tshy ([#54](https://github.com/eggjs/egg-cookies/issues/54)) ([12db545](https://github.com/eggjs/egg-cookies/commit/12db545f887940560f49f792035dbf63d6ceb497))
+
+## [2.10.0](https://github.com/eggjs/egg-cookies/compare/v2.9.4...v2.10.0) (2024-02-19)
+
+
+### Features
+
+* support priority ([#52](https://github.com/eggjs/egg-cookies/issues/52)) ([f9f1214](https://github.com/eggjs/egg-cookies/commit/f9f12149637d37df8e6cecd9cb50d8c27421c7d0))
+
+## [2.9.4](https://github.com/eggjs/egg-cookies/compare/v2.9.3...v2.9.4) (2024-01-05)
+
+
+### Bug Fixes
+
+* disable autoChips if set cookie with partitioned ([#51](https://github.com/eggjs/egg-cookies/issues/51)) ([148c61c](https://github.com/eggjs/egg-cookies/commit/148c61c3be41d90c44c3db8bfe870cae31d586ad))
+
+## [2.9.3](https://github.com/eggjs/egg-cookies/compare/v2.9.2...v2.9.3) (2024-01-04)
+
+
+### Reverts
+
+* Revert "fix: only enable autoChips on cross-site request (#49)" (#50) ([b0452dd](https://github.com/eggjs/egg-cookies/commit/b0452dd0011a7ed5cc8fd489a2fbb6fa5c076ac2)), closes [#49](https://github.com/eggjs/egg-cookies/issues/49) [#50](https://github.com/eggjs/egg-cookies/issues/50)
+
+## [2.9.2](https://github.com/eggjs/egg-cookies/compare/v2.9.1...v2.9.2) (2024-01-04)
+
+
+### Bug Fixes
+
+* only enable autoChips on cross-site request ([#49](https://github.com/eggjs/egg-cookies/issues/49)) ([665a335](https://github.com/eggjs/egg-cookies/commit/665a33574f2c27bda5d59eb8f5e5b70b2ee9ad97))
+
+## [2.9.1](https://github.com/eggjs/egg-cookies/compare/v2.9.0...v2.9.1) (2024-01-03)
+
+
+### Bug Fixes
+
+* use _CHIPS- prefix instead of __Host- ([#48](https://github.com/eggjs/egg-cookies/issues/48)) ([6b5e5be](https://github.com/eggjs/egg-cookies/commit/6b5e5be4f09b692b2867b390a300de8a1e142cbb))
+
+## [2.9.0](https://github.com/eggjs/egg-cookies/compare/v2.8.3...v2.9.0) (2024-01-03)
+
+
+### Features
+
+* add autoChips to adaptation CHIPS mode ([#47](https://github.com/eggjs/egg-cookies/issues/47)) ([38d6408](https://github.com/eggjs/egg-cookies/commit/38d64084b78ad15f816b4e8c46efa3c591c04558))
+
+## [2.8.3](https://github.com/eggjs/egg-cookies/compare/v2.8.2...v2.8.3) (2023-12-28)
+
+
+### Bug Fixes
+
+* should not set sameSite and CHIPS when secure = false ([#45](https://github.com/eggjs/egg-cookies/issues/45)) ([33395bf](https://github.com/eggjs/egg-cookies/commit/33395bfda657fd31b0443dbf0d9cdb3bea697b1b))
+
+## [2.8.2](https://github.com/eggjs/egg-cookies/compare/v2.8.1...v2.8.2) (2023-12-28)
+
+
+### Bug Fixes
+
+* support remove unpartitioned same name cookie first ([#44](https://github.com/eggjs/egg-cookies/issues/44)) ([b81f041](https://github.com/eggjs/egg-cookies/commit/b81f04181e461f2688296e4bd65cad8ac3a8298d))
+
+## [2.8.1](https://github.com/eggjs/egg-cookies/compare/v2.8.0...v2.8.1) (2023-12-27)
+
+
+### Bug Fixes
+
+* add partitioned in index.d.ts ([#43](https://github.com/eggjs/egg-cookies/issues/43)) ([7e01eba](https://github.com/eggjs/egg-cookies/commit/7e01eba444f24bfea810a9b474ff54d182cb80c4))
+
+## [2.8.0](https://github.com/eggjs/egg-cookies/compare/v2.7.1...v2.8.0) (2023-12-26)
+
+
+### Features
+
+* support set partitioned property on Chrome >= 114 ([#42](https://github.com/eggjs/egg-cookies/issues/42)) ([74325b8](https://github.com/eggjs/egg-cookies/commit/74325b89b150ce880dc742f63016f0494fff273a))
+
+## [2.7.1](https://github.com/eggjs/egg-cookies/compare/v2.7.0...v2.7.1) (2023-08-04)
+
+
+### Bug Fixes
+
+* domain can be empty string ([#39](https://github.com/eggjs/egg-cookies/issues/39)) ([0b285e1](https://github.com/eggjs/egg-cookies/commit/0b285e1dc8203dde8670c2459e5f8bbde93a1ef5)), closes [/github.com/eggjs/egg-cookies/pull/38#discussion_r1284672929](https://github.com/eggjs//github.com/eggjs/egg-cookies/pull/38/issues/discussion_r1284672929)
+
+## [2.7.0](https://github.com/eggjs/egg-cookies/compare/v2.6.1...v2.7.0) (2023-08-04)
+
+
+### Features
+
+* support function to set domain ([#38](https://github.com/eggjs/egg-cookies/issues/38)) ([c73b415](https://github.com/eggjs/egg-cookies/commit/c73b415467b9e13363a8a5dd0b5e3c7a72f4adb4))
+
+---
+
+
+2.6.1 / 2022-06-20
+==================
+
+**others**
+  * [[`ebe330e`](http://github.com/eggjs/egg-cookies/commit/ebe330ea461be73e65dd1e2bbd4c9e3eba5e8d89)] - 🐛 FIX: Avoid ReDoS (#36) (fengmk2 <<fengmk2@gmail.com>>)
+
+2.6.0 / 2022-06-20
+==================
+
+**features**
+  * [[`7ed0ded`](http://github.com/eggjs/egg-cookies/commit/7ed0ded5492ebd7a2001407c9a9af638dcfd5307)] - feat: deprecated crypto api (#35) (吖猩 <<whxaxes@gmail.com>>)
+
+2.5.0 / 2022-05-02
+==================
+
+**features**
+  * [[`7377d3b`](http://github.com/eggjs/egg-cookies/commit/7377d3b0a9ee6d137bc07f4742aa499e9ed47d8d)] - feat: add CookieError (#31) (图南 <<xzj15859722542@hotmail.com>>)
+
+**others**
+  * [[`d27be06`](http://github.com/eggjs/egg-cookies/commit/d27be0659889d12af245149b633e7274790a01c4)] - 🤖 TEST: Run on node 18 (#34) (fengmk2 <<fengmk2@gmail.com>>)
+  * [[`9e770ee`](http://github.com/eggjs/egg-cookies/commit/9e770ee61a9e6f1ce9b19e8e028f9847c386f3a0)] - Create codeql-analysis.yml (fengmk2 <<fengmk2@gmail.com>>)
+  * [[`eff0195`](http://github.com/eggjs/egg-cookies/commit/eff01956de00a95fab8a3367ade61b5b8a55b76d)] - chore: update build status badge (#33) (XiaoRui <<xiangwu619@gmail.com>>)
+
+2.4.3 / 2022-04-29
+==================
+
+**fixes**
+  * [[`c8c42d3`](http://github.com/eggjs/egg-cookies/commit/c8c42d30b41f7c3f6c2e9231364e4acf47cea221)] - fix: should only update .sig once (#32) (TZ | 天猪 <<atian25@qq.com>>)
+
+2.4.2 / 2020-06-28
+==================
+
+**fixes**
+  * [[`a72fd0c`](http://github.com/eggjs/egg-cookies/commit/a72fd0cd9518ad8cfb3ad7c8ace1eb14097cea7e)] - fix: ignore maxAge = 0 (#29) (Yiyu He <<dead_horse@qq.com>>)
+
+2.4.1 / 2020-06-28
+==================
+
+**fixes**
+  * [[`7a87cc1`](http://github.com/eggjs/egg-cookies/commit/7a87cc16108bc5b542c0fbe91c4e4a6e986573de)] - fix: ignore invalid maxage (#28) (Yiyu He <<dead_horse@qq.com>>)
+
+2.4.0 / 2020-06-22
+==================
+
+**features**
+  * [[`4417dda`](http://github.com/eggjs/egg-cookies/commit/4417ddacecde2dff3792ca10e0bf05fc94a991ee)] - feat: Send `max-age` header as well as `expires` if it is set(#27) (Junyan <<yancoding@gmail.com>>)
+
+2.3.4 / 2020-06-12
+==================
+
+**fixes**
+  * [[`a146191`](http://github.com/eggjs/egg-cookies/commit/a14619139f585da290d693e6dfcf3e29304bc337)] - fix(typings): value of set method should support null type (#21) (Jedmeng <<roy.urey@gmail.com>>)
+
+2.3.3 / 2020-03-27
+==================
+
+**fixes**
+  * [[`b3f86c0`](http://github.com/eggjs/egg-cookies/commit/b3f86c01b19b790f8c06aca143a094ed4fa575bd)] - fix(SameSite): don't send SameSite=None on non-secure context (#26) (Eric Zhang <<hixyeric@gmail.com>>)
+
+2.3.2 / 2020-02-19
+==================
+
+**fixes**
+  * [[`c6e1e74`](http://github.com/eggjs/egg-cookies/commit/c6e1e74e77c53f68e79f0ebd799c755db470badd)] - fix: don't send SameSite=None on Chromium/Chrome < 80.x (#25) (fengmk2 <<fengmk2@gmail.com>>)
+
+2.3.1 / 2019-12-17
+==================
+
+**fixes**
+  * [[`d4f443a`](http://github.com/eggjs/egg-cookies/commit/d4f443a5bf3bfd0ba7bc726b1e8b74a35ba265d6)] - fix: don't set samesite=none on incompatible clients (#23) (fengmk2 <<fengmk2@gmail.com>>)
+
+2.3.0 / 2019-12-06
+==================
+
+**features**
+  * [[`d5e3d21`](http://github.com/eggjs/egg-cookies/commit/d5e3d215b1c51f70d932dba391d7da228a302312)] - feat: support SameSite=None (#18) (ziyunfei <<446240525@qq.com>>)
+  * [[`4dd74d2`](http://github.com/eggjs/egg-cookies/commit/4dd74d2078b5aea11f11b3b40605b702ca9ccd60)] - feat: allow set default cookie options on top level (#22) (fengmk2 <<fengmk2@gmail.com>>)
+
+**others**
+  * [[`57a005f`](http://github.com/eggjs/egg-cookies/commit/57a005fd501dad5fdadc25ea94db5474fbd6ca8c)] - chore: add license decoration (#20) (刘放 <<brizer@users.noreply.github.com>>)
+
+2.2.7 / 2019-04-28
+==================
+
+**fixes**
+  * [[`64e93e9`](http://github.com/eggjs/egg-cookies/commit/64e93e919558ee96e29de5c49d7132595e96b9b5)] - fix: empty cookie value should ignore maxAge (#17) (fengmk2 <<fengmk2@gmail.com>>)
+
+2.2.6 / 2018-09-07
+==================
+
+  * fix: should still support 4, 6 (#16)
+
+2.2.5 / 2018-09-07
+==================
+
+  * chore(typings): Remove 'ctx' in EggCookie's declaration and add a missing unit test (#15)
+
+2.2.4 / 2018-09-06
+==================
+
+  * fix: public files && deps (#14)
+
+2.2.3 / 2018-09-06
+==================
+
+  * chore: adjust some dep && config (#13)
+  * test: Add unit tests for ts (#12)
+  * chore(typings):  Extract 'EggCookies' for TypeScript intellisense (#11)
+
+2.2.2 / 2017-12-14
+==================
+
+**fixes**
+  * [[`d199238`](http://github.com/eggjs/egg-cookies/commit/d1992389558c24f26fbd6b617054c535e2c51319)] - fix: don't modify options (#9) (Roc Gao <<ggjqzjgp103@qq.com>>)
+
+**others**
+  * [[`1037873`](http://github.com/eggjs/egg-cookies/commit/103787342f9b45bcc794ec2adeda5e809af3328b)] - chore: jsdoc typo (#6) (TZ | 天猪 <<atian25@qq.com>>)
+
+2.2.1 / 2017-02-22
+==================
+
+  * fix: emit on ctx.app (#5)
+
+2.2.0 / 2017-02-21
+==================
+
+  * feat: check cookie value's length (#4)
+  * feat: support cookie.sameSite (#3)
+
+2.1.0 / 2016-11-22
+==================
+
+  * feat: cache keygrip (#2)
+
+2.0.0 / 2016-11-22
+==================
+
+  * refactor: rewrite keygrip and cookies for egg/koa (#1)
+  * chore: add zh-CN readme
+
+1.0.0 / 2016-07-15
+==================
+
+  * init version

--- a/packages/cookies/LICENSE
+++ b/packages/cookies/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-present Alibaba Group Holding Limited and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cookies/README.md
+++ b/packages/cookies/README.md
@@ -1,0 +1,52 @@
+# @eggjs/cookies
+
+[![NPM version][npm-image]][npm-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/@eggjs/cookies.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/@eggjs/cookies
+[download-image]: https://img.shields.io/npm/dm/@eggjs/cookies.svg?style=flat-square
+[download-url]: https://npmjs.org/package/@eggjs/cookies
+
+Extends [pillarjs/cookies](https://github.com/pillarjs/cookies) to adapt koa and egg with some additional features.
+
+## Encrypt
+
+`@eggjs/cookies` provide an alternative `encrypt` mode like `signed`. An encrypt cookie's value will be encrypted base on keys. Anyone who don't have the keys are unable to know the original cookie's value.
+
+```ts
+import { Cookies } from '@eggjs/cookies';
+
+const cookies = new Cookies(ctx, keys[, defaultCookieOptions]);
+
+cookies.set('foo', 'bar', { encrypt: true });
+cookies.get('foo', { encrypt: true });
+```
+
+**Note: you should both indicating in get and set in pairs.**
+
+## Cookie Length Check
+
+[Browsers all had some limitation in cookie's length](http://browsercookielimits.squawky.net/), so if set a cookie with an extremely long value(> 4093), `@eggjs/cookies` will emit an `cookieLimitExceed` event. You can listen to this event and record.
+
+```ts
+import { Cookies } from '@eggjs/cookies';
+
+const cookies = new Cookies(ctx, keys);
+
+cookies.on('cookieLimitExceed', ({ name, value }) => {
+  // log
+});
+
+cookies.set('foo', longText);
+```
+
+## License
+
+[MIT](LICENSE)
+
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg)](https://github.com/eggjs/egg/graphs/contributors)
+
+Made with [contributors-img](https://contrib.rocks).

--- a/packages/cookies/README.zh-CN.md
+++ b/packages/cookies/README.zh-CN.md
@@ -1,0 +1,70 @@
+# @eggjs/cookies
+
+[![NPM version][npm-image]][npm-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/@eggjs/cookies.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/@eggjs/cookies
+[download-image]: https://img.shields.io/npm/dm/@eggjs/cookies.svg?style=flat-square
+[download-url]: https://npmjs.org/package/@eggjs/cookies
+
+为 egg 提供 cookie 操作的封装。
+
+```ts
+ctx.cookies = new Cookies(ctx, keys[, defaultCookieOptions]);
+
+ctx.cookies.get('key', 'value', options);
+ctx.cookies.set('key', 'value', options);
+```
+
+## 初始化
+
+初始化时需要传递 Array 类型 的keys 参数，否则无法使用 cookies 的 `signed` 和 `encrypt` 功能。
+
+每次设置或读取 signed cookie 或者 encrypt cookie 的时候，会用 keys 进行加密。每次加密都通过 keys 数组的第一个 key 进行加密，解密会从先到后逐个 key 尝试解密。读取 signed cookie 时，如果发现不是用第一个 key 进行加密时，会更新签名为第一个 key 加密的值。读取 encrypt cookie 时不会进行更新操作。
+
+### `defaultCookieOptions`
+
+全局默认配置：
+
+- autoChips - `Boolean` 是否开启 [CHIPS](https://developers.google.com/privacy-sandbox/3pcd/chips#security_design) 的自动适配方案，
+  会自动给 Cookie 新增一个 `_CHIPS-` 为前缀的分区 Cookie，优先读取非分区 Cookie，读取失败则尝试读取 `_CHIPS-` 前缀的同名 Cookie 适配三方 Cookie 禁止逻辑。
+  一旦 `cookies.set` 设置 `partitioned=true`，那么会强制忽略 `autoChips` 参数。
+
+## 设置 cookie
+
+通过 `cookies.set(key, value, options)` 的方式来设置一个 cookie。其中 options 支持的参数有：
+
+- path - `String` cookie 的有效路径，默认为 `/`。
+- domain - `String` cookie 的有效域名范围，默认为 `undefined`。
+- expires - `Date` cookie 的失效时间。
+- maxAge - `Number` cookie 的最大有效时间，如果设置了 maxAge，将会覆盖 expires 的值。
+- secure - `Boolean` 是否只在加密信道中传输，注意，如果请求为 http 时，不允许设置为 `true`，https 时自动设置为 `true`。
+- partitioned - `Boolean` 是否设置独立分区状态（[CHIPS](https://developers.google.com/privacy-sandbox/3pcd/chips)）的 Cookie。注意，只有 `secure` 为 `true` 的时候此配置才会生效。
+- removeUnpartitioned - `Boolean` 是否删除非独立分区状态的同名 cookie。注意，只有 `partitioned` 为 `true` 的时候此配置才会生效。
+- httpOnly - `Boolean` 如果设置为 `true`，则浏览器中不允许读取这个 cookie 的值。
+- overwrite - `Boolean` 如果设置为 `true`，在一个请求上重复写入同一个 key 将覆盖前一次写入的值，默认为 `false`。
+- signed - `Boolean` 是否需要对 cookie 进行签名，需要配合 get 时传递 signed 参数，此时前端无法篡改这个 cookie，默认为 `true`。
+- encrypt - `Boolean` 是否需要对 cookie 进行加密，需要配合 get 时传递 encrypt 参数，此时前端无法读到真实的 cookie 值，默认为 `false`。
+- priority - `String` 表示 cookie 优先级的字符串，可以设置为 `'low'`, `'medium'`, `'high'`，默认为 `undefined`。[A Retention Priority Attribute for HTTP Cookies](https://datatracker.ietf.org/doc/html/draft-west-cookie-priority)
+
+## 读取 cookie
+
+通过 `cookies.get(key, value, options)` 的方式来读取一个 cookie。其中 options 支持的参数有：
+
+- signed - `Boolean` 是否需要对 cookie 进行验签，需要配合 set 时传递 signed 参数，此时前端无法篡改这个 cookie，默认为 true。
+- encrypt - `Boolean` 是否需要对 cookie 进行解密，需要配合 set 时传递 encrypt 参数，此时前端无法读到真实的 cookie 值，默认为 false。
+
+## 删除 cookie
+
+通过 `cookie.set(key, null)` 来删除一个 cookie。如果传递了 `signed` 参数，签名也会被删除。
+
+## License
+
+[MIT](LICENSE)
+
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg)](https://github.com/eggjs/egg/graphs/contributors)
+
+Made with [contributors-img](https://contrib.rocks).

--- a/packages/cookies/benchmark/index.cjs
+++ b/packages/cookies/benchmark/index.cjs
@@ -1,0 +1,159 @@
+const Benchmark = require('benchmark');
+const benchmarks = require('beautify-benchmark');
+const Cookies = require('cookies');
+const Keygrip = require('keygrip');
+const { Cookies: EggCookies } = require('..');
+
+const suite = new Benchmark.Suite();
+
+const keys = ['this is a very very loooooooooooooooooooooooooooooooooooooong key'];
+const keygrip = new Keygrip(keys);
+
+const eggCookie = createEggCookie();
+const cookie = createCookie();
+
+console.log('------------get test----------');
+console.log(eggCookie.get('eggSign', { signed: true }));
+console.log(eggCookie.get('eggSign'));
+console.log(eggCookie.get('eggEncrypt', { encrypt: true }));
+console.log(cookie.get('sign', { signed: true }));
+console.log(cookie.get('sign'));
+
+console.log('------------set test----------');
+eggCookie.set('eggSign', 'egg signed cookie', { signed: true });
+cookie.set('sign', 'signed cookie', { signed: true });
+eggCookie.set('eggEncrypt', 'egg encrypt cookie', { encrypt: true });
+console.log(eggCookie.ctx.response.headers);
+console.log(cookie.response.headers);
+
+console.log('------------benchmark start----------');
+
+suite
+  .add('create EggCookie', function () {
+    createEggCookie();
+  })
+  .add('create Cookie', function () {
+    createCookie();
+  })
+  .add('EggCookies.set with signed', function () {
+    createEggCookie().set('foo', 'bar', { signed: true });
+  })
+  .add('Cookies.set with signed', function () {
+    createCookie().set('foo', 'bar', { signed: true });
+  })
+  .add('EggCookies.set without signed', function () {
+    createEggCookie().set('foo', 'bar', { signed: false });
+  })
+  .add('Cookies.set without signed', function () {
+    createCookie().set('foo', 'bar', { signed: false });
+  })
+  .add('EggCookies.set with encrypt', function () {
+    createEggCookie().set('foo', 'bar', { encrypt: true });
+  })
+  .add('EggCookies.get with signed', function () {
+    createEggCookie().get('eggSign', { signed: true });
+  })
+  .add('Cookies.get with signed', function () {
+    createCookie().get('sign', { signed: true });
+  })
+  .add('EggCookies.get without signed', function () {
+    createEggCookie().get('eggSign', { signed: false });
+  })
+  .add('Cookies.get without signed', function () {
+    createCookie().get('sign', { signed: false });
+  })
+  .add('EggCookies.get with encrypt', function () {
+    createEggCookie().get('eggEncrypt', { encrypt: true });
+  })
+  .on('cycle', event => benchmarks.add(event.target))
+  .on('start', () => console.log('\n  node version: %s, date: %s\n  Starting...', process.version, Date()))
+  .on('complete', () => {
+    benchmarks.log();
+    process.exit(0);
+  })
+  .run({ async: false });
+
+function createCtx(egg) {
+  const request = {
+    headers: {
+      cookie:
+        'eggSign=egg signed cookie; eggSign.sig=SQ4wyGWr8vhSg7XCiz_MSxpHQ2GImbxE24fg4JVz7-o; sign=signed cookie; sign.sig=PvhhL9qTxML8uYSOaG_4Fr6EIEE; eggEncrypt=EpfmKzY4tX5OhafZS-onWOEIL0-CR6N_uGkFUFDCUno=;',
+    },
+    get(key) {
+      return this.headers[key.toLowerCase()];
+    },
+    getHeader(key) {
+      return this.get(key);
+    },
+    protocol: 'https',
+    secure: true,
+  };
+  const response = {
+    headers: {},
+    get(key) {
+      return this.headers[key.toLowerCase()];
+    },
+    getHeader(key) {
+      return this.get(key);
+    },
+  };
+  function set(key, value) {
+    this.headers[key.toLowerCase()] = value;
+  }
+  if (egg) response.set = set;
+  else response.setHeader = set;
+
+  return {
+    request,
+    response,
+    res: response,
+    req: request,
+    set(key, value) {
+      this.response.set(key, value);
+    },
+    get(key) {
+      return this.request.get(key);
+    },
+  };
+}
+
+function createEggCookie() {
+  return new EggCookies(createCtx(true), keys);
+}
+
+function createCookie() {
+  const ctx = createCtx();
+  return new Cookies(ctx.req, ctx.res, { keys: keygrip });
+}
+
+// v3
+// node version: v22.3.0, date: Sun Jun 23 2024 17:19:38 GMT+0800 (中国标准时间)
+// Starting...
+// 12 tests completed.
+
+// create EggCookie              x 26,305,561 ops/sec ±3.41% (87 runs sampled)
+// create Cookie                 x 18,373,466 ops/sec ±8.96% (81 runs sampled)
+// EggCookies.set with signed    x    453,511 ops/sec ±1.37% (97 runs sampled)
+// Cookies.set with signed       x    442,143 ops/sec ±2.48% (92 runs sampled)
+// EggCookies.set without signed x  4,644,441 ops/sec ±2.05% (95 runs sampled)
+// Cookies.set without signed    x  4,055,903 ops/sec ±0.14% (98 runs sampled)
+// EggCookies.set with encrypt   x    477,018 ops/sec ±1.10% (97 runs sampled)
+// EggCookies.get with signed    x    367,708 ops/sec ±0.29% (92 runs sampled)
+// Cookies.get with signed       x    133,608 ops/sec ±4.24% (87 runs sampled)
+// EggCookies.get without signed x  9,233,880 ops/sec ±8.40% (86 runs sampled)
+// Cookies.get without signed    x  7,135,602 ops/sec ±4.52% (86 runs sampled)
+// EggCookies.get with encrypt   x    423,227 ops/sec ±2.52% (89 runs sampled)
+
+// v2
+// create EggCookie              x 6,892,450 ops/sec ±1.19% (85 runs sampled)
+// create Cookie                 x 3,885,528 ops/sec ±1.07% (84 runs sampled)
+// EggCookies.set with signed    x    87,470 ops/sec ±1.63% (84 runs sampled)
+// Cookies.set with signed       x    85,711 ops/sec ±1.26% (85 runs sampled)
+// EggCookies.set without signed x   557,636 ops/sec ±0.97% (86 runs sampled)
+// Cookies.set without signed    x   550,085 ops/sec ±1.16% (86 runs sampled)
+// EggCookies.set with encrypt   x    68,705 ops/sec ±1.78% (80 runs sampled)
+// EggCookies.get with signed    x    78,196 ops/sec ±1.70% (83 runs sampled)
+// Cookies.get with signed       x    93,181 ops/sec ±1.58% (81 runs sampled)
+// EggCookies.get without signed x 1,942,366 ops/sec ±1.14% (84 runs sampled)
+// Cookies.get without signed    x 1,707,255 ops/sec ±1.13% (86 runs sampled)
+// EggCookies.get with encrypt   x    71,063 ops/sec ±2.53% (81 runs sampled)

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@eggjs/cookies",
+  "version": "4.0.0-beta.11",
+  "engines": {
+    "node": ">= 20.19.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "description": "cookies module for egg",
+  "dependencies": {
+    "should-send-same-site-none": "catalog:",
+    "utility": "catalog:"
+  },
+  "devDependencies": {
+    "beautify-benchmark": "catalog:",
+    "benchmark": "catalog:",
+    "cookies": "catalog:",
+    "keygrip": "catalog:",
+    "@eggjs/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "tsdown": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/eggjs/egg-cookies.git"
+  },
+  "homepage": "https://github.com/eggjs/egg-cookies",
+  "author": "fengmk2 <fengmk2@gmail.com> (https://github.com/fengmk2)",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint --type-aware",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "npm run lint:fix && vitest run",
+    "ci": "vitest run --coverage",
+    "prepublishOnly": "pnpm run build"
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  }
+}

--- a/packages/cookies/src/cookie.ts
+++ b/packages/cookies/src/cookie.ts
@@ -1,0 +1,164 @@
+import assert from 'node:assert';
+
+/**
+ * RegExp to match field-content in RFC 7230 sec 3.2
+ *
+ * field-content = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+ * field-vchar   = VCHAR / obs-text
+ * obs-text      = %x80-FF
+ */
+const fieldContentRegExp = /^[\u0009\u0020-\u007e\u0080-\u00ff]+$/; // eslint-disable-line no-control-regex
+
+/**
+ * RegExp to match Same-Site cookie attribute value.
+ * https://en.wikipedia.org/wiki/HTTP_cookie#SameSite_cookie
+ */
+const sameSiteRegExp = /^(?:none|lax|strict)$/i;
+
+/**
+ * RegExp to match Priority cookie attribute value.
+ */
+const PRIORITY_REGEXP = /^(?:low|medium|high)$/i;
+
+export interface CookieSetOptions {
+  /**
+   * The path for the cookie to be set in
+   */
+  path?: string | null;
+  /**
+   * The domain for the cookie
+   */
+  domain?: string | (() => string);
+  /**
+   * Is overridable
+   */
+  overwrite?: boolean;
+  /**
+   * Is the same site
+   */
+  sameSite?: string | boolean;
+  /**
+   * Encrypt the cookie's value or not
+   */
+  encrypt?: boolean;
+  /**
+   * Max age for browsers
+   */
+  maxAge?: number;
+  /**
+   * Expire time
+   */
+  expires?: Date;
+  /**
+   * Is for http only
+   */
+  httpOnly?: boolean;
+  /**
+   * Encrypt the cookie's value or not
+   */
+  secure?: boolean;
+
+  /**
+   * Once `true` and secure set to `true`, ignore the secure error in a none-ssl environment.
+   */
+  ignoreSecureError?: boolean;
+  /**
+   * Is it signed or not.
+   */
+  signed?: boolean | number;
+  /**
+   * Is it partitioned or not.
+   */
+  partitioned?: boolean;
+  /**
+   * Remove unpartitioned same name cookie or not.
+   */
+  removeUnpartitioned?: boolean;
+  /**
+   * The cookie priority.
+   */
+  priority?: 'low' | 'medium' | 'high' | 'LOW' | 'MEDIUM' | 'HIGH';
+}
+
+export class Cookie {
+  name: string;
+  value: string;
+  readonly attrs: CookieSetOptions;
+
+  constructor(name: string, value?: string | null, attrs?: CookieSetOptions) {
+    assert(fieldContentRegExp.test(name), 'argument name is invalid');
+    assert(!value || fieldContentRegExp.test(value), 'argument value is invalid');
+    this.name = name;
+    this.value = value ?? '';
+    this.attrs = mergeDefaultAttrs(attrs);
+    assert(!this.attrs.path || fieldContentRegExp.test(this.attrs.path), 'argument option path is invalid');
+    if (typeof this.attrs.domain === 'function') {
+      this.attrs.domain = this.attrs.domain();
+    }
+    assert(!this.attrs.domain || fieldContentRegExp.test(this.attrs.domain), 'argument option domain is invalid');
+    assert(
+      !this.attrs.sameSite || this.attrs.sameSite === true || sameSiteRegExp.test(this.attrs.sameSite),
+      'argument option sameSite is invalid'
+    );
+    assert(!this.attrs.priority || PRIORITY_REGEXP.test(this.attrs.priority), 'argument option priority is invalid');
+    if (!value) {
+      this.attrs.expires = new Date(0);
+      // make sure maxAge is empty
+      this.attrs.maxAge = undefined;
+    }
+  }
+
+  toString() {
+    return this.name + '=' + this.value;
+  }
+
+  toHeader() {
+    let header = this.toString();
+    const attrs = this.attrs;
+    if (attrs.path) {
+      header += '; path=' + attrs.path;
+    }
+    const maxAge = typeof attrs.maxAge === 'string' ? parseInt(attrs.maxAge, 10) : attrs.maxAge;
+    // ignore 0, `session` and other invalid maxAge
+    if (maxAge) {
+      header += '; max-age=' + Math.round(maxAge / 1000);
+      attrs.expires = new Date(Date.now() + maxAge);
+    }
+    if (attrs.expires) {
+      header += '; expires=' + attrs.expires.toUTCString();
+    }
+    if (attrs.domain) {
+      header += '; domain=' + attrs.domain;
+    }
+    if (attrs.priority) {
+      header += '; priority=' + attrs.priority.toLowerCase();
+    }
+    if (attrs.sameSite) {
+      header += '; samesite=' + (attrs.sameSite === true ? 'strict' : attrs.sameSite.toLowerCase());
+    }
+    if (attrs.secure) {
+      header += '; secure';
+    }
+    if (attrs.httpOnly) {
+      header += '; httponly';
+    }
+    if (attrs.partitioned) {
+      header += '; partitioned';
+    }
+    return header;
+  }
+}
+
+function mergeDefaultAttrs(attrs?: CookieSetOptions) {
+  const merged = {
+    path: '/',
+    httpOnly: true,
+    secure: false,
+    overwrite: false,
+    sameSite: false,
+    partitioned: false,
+    priority: undefined,
+    ...attrs,
+  };
+  return merged;
+}

--- a/packages/cookies/src/cookies.ts
+++ b/packages/cookies/src/cookies.ts
@@ -1,0 +1,341 @@
+import assert from 'node:assert';
+
+import { base64decode, base64encode } from 'utility';
+import { isSameSiteNoneCompatible } from 'should-send-same-site-none';
+
+import { Keygrip } from './keygrip.ts';
+import { Cookie, type CookieSetOptions } from './cookie.ts';
+import { CookieError } from './error.ts';
+
+const keyCache = new Map<string[], Keygrip>();
+
+export interface DefaultCookieOptions extends CookieSetOptions {
+  /**
+   * Auto get and set `_CHIPS-` prefix cookie to adaptation CHIPS mode (The default value is false).
+   */
+  autoChips?: boolean;
+}
+
+export interface CookieGetOptions {
+  /**
+   * Whether to sign or not (The default value is true).
+   */
+  signed?: boolean;
+  /**
+   * Encrypt the cookie's value or not (The default value is false).
+   */
+  encrypt?: boolean;
+}
+
+/**
+ * cookies for egg
+ * extend pillarjs/cookies, add encrypt and decrypt
+ */
+export class Cookies {
+  readonly #keysArray: string[];
+  #keys: Keygrip;
+  readonly #defaultCookieOptions?: DefaultCookieOptions;
+  readonly #autoChips?: boolean;
+  readonly ctx: Record<string, any>;
+  readonly app: Record<string, any>;
+  readonly secure: boolean;
+  #parseChromiumResult?: ParseChromiumResult;
+
+  constructor(ctx: Record<string, any>, keys: string[], defaultCookieOptions?: DefaultCookieOptions) {
+    this.#keysArray = keys;
+    // default cookie options
+    this.#defaultCookieOptions = defaultCookieOptions;
+    this.#autoChips = defaultCookieOptions?.autoChips;
+    this.ctx = ctx;
+    this.secure = this.ctx.secure;
+    this.app = ctx.app;
+  }
+
+  get keys() {
+    if (!this.#keys) {
+      assert(Array.isArray(this.#keysArray), '.keys required for encrypt/sign cookies');
+      const cache = keyCache.get(this.#keysArray);
+      if (cache) {
+        this.#keys = cache;
+      } else {
+        this.#keys = new Keygrip(this.#keysArray);
+        keyCache.set(this.#keysArray, this.#keys);
+      }
+    }
+    return this.#keys;
+  }
+
+  /**
+   * get cookie value by name
+   * @param  {String} name - cookie's name
+   * @param  {Object} opts - cookies' options
+   *            - {Boolean} signed - default to true
+   *            - {Boolean} encrypt - default to false
+   * @return {String} value - cookie's value
+   */
+  get(name: string, opts: CookieGetOptions = {}): string | undefined {
+    let value = this._get(name, opts);
+    if (value === undefined && this.#autoChips) {
+      // try to read _CHIPS-${name} prefix cookie
+      value = this._get(this.#formatChipsCookieName(name), opts);
+    }
+    return value;
+  }
+
+  _get(name: string, opts: CookieGetOptions) {
+    const signed = computeSigned(opts);
+    const header: string = this.ctx.get('cookie');
+    if (!header) return;
+
+    const match = header.match(getPattern(name));
+    if (!match) return;
+
+    let value = match[1];
+    if (!opts.encrypt && !signed) return value;
+
+    // signed
+    if (signed) {
+      const sigName = name + '.sig';
+      const sigValue = this.get(sigName, { signed: false });
+      if (!sigValue) return;
+
+      const raw = name + '=' + value;
+      const index = this.keys.verify(raw, sigValue);
+      if (index < 0) {
+        // can not match any key, remove ${name}.sig
+        this.set(sigName, null, { path: '/', signed: false, overwrite: true });
+        return;
+      }
+      if (index > 0) {
+        // not signed by the first key, update sigValue
+        this.set(sigName, this.keys.sign(raw), { signed: false, overwrite: true });
+      }
+      return value;
+    }
+
+    // encrypt
+    value = base64decode(value, true, 'buffer') as string;
+    const res = this.keys.decrypt(value);
+    return res ? res.value.toString() : undefined;
+  }
+
+  set(name: string, value: string | null, opts?: CookieSetOptions) {
+    opts = {
+      ...this.#defaultCookieOptions,
+      ...opts,
+    };
+    const signed = computeSigned(opts);
+    const shouldIgnoreSecureError = opts && opts.ignoreSecureError;
+    value = value || '';
+    if (!shouldIgnoreSecureError) {
+      if (!this.secure && opts.secure) {
+        throw new CookieError('Cannot send secure cookie over unencrypted connection');
+      }
+    }
+
+    let headers: string[] = this.ctx.response.get('set-cookie') || [];
+    if (!Array.isArray(headers)) {
+      headers = [headers];
+    }
+
+    // encrypt
+    if (opts.encrypt) {
+      value = value && base64encode(this.keys.encrypt(value), true);
+    }
+
+    // http://browsercookielimits.squawky.net/
+    if (value.length > 4093) {
+      this.app.emit('cookieLimitExceed', { name, value, ctx: this.ctx });
+    }
+
+    // https://github.com/linsight/should-send-same-site-none
+    // fixed SameSite=None: Known Incompatible Clients
+    const userAgent: string | undefined = this.ctx.get('user-agent');
+    let isSameSiteNone = false;
+    // disable autoChips if partitioned enable
+    let autoChips = !opts.partitioned && this.#autoChips;
+    if (opts.sameSite && typeof opts.sameSite === 'string' && opts.sameSite.toLowerCase() === 'none') {
+      isSameSiteNone = true;
+      if (opts.secure === false || !this.secure || (userAgent && !this.isSameSiteNoneCompatible(userAgent))) {
+        // Non-secure context or Incompatible clients, don't send SameSite=None property
+        opts.sameSite = false;
+        isSameSiteNone = false;
+      }
+    }
+    if (autoChips || opts.partitioned) {
+      // allow to set partitioned: secure=true and sameSite=none and chrome >= 118
+      if (
+        !isSameSiteNone ||
+        opts.secure === false ||
+        !this.secure ||
+        (userAgent && !this.isPartitionedCompatible(userAgent))
+      ) {
+        // Non-secure context or Incompatible clients, don't send partitioned property
+        autoChips = false;
+        opts.partitioned = false;
+      }
+    }
+
+    // remove unpartitioned same name cookie first
+    if (opts.partitioned && opts.removeUnpartitioned) {
+      const overwrite = opts.overwrite;
+      if (overwrite) {
+        opts.overwrite = false;
+        headers = ignoreCookiesByName(headers, name);
+      }
+      const removeCookieOpts = {
+        ...opts,
+        partitioned: false,
+      };
+      const removeUnpartitionedCookie = new Cookie(name, '', removeCookieOpts);
+      // if user not set secure, reset secure to ctx.secure
+      if (opts.secure === undefined) {
+        removeUnpartitionedCookie.attrs.secure = this.secure;
+      }
+
+      headers = pushCookie(headers, removeUnpartitionedCookie);
+      // signed
+      if (signed) {
+        removeUnpartitionedCookie.name += '.sig';
+        headers = ignoreCookiesByNameAndPath(
+          headers,
+          removeUnpartitionedCookie.name,
+          removeUnpartitionedCookie.attrs.path
+        );
+        headers = pushCookie(headers, removeUnpartitionedCookie);
+      }
+    } else if (autoChips) {
+      // add _CHIPS-${name} prefix cookie
+      const newCookieName = this.#formatChipsCookieName(name);
+      const newCookieOpts = {
+        ...opts,
+        partitioned: true,
+      };
+      const newPartitionedCookie = new Cookie(newCookieName, value, newCookieOpts);
+      // if user not set secure, reset secure to ctx.secure
+      if (opts.secure === undefined) newPartitionedCookie.attrs.secure = this.secure;
+
+      headers = pushCookie(headers, newPartitionedCookie);
+      // signed
+      if (signed) {
+        newPartitionedCookie.value = value && this.keys.sign(newPartitionedCookie.toString());
+        newPartitionedCookie.name += '.sig';
+        headers = ignoreCookiesByNameAndPath(headers, newPartitionedCookie.name, newPartitionedCookie.attrs.path);
+        headers = pushCookie(headers, newPartitionedCookie);
+      }
+    }
+
+    const cookie = new Cookie(name, value, opts);
+    // if user not set secure, reset secure to ctx.secure
+    if (opts.secure === undefined) {
+      cookie.attrs.secure = this.secure;
+    }
+    headers = pushCookie(headers, cookie);
+
+    // signed
+    if (signed) {
+      cookie.value = value && this.keys.sign(cookie.toString());
+      cookie.name += '.sig';
+      headers = pushCookie(headers, cookie);
+    }
+
+    this.ctx.set('set-cookie', headers);
+    return this;
+  }
+
+  #formatChipsCookieName(name: string) {
+    return `_CHIPS-${name}`;
+  }
+
+  #parseChromiumAndMajorVersion(userAgent: string) {
+    if (!this.#parseChromiumResult) {
+      this.#parseChromiumResult = parseChromiumAndMajorVersion(userAgent);
+    }
+    return this.#parseChromiumResult;
+  }
+
+  isSameSiteNoneCompatible(userAgent: string) {
+    // Chrome >= 80.0.0.0
+    const result = this.#parseChromiumAndMajorVersion(userAgent);
+    if (result.chromium) {
+      return result.majorVersion >= 80;
+    }
+    return isSameSiteNoneCompatible(userAgent);
+  }
+
+  isPartitionedCompatible(userAgent: string) {
+    // support: Chrome >= 114.0.0.0
+    // default enable: Chrome >= 118.0.0.0
+    // https://developers.google.com/privacy-sandbox/3pcd/chips
+    const result = this.#parseChromiumAndMajorVersion(userAgent);
+    if (result.chromium) {
+      return result.majorVersion >= 118;
+    }
+    return false;
+  }
+}
+
+interface ParseChromiumResult {
+  chromium: boolean;
+  majorVersion: number;
+}
+
+// https://github.com/linsight/should-send-same-site-none/blob/master/index.js#L86
+function parseChromiumAndMajorVersion(userAgent: string): ParseChromiumResult {
+  const m = /Chrom[^ /]{1,100}\/(\d{1,100}?)\./.exec(userAgent);
+  if (!m) {
+    return { chromium: false, majorVersion: 0 };
+  }
+  // Extract digits from first capturing group.
+  return { chromium: true, majorVersion: parseInt(m[1]) };
+}
+
+const _patternCache = new Map<string, RegExp>();
+function getPattern(name: string) {
+  const cache = _patternCache.get(name);
+  if (cache) {
+    return cache;
+  }
+  const reg = new RegExp('(?:^|;) *' + name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&') + '=([^;]*)');
+  _patternCache.set(name, reg);
+  return reg;
+}
+
+function computeSigned(opts: { encrypt?: boolean; signed?: boolean | number }) {
+  // encrypt default to false, signed default to true.
+  // disable singed when encrypt is true.
+  if (opts.encrypt) return false;
+  return opts.signed !== false;
+}
+
+function pushCookie(cookies: string[], cookie: Cookie) {
+  if (cookie.attrs.overwrite) {
+    cookies = ignoreCookiesByName(cookies, cookie.name);
+  }
+  cookies.push(cookie.toHeader());
+  return cookies;
+}
+
+function ignoreCookiesByName(cookies: string[], name: string) {
+  const prefix = `${name}=`;
+  return cookies.filter(c => !c.startsWith(prefix));
+}
+
+function ignoreCookiesByNameAndPath(cookies: string[], name: string, path: string | null | undefined) {
+  if (!path) {
+    return ignoreCookiesByName(cookies, name);
+  }
+  const prefix = `${name}=`;
+  // foo=hello; path=/path1; samesite=none
+  const includedPath = `; path=${path};`;
+  // foo=hello; path=/path1
+  const endsWithPath = `; path=${path}`;
+  return cookies.filter(c => {
+    if (c.startsWith(prefix)) {
+      if (c.includes(includedPath) || c.endsWith(endsWithPath)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}

--- a/packages/cookies/src/error.ts
+++ b/packages/cookies/src/error.ts
@@ -1,0 +1,9 @@
+export class CookieError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = this.constructor.name;
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/packages/cookies/src/index.ts
+++ b/packages/cookies/src/index.ts
@@ -1,0 +1,4 @@
+export * from './cookies.ts';
+export * from './cookie.ts';
+export * from './error.ts';
+export * from './keygrip.ts';

--- a/packages/cookies/src/keygrip.ts
+++ b/packages/cookies/src/keygrip.ts
@@ -1,0 +1,129 @@
+import { debuglog } from 'node:util';
+import crypto, { type Cipheriv } from 'node:crypto';
+import assert from 'node:assert';
+
+const debug = debuglog('egg/cookies:keygrip');
+
+const KEY_LEN = 32;
+const IV_SIZE = 16;
+const passwordCache = new Map();
+
+const replacer: Record<string, string> = {
+  '/': '_',
+  '+': '-',
+  '=': '',
+};
+
+function constantTimeCompare(a: Buffer, b: Buffer) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(a, b);
+}
+
+// patch from https://github.com/crypto-utils/keygrip
+
+export class Keygrip {
+  readonly #keys: string[];
+  readonly #hash = 'sha256';
+  readonly #cipher = 'aes-256-cbc';
+
+  constructor(keys: string[]) {
+    assert(Array.isArray(keys) && keys.length > 0, 'keys must be provided and should be an array');
+    this.#keys = keys;
+  }
+
+  // encrypt a message
+  encrypt(data: string, key?: string) {
+    key = key || this.#keys[0];
+    const password = keyToPassword(key);
+    const cipher = crypto.createCipheriv(this.#cipher, password.key, password.iv);
+    return crypt(cipher, data);
+  }
+
+  // decrypt a single message
+  // returns false on bad decrypts
+  decrypt(data: string | Buffer): { value: Buffer; index: number } | false {
+    // decrypt every key
+    const keys = this.#keys;
+    for (let i = 0; i < keys.length; i++) {
+      const value = this.#decryptByKey(data, keys[i]);
+      if (value !== false) {
+        return { value, index: i };
+      }
+    }
+    return false;
+  }
+
+  #decryptByKey(data: string | Buffer, key: string) {
+    try {
+      const password = keyToPassword(key);
+      const cipher = crypto.createDecipheriv(this.#cipher, password.key, password.iv);
+      return crypt(cipher, data);
+    } catch (err: any) {
+      debug('crypt error: %s', err);
+      return false;
+    }
+  }
+
+  sign(data: string | Buffer, key?: string) {
+    // default to the first key
+    key = key || this.#keys[0];
+
+    // url safe base64
+    return crypto
+      .createHmac(this.#hash, key)
+      .update(data)
+      .digest('base64')
+      .replace(/\/|\+|=/g, x => {
+        return replacer[x];
+      });
+  }
+
+  verify(data: string, digest: string) {
+    const keys = this.#keys;
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      if (constantTimeCompare(Buffer.from(digest), Buffer.from(this.sign(data, key)))) {
+        debug('data %s match key %s, index: %d', data, key, i);
+        return i;
+      }
+    }
+    return -1;
+  }
+}
+
+function crypt(cipher: Cipheriv, data: string | Buffer) {
+  const text = Buffer.isBuffer(data) ? cipher.update(data) : cipher.update(data, 'utf-8');
+  const pad = cipher.final();
+  return Buffer.concat([text, pad]);
+}
+
+function keyToPassword(key: string) {
+  if (passwordCache.has(key)) {
+    return passwordCache.get(key);
+  }
+
+  // Simulate EVP_BytesToKey.
+  // see https://github.com/nodejs/help/issues/1673#issuecomment-503222925
+  const bytes = Buffer.alloc(KEY_LEN + IV_SIZE);
+  let lastHash = null,
+    nBytes = 0;
+  while (nBytes < bytes.length) {
+    const hash = crypto.createHash('md5');
+    if (lastHash) hash.update(lastHash);
+    hash.update(key);
+    lastHash = hash.digest();
+    lastHash.copy(bytes, nBytes);
+    nBytes += lastHash.length;
+  }
+
+  // Use these for decryption.
+  const password = {
+    key: bytes.subarray(0, KEY_LEN),
+    iv: bytes.subarray(KEY_LEN, bytes.length),
+  };
+
+  passwordCache.set(key, password);
+  return password;
+}

--- a/packages/cookies/test/cookie.test.ts
+++ b/packages/cookies/test/cookie.test.ts
@@ -1,0 +1,259 @@
+import { strict as assert } from 'node:assert';
+
+import { describe, it } from 'vitest';
+
+import { Cookie } from '../src/index.ts';
+
+describe('test/cookie.test.ts', () => {
+  it('create cookies contains invalid string error should throw', () => {
+    assert.throws(() => new Cookie('中文', 'value'), /argument name is invalid/);
+    assert.throws(() => new Cookie('name', '中文'), /argument value is invalid/);
+    assert.throws(() => new Cookie('name', 'value', { path: '中文' }), /argument option path is invalid/);
+    assert.throws(() => new Cookie('name', 'value', { domain: '中文' }), /argument option domain is invalid/);
+  });
+
+  it('set expires to 0 if value not present', () => {
+    assert.equal(new Cookie('name', null).attrs.expires!.getTime(), 0);
+  });
+
+  describe('toString()', () => {
+    it('return name=value', () => {
+      assert.equal(new Cookie('name', 'value').toString(), 'name=value');
+    });
+  });
+
+  describe('toHeader()', () => {
+    it('return name=value;params', () => {
+      assert.match(
+        new Cookie('name', 'value', {
+          secure: true,
+          maxAge: 1000,
+          domain: 'eggjs.org',
+          path: '/',
+          httpOnly: true,
+        }).toHeader(),
+        /^name=value; path=\/; max-age=1; expires=(.*?)GMT; domain=eggjs\.org; secure; httponly$/
+      );
+    });
+
+    it('no emit error once setting secure=true in none ssl environment', () => {
+      new Cookie('name', 'value', {
+        secure: true,
+        ignoreSecureError: true,
+      });
+    });
+
+    it('no emit error once setting secure=true in none ssl environment', () => {
+      const exceptionMessage = 'Cannot send secure cookie over unencrypted connection';
+      try {
+        new Cookie('name', 'value', {
+          secure: true,
+        });
+      } catch (error) {
+        assert.strictEqual((error as Error).message, exceptionMessage);
+      }
+
+      try {
+        new Cookie('name', 'value', {
+          secure: true,
+          ignoreSecureError: false,
+        });
+      } catch (error) {
+        assert.strictEqual((error as Error).message, exceptionMessage);
+      }
+    });
+
+    it('set domain when domain is a function', () => {
+      assert(
+        new Cookie('name', 'value', {
+          secure: true,
+          maxAge: 1000,
+          domain: () => 'eggjs.org',
+          path: '/',
+          httpOnly: true,
+        })
+          .toHeader()
+          .match(/^name=value; path=\/; max-age=1; expires=(.*?)GMT; domain=eggjs\.org; secure; httponly$/)
+      );
+    });
+
+    it('do not set path when set path to null', () => {
+      const header = new Cookie('name', 'value', {
+        path: null,
+      }).toHeader();
+      assert.doesNotMatch(header, /path=/);
+    });
+
+    it('do not set httponly when set httpOnly to false', () => {
+      const header = new Cookie('name', 'value', {
+        httpOnly: false,
+      }).toHeader();
+      assert.doesNotMatch(header, /httponly/);
+    });
+  });
+
+  describe('maxAge', () => {
+    it('maxAge overwrite expires', () => {
+      const expires = new Date('2020-01-01');
+      let header = new Cookie('name', 'value', {
+        secure: true,
+        expires,
+        domain: 'eggjs.org',
+        path: '/',
+        httpOnly: true,
+      }).toHeader();
+      assert.match(header, /expires=Wed, 01 Jan 2020 00:00:00 GMT/);
+      header = new Cookie('name', 'value', {
+        secure: true,
+        maxAge: 1000,
+        expires,
+        domain: 'eggjs.org',
+        path: '/',
+        httpOnly: true,
+      }).toHeader();
+      assert(!header.match(/expires=Wed, 01 Jan 2020 00:00:00 GMT/));
+    });
+
+    it('ignore maxage NaN', () => {
+      const header = new Cookie('name', 'value', {
+        secure: true,
+        maxAge: 'session' as any,
+        domain: 'eggjs.org',
+        path: '/',
+        httpOnly: true,
+      }).toHeader();
+      assert(!header.includes('max-age'));
+      assert(!header.includes('expires'));
+    });
+
+    it('ignore maxage 0', () => {
+      // In previous implementations, maxAge = 0 was considered unnecessary to set this header
+      const header = new Cookie('name', 'value', {
+        secure: true,
+        maxAge: 0,
+        domain: 'eggjs.org',
+        path: '/',
+        httpOnly: true,
+      }).toHeader();
+      assert(!header.includes('max-age'));
+      assert(!header.includes('expires'));
+    });
+  });
+
+  describe('sameSite', () => {
+    it('should default to false', () => {
+      const cookie = new Cookie('foo', 'bar');
+      assert.equal(cookie.attrs.sameSite, false);
+    });
+
+    it('should throw on invalid value', () => {
+      assert.throws(() => {
+        new Cookie('foo', 'bar', { sameSite: 'foo' });
+      }, /argument option sameSite is invalid/);
+    });
+
+    describe('when set to falsy values', () => {
+      it('should not add "samesite" attribute in header', () => {
+        const falsyValues = [false, 0, '', null, undefined, NaN];
+        falsyValues.forEach(falsy => {
+          const cookie = new Cookie('foo', 'bar', { sameSite: falsy as any });
+          assert.ok(Object.is(cookie.attrs.sameSite, falsy));
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; httponly');
+        });
+      });
+    });
+
+    describe('when set to "true"', () => {
+      it('should set "samesite=strict" attribute in header', () => {
+        const cookie = new Cookie('foo', 'bar', { sameSite: true });
+        assert.equal(cookie.attrs.sameSite, true);
+        assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=strict; httponly');
+      });
+    });
+
+    describe('when set to "none"', () => {
+      it('should set "samesite=none" attribute in header', () => {
+        {
+          const cookie = new Cookie('foo', 'bar', { sameSite: 'none' });
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=none; httponly');
+        }
+        {
+          const cookie = new Cookie('foo', 'bar', { sameSite: 'None' });
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=none; httponly');
+        }
+      });
+    });
+
+    describe('when set to "lax"', () => {
+      it('should set "samesite=lax" attribute in header', () => {
+        {
+          const cookie = new Cookie('foo', 'bar', { sameSite: 'lax' });
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=lax; httponly');
+        }
+        {
+          const cookie = new Cookie('foo', 'bar', { sameSite: 'Lax' });
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=lax; httponly');
+        }
+      });
+    });
+
+    describe('when set to "strict"', () => {
+      it('should set "samesite=strict" attribute in header', () => {
+        {
+          const cookie = new Cookie('foo', 'bar', { sameSite: 'strict' });
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=strict; httponly');
+        }
+        {
+          const cookie = new Cookie('foo', 'bar', { sameSite: 'Strict' });
+          assert.equal(cookie.toHeader(), 'foo=bar; path=/; samesite=strict; httponly');
+        }
+      });
+    });
+  });
+
+  describe('priority', () => {
+    it('should set the .priority property', () => {
+      const cookie = new Cookie('foo', 'bar', { priority: 'low' });
+      assert.strictEqual(cookie.attrs.priority, 'low');
+    });
+
+    it('should default to undefined', () => {
+      const cookie = new Cookie('foo', 'bar');
+      assert.strictEqual(cookie.attrs.priority, undefined);
+    });
+
+    it('should throw on invalid value', () => {
+      assert.throws(() => {
+        new Cookie('foo', 'bar', { priority: 'foo' as any });
+      }, /argument option priority is invalid/);
+    });
+
+    describe('when set to "low"', () => {
+      it('should set "priority=low" attribute in header', () => {
+        const cookie = new Cookie('foo', 'bar', { priority: 'low' });
+        assert.strictEqual(cookie.toHeader(), 'foo=bar; path=/; priority=low; httponly');
+      });
+    });
+
+    describe('when set to "medium"', () => {
+      it('should set "priority=medium" attribute in header', () => {
+        const cookie = new Cookie('foo', 'bar', { priority: 'medium' });
+        assert.strictEqual(cookie.toHeader(), 'foo=bar; path=/; priority=medium; httponly');
+      });
+    });
+
+    describe('when set to "high"', () => {
+      it('should set "priority=high" attribute in header', () => {
+        const cookie = new Cookie('foo', 'bar', { priority: 'high' });
+        assert.strictEqual(cookie.toHeader(), 'foo=bar; path=/; priority=high; httponly');
+      });
+    });
+
+    describe('when set to "HIGH"', () => {
+      it('should set "priority=high" attribute in header', () => {
+        const cookie = new Cookie('foo', 'bar', { priority: 'HIGH' });
+        assert.strictEqual(cookie.toHeader(), 'foo=bar; path=/; priority=high; httponly');
+      });
+    });
+  });
+});

--- a/packages/cookies/test/cookies.test.ts
+++ b/packages/cookies/test/cookies.test.ts
@@ -1,0 +1,1387 @@
+import { strict as assert } from 'node:assert';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { CookieError, type CookieSetOptions } from '../src/index.ts';
+import Cookies from './cookies.ts';
+
+describe('test/cookies.test.ts', () => {
+  it('should encrypt error when keys not present', () => {
+    const cookies = Cookies({}, { keys: null });
+    try {
+      cookies.set('foo', 'bar', { encrypt: true });
+      throw new Error('should not exec');
+    } catch (err: any) {
+      assert.equal(err.message, '.keys required for encrypt/sign cookies');
+    }
+  });
+
+  it('should not thrown when keys not present and do not use encrypt or sign', () => {
+    const cookies = Cookies({}, { keys: null });
+    cookies.set('foo', 'bar', { encrypt: false, signed: false });
+  });
+
+  it('should encrypt ok', () => {
+    const cookies = Cookies();
+    cookies.set('foo', 'bar', { encrypt: true });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    cookies.ctx.request.headers.cookie = cookie;
+    const value = cookies.get('foo', { encrypt: true });
+    assert(value, 'bar');
+    assert(cookie.indexOf('bar') === -1);
+  });
+
+  it('should cache keygrip', () => {
+    const keys = ['key'];
+    assert.equal(Cookies({}, { keys }).keys, Cookies({}, { keys }).keys);
+    assert.equal(Cookies({}, { keys }).keys, Cookies({}, { keys }).keys);
+    assert.equal(Cookies({}, { keys }).keys, Cookies({}, { keys }).keys);
+    assert.notEqual(Cookies({}, { keys }).keys, Cookies({}, { keys: ['foo'] }).keys);
+  });
+
+  it('should encrypt failed return undefined', () => {
+    const cookies = Cookies();
+    cookies.set('foo', 'bar', { encrypt: true });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    const newCookies = Cookies(
+      {
+        headers: { cookie },
+      },
+      { keys: ['another key'] }
+    );
+    const value = newCookies.get('foo', { encrypt: true });
+    assert(value === undefined);
+  });
+
+  it('should disable signed when encrypt enable', () => {
+    const cookies = Cookies();
+    cookies.set('foo', 'bar', { encrypt: true, signed: true });
+    const cookie = cookies.ctx.response.headers['set-cookie'].join(';');
+    cookies.ctx.request.headers.cookie = cookie;
+    const value = cookies.get('foo', { encrypt: true });
+    assert(value, 'bar');
+    assert(cookie.indexOf('bar') === -1);
+    assert(cookie.indexOf('sig') === -1);
+  });
+
+  it('should work with secure ok', () => {
+    const cookies = Cookies(
+      {},
+      {
+        secure: true,
+      }
+    );
+    cookies.set('foo', 'bar', { encrypt: true });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    assert(cookie.indexOf('secure') > 0);
+  });
+
+  it('should work with domain ok, when domain is a function', () => {
+    const cookies = Cookies(
+      {},
+      {
+        secure: true,
+      }
+    );
+    cookies.set('foo', 'bar', { encrypt: true, domain: () => 'foo.com' });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    assert(cookie.indexOf('domain=foo.com') > 0);
+  });
+
+  it('should work with domain is empty string', () => {
+    const cookies = Cookies(
+      {},
+      {
+        secure: true,
+      }
+    );
+    cookies.set('foo', 'bar', { encrypt: true, domain: '' });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    assert.equal(cookie, 'foo=SBfi5dnMSwNmMdeydI_zdw==; path=/; secure; httponly');
+  });
+
+  it('should work with domain is string', () => {
+    const cookies = Cookies(
+      {},
+      {
+        secure: true,
+      }
+    );
+    cookies.set('foo', 'bar', { encrypt: true, domain: 'foo.com' });
+    const cookie = cookies.ctx.response.headers['set-cookie'][0];
+    assert(cookie.indexOf('domain=foo.com') > 0);
+  });
+
+  it('should signed work fine', () => {
+    const cookies = Cookies();
+    cookies.set('foo', 'bar', { signed: true });
+    const cookie = cookies.ctx.response.headers['set-cookie'].join(';');
+    assert(cookie.indexOf('foo=bar') >= 0);
+    assert(cookie.indexOf('foo.sig=') >= 0);
+    cookies.ctx.request.headers.cookie = cookie;
+    let value = cookies.get('foo', { signed: true });
+    assert(value === 'bar');
+    cookies.ctx.request.headers.cookie = cookie.replace('foo=bar', 'foo=bar1');
+    value = cookies.get('foo', { signed: true });
+    assert(!value);
+    value = cookies.get('foo', { signed: false });
+    assert(value === 'bar1');
+  });
+
+  it('should return undefined when header.cookie not exists', () => {
+    const cookies = Cookies();
+    assert(cookies.get('hello') === undefined);
+  });
+
+  it('should return undefined when cookie not exists', () => {
+    const cookies = Cookies({
+      headers: { cookie: 'foo=bar' },
+    });
+    assert(cookies.get('hello') === undefined);
+  });
+
+  it('should return undefined when signed and name.sig not exists', () => {
+    const cookies = Cookies({
+      headers: { cookie: 'foo=bar;' },
+    });
+    assert(cookies.get('foo', { signed: true }) === undefined);
+    assert(cookies.get('foo', { signed: false }) === 'bar');
+    assert(cookies.get('foo') === undefined);
+  });
+
+  it('should set .sig to null if not match', () => {
+    const cookies = Cookies({
+      headers: { cookie: 'foo=bar;foo.sig=bar.sig;' },
+    });
+    assert(cookies.get('foo', { signed: true }) === undefined);
+    assert(
+      cookies.ctx.response.headers['set-cookie'][0] ===
+        'foo.sig=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly'
+    );
+  });
+
+  it('should update .sig if not match the first key', () => {
+    const cookies = Cookies(
+      {
+        headers: { cookie: 'foo=bar;foo.sig=bar.sig;' },
+      },
+      { keys: ['hello', 'world'] }
+    );
+    cookies.set('foo', 'bar');
+    const cookie = cookies.ctx.response.headers['set-cookie'].join(';');
+
+    const newCookies = Cookies(
+      {
+        headers: { cookie },
+      },
+      { keys: ['hi', 'hello'] }
+    );
+
+    assert(newCookies.get('foo', { signed: true }) === 'bar');
+    // call twice but should only update once
+    newCookies.get('foo', { signed: true });
+    assert(newCookies.ctx.response.headers['set-cookie'].length === 1);
+    const newSign = newCookies.keys.sign('foo=bar');
+    assert(newCookies.ctx.response.headers['set-cookie'][0].startsWith(`foo.sig=${newSign}`));
+  });
+
+  it('should not overwrite default', () => {
+    const cookies = Cookies();
+    cookies.set('foo', 'bar');
+    cookies.set('foo', 'hello');
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=bar/));
+  });
+
+  it('should overwrite when opts.overwrite = true', () => {
+    const cookies = Cookies();
+    cookies.set('foo', 'bar');
+    cookies.set('foo', 'hello', { overwrite: true });
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+  });
+
+  it('should remove signed cookie ok', () => {
+    const cookies = Cookies();
+    cookies.set('foo', null, { signed: true });
+    assert(
+      cookies.ctx.response.headers['set-cookie']
+        .join(';')
+        .match(/foo=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly/)
+    );
+    assert(
+      cookies.ctx.response.headers['set-cookie']
+        .join(';')
+        .match(/foo\.sig=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly/)
+    );
+  });
+
+  it('should remove encrypt cookie ok', () => {
+    const cookies = Cookies();
+    cookies.set('foo', null, { encrypt: true });
+    assert(
+      cookies.ctx.response.headers['set-cookie']
+        .join(';')
+        .match(/foo=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly/)
+    );
+  });
+
+  it('should remove cookie ok event it set maxAge', () => {
+    const cookies = Cookies();
+    cookies.set('foo', null, { signed: true, maxAge: 1200 });
+    assert(
+      cookies.ctx.response.headers['set-cookie']
+        .join(';')
+        .match(/foo=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly/)
+    );
+    assert(
+      cookies.ctx.response.headers['set-cookie']
+        .join(';')
+        .match(/foo\.sig=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly/)
+    );
+  });
+
+  it('should add secure when ctx.secure = true', () => {
+    const cookies = Cookies({}, { secure: true });
+    cookies.set('foo', 'bar');
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/secure;/));
+  });
+
+  it('should not add secure when ctx.secure = true but opt.secure = false', () => {
+    const cookies = Cookies({}, { secure: true });
+    cookies.set('foo', 'bar', { secure: false });
+    assert(!cookies.ctx.response.headers['set-cookie'].join(';').match(/secure;/));
+  });
+
+  it('should throw when ctx.secure = false but opt.secure = true', () => {
+    const cookies = Cookies({}, { secure: false });
+    try {
+      cookies.set('foo', 'bar', { secure: true });
+      throw new Error('should not exec');
+    } catch (err) {
+      assert(err instanceof CookieError);
+      assert(err.message === 'Cannot send secure cookie over unencrypted connection');
+    }
+  });
+
+  it('should set cookie success when set-cookie already exist', () => {
+    const cookies = Cookies();
+    cookies.ctx.response.headers['set-cookie'] = 'foo=bar';
+    cookies.set('foo1', 'bar1');
+    assert(cookies.ctx.response.headers['set-cookie'][0] === 'foo=bar');
+    assert(cookies.ctx.response.headers['set-cookie'][1] === 'foo1=bar1; path=/; httponly');
+    assert(
+      cookies.ctx.response.headers['set-cookie'][2] ===
+        'foo1.sig=_OGF14M_XqPTd58nMRUco2iwwhlZvq7h8ifl3Kej_jg; path=/; httponly'
+    );
+  });
+
+  it('should emit cookieLimitExceed event in app when value length exceed the limit', () => {
+    const cookies = Cookies();
+    const value = Buffer.alloc(4094).fill(49).toString();
+    const emit = vi.spyOn(cookies.app, 'emit');
+    cookies.set('foo', value);
+
+    expect(emit.mock.calls.length).toBe(1);
+    expect(emit.mock.calls[0][0]).toBe('cookieLimitExceed');
+    expect(emit.mock.calls[0][1]).toEqual({
+      name: 'foo',
+      value,
+      ctx: cookies.ctx,
+    });
+    expect(cookies.ctx.response.headers['set-cookie'][0]).toMatch(/^foo=1{4094}; path=\/; httponly$/);
+  });
+
+  it('should opts do not modify', () => {
+    const cookies = Cookies({ secure: true });
+    const opts: CookieSetOptions = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+  });
+
+  it('should defaultCookieOptions with sameSite=lax', () => {
+    const cookies = Cookies({ secure: true }, null, { sameSite: 'lax' });
+    const opts: CookieSetOptions = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; samesite=lax; httponly'));
+    }
+  });
+
+  it('should not send SameSite=None property on incompatible clients', () => {
+    const userAgents = [
+      'Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/64.0.3282.140 Safari/537.36',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3165.0 Safari/537.36',
+      'Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; OE106 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML%2C like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/11.9.4.974 UWS/2.13.2.90 Mobile Safari/537.36 AliApp(DingTalk/4.7.18) com.alibaba.android.rimet/12362010 Channel/1565683214685 language/zh-CN UT4Aplus/0.2.25',
+      'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/63.0.3239.132 Safari/537.36 dingtalk-win/1.0.0 nw(0.14.7) DingTalk(4.7.19-Release.16) Mojo/1.0.0 Native AppType(release)',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/62.0.3202.94 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/52.0.2723.2 Safari/537.36',
+    ];
+    for (const ua of userAgents) {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent': ua,
+          },
+        },
+        { secure: true },
+        { sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; secure; httponly'));
+      }
+    }
+  });
+
+  it('should not send SameSite=None property on Chrome < 80', () => {
+    const cookies = Cookies(
+      {
+        secure: true,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.29 Safari/537.36',
+        },
+      },
+      { secure: true },
+      { sameSite: 'None' }
+    );
+    const opts: CookieSetOptions = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; secure; httponly'));
+    }
+  });
+
+  it('should send SameSite=None property on Chrome >= 80', () => {
+    let cookies = Cookies(
+      {
+        secure: true,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3945.29 Safari/537.36',
+        },
+      },
+      { secure: true },
+      { sameSite: 'None' }
+    );
+    const opts: CookieSetOptions = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; samesite=none; secure; httponly'));
+    }
+
+    cookies = Cookies(
+      {
+        secure: true,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.3945.29 Safari/537.36',
+        },
+      },
+      { secure: true },
+      { sameSite: 'None' }
+    );
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; samesite=none; secure; httponly'));
+    }
+  });
+
+  it('should send SameSite=none property on compatible clients', () => {
+    const cookies = Cookies(
+      {
+        secure: true,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/66.6 Mobile/14A5297c Safari/602.1',
+        },
+      },
+      { secure: true },
+      { sameSite: 'none' }
+    );
+
+    const opts: CookieSetOptions = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; samesite=none; secure; httponly'));
+    }
+  });
+
+  it('should not send SameSite=none property on non-secure context', () => {
+    const cookies = Cookies(
+      {
+        secure: false,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.3945.29 Safari/537.36',
+        },
+      },
+      null,
+      { sameSite: 'none' }
+    );
+    const opts: CookieSetOptions = {
+      signed: 1,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === undefined);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; httponly'));
+    }
+  });
+
+  it('should not send SameSite=none property on options.secure = false', () => {
+    const cookies = Cookies(
+      {
+        secure: true,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/66.6 Mobile/14A5297c Safari/602.1',
+        },
+      },
+      { secure: true },
+      { sameSite: 'none' }
+    );
+
+    const opts: CookieSetOptions = {
+      signed: 1,
+      secure: false,
+    };
+    cookies.set('foo', 'hello', opts);
+
+    assert(opts.signed === 1);
+    assert(opts.secure === false);
+    assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+    for (const str of cookies.ctx.response.headers['set-cookie']) {
+      assert(str.includes('; path=/; httponly'));
+    }
+  });
+
+  describe('opts.partitioned', () => {
+    it('should not send partitioned property on incompatible clients', () => {
+      const userAgents = [
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/62.0.3202.94 Safari/537.36',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/52.0.2723.2 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/100.36 (KHTML, like Gecko) Safari/100.36',
+      ];
+      for (const ua of userAgents) {
+        const cookies = Cookies(
+          {
+            secure: true,
+            headers: {
+              'user-agent': ua,
+            },
+          },
+          { secure: true },
+          { partitioned: true, sameSite: 'None' }
+        );
+        const opts: CookieSetOptions = {
+          signed: 1,
+        };
+        cookies.set('foo', 'hello', opts);
+
+        assert(opts.signed === 1);
+        assert(opts.secure === undefined);
+        assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+        for (const str of cookies.ctx.response.headers['set-cookie']) {
+          assert(!str.includes('partitioned'));
+        }
+      }
+    });
+
+    it('should not send partitioned property on Chrome < 118', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; samesite=none; secure; httponly'));
+      }
+    });
+
+    it('should send partitioned property on Chrome >= 118', () => {
+      let cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; samesite=none; secure; httponly; partitioned'));
+      }
+
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, sameSite: 'None' }
+      );
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; samesite=none; secure; httponly; partitioned'));
+      }
+
+      // empty user-agent
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent': '',
+          },
+        },
+        { secure: true },
+        { partitioned: true, sameSite: 'None' }
+      );
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; samesite=none; secure; httponly; partitioned'));
+      }
+
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent': '',
+          },
+        },
+        { secure: true }
+      );
+      cookies.set('foo', 'hello', {
+        sameSite: 'None',
+        partitioned: true,
+      });
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; samesite=none; secure; httponly; partitioned'));
+      }
+    });
+
+    it('should not send SameSite=none property on non-secure context', () => {
+      const cookies = Cookies(
+        {
+          secure: false,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.3945.29 Safari/537.36',
+          },
+        },
+        null,
+        { partitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; httponly'));
+      }
+    });
+
+    it('should remove unpartitioned property first', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      // console.log(headers);
+      assert.equal(headers.length, 4);
+      assert.equal(headers[0], 'foo=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly');
+      assert.equal(
+        headers[1],
+        'foo.sig=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly'
+      );
+      assert.equal(headers[2], 'foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        headers[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly; partitioned'
+      );
+    });
+
+    it('should remove unpartitioned property first when opts.secure = true and signed = false', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        secure: true,
+        signed: false,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === false);
+      assert(opts.secure === true);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      // console.log(headers);
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], 'foo=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly');
+      assert.equal(headers[1], 'foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+    });
+
+    it('should remove unpartitioned property first with overwrite = true', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true, overwrite: true, sameSite: 'none' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello2222', opts);
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(headers.length, 4);
+      assert.equal(headers[0], 'foo=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly');
+      assert.equal(
+        headers[1],
+        'foo.sig=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly'
+      );
+      assert.equal(headers[2], 'foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        headers[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly; partitioned'
+      );
+    });
+
+    it('should not set partitioned property when secure = false', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+        secure: false,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], 'foo=hello; path=/; httponly');
+      assert.equal(headers[1], 'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; httponly');
+    });
+
+    it('should not set partitioned property when sameSite != none', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], 'foo=hello; path=/; secure; httponly');
+      assert.equal(headers[1], 'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; secure; httponly');
+    });
+  });
+
+  describe('defaultCookieOptions.autoChips = true', () => {
+    it('should not send partitioned property on incompatible clients', () => {
+      const userAgents = [
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/62.0.3202.94 Safari/537.36',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML%2C like Gecko) Chrome/52.0.2723.2 Safari/537.36',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/100.36 (KHTML, like Gecko) Safari/100.36',
+      ];
+      for (const ua of userAgents) {
+        const cookies = Cookies(
+          {
+            secure: true,
+            headers: {
+              'user-agent': ua,
+            },
+          },
+          { secure: true },
+          { autoChips: true, sameSite: 'None' }
+        );
+        const opts: CookieSetOptions = {
+          signed: 1,
+        };
+        cookies.set('foo', 'hello', opts);
+
+        assert(opts.signed === 1);
+        assert(opts.secure === undefined);
+        assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+        for (const str of cookies.ctx.response.headers['set-cookie']) {
+          assert(!str.includes('partitioned'));
+        }
+      }
+    });
+
+    it('should not send partitioned property on Chrome < 118', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; samesite=none; secure; httponly'));
+      }
+    });
+
+    it('should send partitioned property on Chrome >= 118', () => {
+      let cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      let setCookies = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(setCookies.length, 4);
+      assert.equal(setCookies[0], '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        setCookies[1],
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/; samesite=none; secure; httponly; partitioned'
+      );
+      assert.equal(setCookies[2], 'foo=hello; path=/; samesite=none; secure; httponly');
+      assert.equal(
+        setCookies[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly'
+      );
+
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, sameSite: 'None' }
+      );
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      setCookies = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(setCookies[0], '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        setCookies[1],
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/; samesite=none; secure; httponly; partitioned'
+      );
+      assert.equal(setCookies[2], 'foo=hello; path=/; samesite=none; secure; httponly');
+      assert.equal(
+        setCookies[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly'
+      );
+
+      // empty user-agent
+      // disable autoChips if partitioned enable
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent': '',
+          },
+        },
+        { secure: true },
+        { autoChips: true, partitioned: true, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      setCookies = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(
+        setCookies[0],
+        'foo=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly'
+      );
+      assert.equal(
+        setCookies[1],
+        'foo.sig=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly'
+      );
+      assert.equal(setCookies[2], 'foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        setCookies[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly; partitioned'
+      );
+
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent': '',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      cookies.set('foo', 'hello', {
+        sameSite: 'None',
+        // ignore removeUnpartitioned options
+        removeUnpartitioned: true,
+      });
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      setCookies = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(setCookies[0], '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        setCookies[1],
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/; samesite=none; secure; httponly; partitioned'
+      );
+      assert.equal(setCookies[2], 'foo=hello; path=/; samesite=none; secure; httponly');
+      assert.equal(
+        setCookies[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly'
+      );
+
+      // read from cookie
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            cookie:
+              '_CHIPS-foo=hello; _CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; foo=hello; foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      assert.equal(cookies.get('foo'), 'hello');
+      assert.equal(cookies.get('_CHIPS-foo'), 'hello');
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            cookie: '_CHIPS-foo=hello; _CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      assert.equal(cookies.get('foo', { signed: true }), 'hello');
+      assert.equal(cookies.get('foo', { signed: false }), 'hello');
+      assert.equal(cookies.get('foo'), 'hello');
+
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            cookie: '_CHIPS-foo=hello; _CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk-invalid',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      assert.equal(cookies.get('foo', { signed: true }), undefined);
+      assert.equal(cookies.get('foo', { signed: false }), 'hello');
+      assert.equal(cookies.get('foo'), undefined);
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            cookie: '_CHIPS-foo=hello',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      assert.equal(cookies.get('foo', { signed: true }), undefined);
+      assert.equal(cookies.get('foo', { signed: false }), 'hello');
+      assert.equal(cookies.get('foo'), undefined);
+      cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            cookie: '_CHIPS-foo=hello; foo=',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      assert.equal(cookies.get('foo', { signed: true }), undefined);
+      assert.equal(cookies.get('foo', { signed: false }), '');
+      assert.equal(cookies.get('foo'), undefined);
+    });
+
+    it('should not send SameSite=none property on non-secure context', () => {
+      const cookies = Cookies(
+        {
+          secure: false,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.3945.29 Safari/537.36',
+          },
+        },
+        null,
+        { autoChips: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      assert(cookies.ctx.response.headers['set-cookie'].join(';').match(/foo=hello/));
+      for (const str of cookies.ctx.response.headers['set-cookie']) {
+        assert(str.includes('; path=/; httponly'));
+      }
+    });
+
+    it('should disable autoChips when partitioned=true', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, partitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      // console.log(headers);
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], 'foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        headers[1],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly; partitioned'
+      );
+    });
+
+    it('should ignore remove unpartitioned property', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, partitioned: false, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      // console.log(headers);
+      assert.equal(headers.length, 4);
+      assert.equal(headers[0], '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        headers[1],
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/; samesite=none; secure; httponly; partitioned'
+      );
+      assert.equal(headers[2], 'foo=hello; path=/; samesite=none; secure; httponly');
+      assert.equal(
+        headers[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly'
+      );
+    });
+
+    it('should ignore remove unpartitioned property with different paths', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, partitioned: false, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+      cookies.set('foo', 'hello', {
+        ...opts,
+        path: '/path2',
+      });
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.deepEqual(headers, [
+        '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned',
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/; samesite=none; secure; httponly; partitioned',
+        'foo=hello; path=/; samesite=none; secure; httponly',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly',
+        '_CHIPS-foo=hello; path=/path2; samesite=none; secure; httponly; partitioned',
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/path2; samesite=none; secure; httponly; partitioned',
+        'foo=hello; path=/path2; samesite=none; secure; httponly',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/path2; samesite=none; secure; httponly',
+      ]);
+    });
+
+    it('should ignore remove unpartitioned property when autoChips = true and signed = false', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, partitioned: false, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        secure: true,
+        signed: false,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === false);
+      assert(opts.secure === true);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      // console.log(headers);
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(headers[1], 'foo=hello; path=/; samesite=none; secure; httponly');
+    });
+
+    it('should work on unpartitioned = true and partitioned = true with different paths', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      cookies.set('foo', 'hello', {
+        signed: 1,
+      });
+      cookies.set('foo', 'hello', {
+        signed: 1,
+        path: '/path1',
+      });
+      cookies.set('foo', 'hello', {
+        signed: 1,
+        path: '/path2',
+      });
+      cookies.set('foo', 'hello', {
+        signed: 1,
+        path: '/path3',
+      });
+
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.deepEqual(headers, [
+        'foo=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo.sig=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/; samesite=none; secure; httponly; partitioned',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly; partitioned',
+        'foo=; path=/path1; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo.sig=; path=/path1; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/path1; samesite=none; secure; httponly; partitioned',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/path1; samesite=none; secure; httponly; partitioned',
+        'foo=; path=/path2; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo.sig=; path=/path2; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/path2; samesite=none; secure; httponly; partitioned',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/path2; samesite=none; secure; httponly; partitioned',
+        'foo=; path=/path3; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo.sig=; path=/path3; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/path3; samesite=none; secure; httponly; partitioned',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/path3; samesite=none; secure; httponly; partitioned',
+      ]);
+    });
+
+    it('should work on unpartitioned = true and partitioned = true with different null path', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { partitioned: true, removeUnpartitioned: true, sameSite: 'None' }
+      );
+      cookies.set('foo', 'hello', {
+        signed: 1,
+      });
+      cookies.set('foo', 'hello', {
+        signed: 1,
+        path: '/path1',
+      });
+      cookies.set('foo', 'hello', {
+        signed: 1,
+        path: '/path2',
+      });
+      cookies.set('foo', 'hello', {
+        signed: 1,
+        path: null,
+      });
+
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.deepEqual(headers, [
+        'foo=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/; samesite=none; secure; httponly; partitioned',
+        'foo=; path=/path1; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/path1; samesite=none; secure; httponly; partitioned',
+        'foo=; path=/path2; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; path=/path2; samesite=none; secure; httponly; partitioned',
+        'foo=; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo.sig=; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=none; secure; httponly',
+        'foo=hello; samesite=none; secure; httponly; partitioned',
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; samesite=none; secure; httponly; partitioned',
+      ]);
+    });
+
+    it('should work with overwrite = true', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, overwrite: true, sameSite: 'none' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello2222', opts);
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      assert(opts.secure === undefined);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(headers.length, 4);
+      assert.equal(headers[0], '_CHIPS-foo=hello; path=/; samesite=none; secure; httponly; partitioned');
+      assert.equal(
+        headers[1],
+        '_CHIPS-foo.sig=G4Idm9Wdp_vfCnUbOpQG284o22SgTe88SUmG6QW1ylk; path=/; samesite=none; secure; httponly; partitioned'
+      );
+      assert.equal(headers[2], 'foo=hello; path=/; samesite=none; secure; httponly');
+      assert.equal(
+        headers[3],
+        'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; samesite=none; secure; httponly'
+      );
+    });
+
+    it('should not set partitioned property when secure = false', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true, sameSite: 'None' }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+        secure: false,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], 'foo=hello; path=/; httponly');
+      assert.equal(headers[1], 'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; httponly');
+    });
+
+    it('should not set partitioned property when sameSite != none', () => {
+      const cookies = Cookies(
+        {
+          secure: true,
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.3945.29 Safari/537.36',
+          },
+        },
+        { secure: true },
+        { autoChips: true }
+      );
+      const opts: CookieSetOptions = {
+        signed: 1,
+      };
+      cookies.set('foo', 'hello', opts);
+
+      assert(opts.signed === 1);
+      const headers = cookies.ctx.response.headers['set-cookie'];
+      assert.equal(headers.length, 2);
+      assert.equal(headers[0], 'foo=hello; path=/; secure; httponly');
+      assert.equal(headers[1], 'foo.sig=ZWbaA4bWk8ByBuYVgfmJ2DMvhhS3sOctMbfXAQ2vnwI; path=/; secure; httponly');
+    });
+  });
+});

--- a/packages/cookies/test/cookies.ts
+++ b/packages/cookies/test/cookies.ts
@@ -1,0 +1,39 @@
+import { EventEmitter } from 'node:events';
+
+import { Cookies, type DefaultCookieOptions } from '../src/index.ts';
+
+export default function createCookie(
+  req?: any,
+  options?: { keys?: string[] | null; secure?: boolean } | null,
+  defaultCookieOptions?: DefaultCookieOptions
+) {
+  options = options || {};
+  let keys = options.keys;
+  keys = keys === undefined ? ['key', 'keys'] : keys;
+  const ctx: Record<string, any> = {
+    secure: options.secure,
+    app: new EventEmitter(),
+  };
+  ctx.request = {
+    headers: {},
+    get(key: string) {
+      return this.headers[key];
+    },
+    ...req,
+  };
+
+  ctx.response = {
+    headers: {},
+    get(key: string) {
+      return this.headers[key];
+    },
+    set(key: string, value: string) {
+      this.headers[key] = value;
+    },
+  };
+
+  ctx.get = ctx.request.get.bind(ctx.request);
+  ctx.set = ctx.response.set.bind(ctx.response);
+
+  return new Cookies(ctx, keys as any, defaultCookieOptions);
+}

--- a/packages/cookies/test/keygrip.test.ts
+++ b/packages/cookies/test/keygrip.test.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from 'node:assert';
+import crypto from 'node:crypto';
+
+import { describe, it } from 'vitest';
+
+import { Keygrip } from '../src/index.ts';
+
+describe('test/keygrip.test.ts', () => {
+  it('should throw without keys', () => {
+    assert.throws(() => {
+      new (Keygrip as any)();
+    }, /keys must be provided and should be an array/);
+    assert.throws(() => {
+      new Keygrip([]);
+    }, /keys must be provided and should be an array/);
+    assert.throws(() => {
+      new Keygrip('hello' as any);
+    }, /keys must be provided and should be an array/);
+  });
+
+  it('should encrypt and decrypt success', () => {
+    const keygrip = new Keygrip(['foo', 'bar']);
+    const newKeygrip = new Keygrip(['another', 'foo']);
+
+    const encrypted = keygrip.encrypt('hello');
+    const result = keygrip.decrypt(encrypted);
+    assert(result);
+    assert.equal(result.value.toString(), 'hello');
+    assert.equal(result.index, 0);
+    const result2 = newKeygrip.decrypt(encrypted);
+    assert(result2);
+    assert.equal(result2.value.toString(), 'hello');
+    assert.equal(result2.index, 1);
+  });
+
+  it('should decrypt error return false', () => {
+    const keygrip = new Keygrip(['foo', 'bar']);
+    const newKeygrip = new Keygrip(['another']);
+
+    const encrypted = keygrip.encrypt('hello');
+    const result = keygrip.decrypt(encrypted);
+    assert(result);
+    assert.equal(result.value.toString(), 'hello');
+    assert.equal(result.index, 0);
+    assert.equal(newKeygrip.decrypt(encrypted), false);
+  });
+
+  it.skipIf(!('createCipher' in crypto))('should decrypt key encrypted by createCipher without error', () => {
+    const keygrip = new Keygrip(['foo']);
+    const encrypted = keygrip.encrypt('hello');
+
+    // @ts-expect-error crypto.createCipher is deprecated
+    const cipher = crypto.createCipher('aes-256-cbc', 'foo');
+    const text = cipher.update('hello', 'utf8');
+    const oldEncrypted = Buffer.concat([text, cipher.final()]);
+
+    assert.equal(encrypted.toString('hex'), oldEncrypted.toString('hex'));
+    const result = keygrip.decrypt(oldEncrypted);
+    assert(result);
+    assert.equal(result.value.toString('utf-8'), 'hello');
+  });
+
+  it('should signed and verify success', () => {
+    const keygrip = new Keygrip(['foo', 'bar']);
+    const newKeygrip = new Keygrip(['another', 'foo']);
+
+    const signed = keygrip.sign('hello');
+    assert.equal(keygrip.verify('hello', signed), 0);
+    assert.equal(newKeygrip.verify('hello', signed), 1);
+  });
+
+  it('should signed and verify failed return -1', () => {
+    const keygrip = new Keygrip(['foo', 'bar']);
+    const newKeygrip = new Keygrip(['another']);
+
+    const signed = keygrip.sign('hello');
+    assert.equal(keygrip.verify('hello', signed), 0);
+    assert.equal(newKeygrip.verify('hello', signed), -1);
+  });
+});

--- a/packages/cookies/tsconfig.json
+++ b/packages/cookies/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  }
+}

--- a/packages/cookies/tsdown.config.ts
+++ b/packages/cookies/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+  },
+  unbundle: true,
+  dts: true,
+  exports: {
+    devExports: true,
+  },
+});

--- a/packages/cookies/vitest.config.ts
+++ b/packages/cookies/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -116,7 +116,7 @@
   ],
   "dependencies": {
     "@eggjs/cluster": "workspace:*",
-    "@eggjs/cookies": "catalog:",
+    "@eggjs/cookies": "workspace:*",
     "@eggjs/core": "workspace:*",
     "@eggjs/development": "workspace:*",
     "@eggjs/extend2": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,6 @@ catalogs:
     '@clack/prompts':
       specifier: ^0.11.0
       version: 0.11.0
-    '@eggjs/cookies':
-      specifier: ^3.1.0
-      version: 3.1.0
     '@eggjs/i18n':
       specifier: ^3.0.1
       version: 3.0.1
@@ -168,6 +165,12 @@ catalogs:
     await-event:
       specifier: '2'
       version: 2.1.0
+    beautify-benchmark:
+      specifier: ^0.2.4
+      version: 0.2.4
+    benchmark:
+      specifier: ^2.1.4
+      version: 2.1.4
     body-parser:
       specifier: ^2.0.0
       version: 2.2.0
@@ -315,6 +318,9 @@ catalogs:
     js-yaml:
       specifier: ^4.1.0
       version: 4.1.0
+    keygrip:
+      specifier: ^1.0.2
+      version: 1.1.0
     koa-bodyparser:
       specifier: ^4.4.1
       version: 4.4.1
@@ -405,6 +411,9 @@ catalogs:
     sendmessage:
       specifier: ^3.0.1
       version: 3.0.1
+    should-send-same-site-none:
+      specifier: ^2.0.5
+      version: 2.0.5
     spy:
       specifier: ^1.0.0
       version: 1.0.0
@@ -612,6 +621,43 @@ importers:
         specifier: 'catalog:'
         version: 4.0.0-beta.13(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@4.0.0-beta.13)(esbuild@0.25.10)(jiti@2.6.0)(less@4.4.1)(sass@1.93.1)(terser@5.44.0)(yaml@2.8.1)
 
+  packages/cookies:
+    dependencies:
+      should-send-same-site-none:
+        specifier: 'catalog:'
+        version: 2.0.5
+      utility:
+        specifier: 'catalog:'
+        version: 2.5.0
+    devDependencies:
+      '@eggjs/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.5.2
+      beautify-benchmark:
+        specifier: 'catalog:'
+        version: 0.2.4
+      benchmark:
+        specifier: 'catalog:'
+        version: 2.1.4
+      cookies:
+        specifier: 'catalog:'
+        version: 0.9.1
+      keygrip:
+        specifier: 'catalog:'
+        version: 1.1.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.18.0(oxlint-tsgolint@0.2.0)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.4(oxc-resolver@11.8.3)(typescript@5.9.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+
   packages/core:
     dependencies:
       '@eggjs/extend2':
@@ -712,8 +758,8 @@ importers:
         specifier: workspace:*
         version: link:../cluster
       '@eggjs/cookies':
-        specifier: 'catalog:'
-        version: 3.1.0
+        specifier: workspace:*
+        version: link:../cookies
       '@eggjs/core':
         specifier: workspace:*
         version: link:../core
@@ -4556,6 +4602,12 @@ packages:
   baseline-browser-mapping@2.8.6:
     resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
     hasBin: true
+
+  beautify-benchmark@0.2.4:
+    resolution: {integrity: sha512-LZiZ6wl0Rs+A4Xv9Vn9W5GOVrBmPlWLP/ns5GszjRCoyQ5gFyLoJ8bCJuVS8fo88Ww+TWF/8UrGEHYnypgp3dQ==}
+
+  benchmark@2.1.4:
+    resolution: {integrity: sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==}
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -8617,6 +8669,9 @@ packages:
   pkce-challenge@5.0.0:
     resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   plur@4.0.0:
     resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}
@@ -14502,6 +14557,13 @@ snapshots:
 
   baseline-browser-mapping@2.8.6: {}
 
+  beautify-benchmark@0.2.4: {}
+
+  benchmark@2.1.4:
+    dependencies:
+      lodash: 4.17.21
+      platform: 1.3.6
+
   big-integer@1.6.52: {}
 
   big.js@5.2.2: {}
@@ -19619,6 +19681,8 @@ snapshots:
       '@napi-rs/nice': 1.1.1
 
   pkce-challenge@5.0.0: {}
+
+  platform@1.3.6: {}
 
   plur@4.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,6 @@ packages:
 
 catalog:
   '@clack/prompts': ^0.11.0
-  '@eggjs/cookies': ^3.1.0
   '@eggjs/i18n': ^3.0.1
   '@eggjs/jsonp': ^3.0.0
   '@eggjs/logrotator': ^4.0.0
@@ -60,6 +59,8 @@ catalog:
   address: '2'
   assert-file: '1'
   await-event: '2'
+  beautify-benchmark: ^0.2.4
+  benchmark: ^2.1.4
   body-parser: ^2.0.0
   c8: 10.1.3
   cache-content-type: ^2.0.0
@@ -94,6 +95,7 @@ catalog:
   esbuild: ^0.25.0
   esbuild-register: ^3.6.0
   escape-html: ^1.0.3
+  eslint: ^8.57.0
   eslint-config-egg: '14'
   execa: ^9.6.0
   express: ^4.21.2
@@ -110,6 +112,7 @@ catalog:
   is-type-of: ^2.2.0
   jest-changed-files: ^30.0.0
   js-yaml: ^4.1.0
+  keygrip: ^1.0.2
   koa-bodyparser: ^4.4.1
   koa-compose: ^4.1.0
   koa-onerror: ^5.0.1
@@ -137,6 +140,7 @@ catalog:
   ready-callback: ^4.0.0
   rimraf: ^6.0.1
   runscript: ^2.0.1
+  should-send-same-site-none: ^2.0.5
   sdk-base: ^5.0.1
   semver: ^7.7.2
   sendmessage: ^3.0.1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "./tools/create-egg"
     },
     {
+      "path": "./packages/cookies"
+    },
+    {
       "path": "./plugins/development"
     },
     {


### PR DESCRIPTION
- Move @eggjs/cookies from tools/ to packages/ directory
- Update to version 4.0.0-beta.11
- Replace ESLint with oxlint for linting
- Add tsc --noEmit for TypeScript type checking
- Update CLAUDE.md documentation to reflect oxlint usage
- Configure package for monorepo integration with workspace dependencies

BREAKING CHANGE: cookies package now uses oxlint instead of ESLint

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced @eggjs/cookies with signing, optional encryption, SameSite handling, CHIPS/partitioned cookies, and cookie size limit event.
- Documentation
  - Added comprehensive package README (EN/zh-CN), CHANGELOG, LICENSE.
  - Updated monorepo docs: linting/type-check strategy, oxlint migration guide, testing notes, TypeScript/Vitest guidance.
- Tests
  - Added extensive unit tests for cookies, cookie serialization, and key handling.
- Chores
  - Added package configs (package.json, tsconfig, vitest, tsdown, .gitignore), benchmarks.
  - Updated workspace/dependencies and TypeScript project references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->