### PR TITLE
chore: require Node.js >=22.18.0 for all packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 4.1.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [4.1.0](https://github.com/eggjs/egg/compare/v4.0.10...v4.1.0) (2025-08-31)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@ This is the **Eggjs** framework - a progressive Node.js framework for building e
 
 **This project is structured as a pnpm monorepo** with multiple packages and uses pnpm workspaces for dependency management.
 
+### Node.js Requirements
+
+**IMPORTANT: All packages in this monorepo require Node.js >= 22.18.0**. This minimum version is enforced across all packages to ensure compatibility with modern JavaScript features and optimal performance.
+
+> Node.js will be able to execute TypeScript files without additional configuration. See https://nodejs.org/en/blog/release/v22.18.0
+
 ## Monorepo Structure
 
 ### Packages
@@ -586,7 +592,7 @@ NODE_OPTIONS='--inspect-brk' pnpm --filter=egg run test
 
 ### Migrating from Egg v2 to v3
 
-1. Update Node.js to v14+ (v18+ recommended)
+1. Update Node.js to v22.18.0+ (required minimum version)
 2. Migrate to ESM syntax where applicable
 3. Update plugin configurations
 4. Review breaking changes in CHANGELOG.md

--- a/examples/helloworld-commonjs/package.json
+++ b/examples/helloworld-commonjs/package.json
@@ -22,6 +22,6 @@
     "stop": "egg-scripts stop"
   },
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   }
 }

--- a/examples/helloworld-typescript/package.json
+++ b/examples/helloworld-typescript/package.json
@@ -26,6 +26,6 @@
     "stop": "egg-scripts stop"
   },
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@eggjs/monorepo",
-  "version": "4.1.0-beta.11",
+  "version": "4.2.0-beta.11",
   "private": true,
   "description": "Eggjs framework monorepo",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "type": "module",
   "packageManager": "pnpm@10.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/monorepo",
-  "version": "4.2.0-beta.11",
+  "version": "4.1.0-beta.11",
   "private": true,
   "description": "Eggjs framework monorepo",
   "engines": {

--- a/packages/cluster/CHANGELOG.md
+++ b/packages/cluster/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 4.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [3.0.1](https://github.com/eggjs/cluster/compare/v3.0.0...v3.0.1) (2024-12-30)
 
 

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cluster",
-  "version": "3.1.0-beta.11",
+  "version": "4.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -73,6 +73,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   }
 }

--- a/packages/cookies/CHANGELOG.md
+++ b/packages/cookies/CHANGELOG.md
@@ -7,10 +7,12 @@
 
 ## 4.0.0+
 
-### ⚠ BREAKING CHANGES
+* drop Node.js < 22.18.0 support
+* only support egg@4
 
-* drop Node.js < 20.19.0 support
+part of https://github.com/eggjs/egg/issues/5434
 
+---
 
 ## [3.1.0](https://github.com/eggjs/egg-cookies/compare/v3.0.1...v3.1.0) (2024-12-26)
 

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -2,7 +2,7 @@
   "name": "@eggjs/cookies",
   "version": "4.0.0-beta.11",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 7.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [6.5.0](https://github.com/eggjs/core/compare/v6.4.1...v6.5.0) (2025-03-28)
 
 ### Features

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core",
-  "version": "6.6.0-beta.11",
+  "version": "7.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -20,7 +20,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "description": "A core plugin framework based on @eggjs/koa",
   "scripts": {

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -2,7 +2,7 @@
   "name": "egg",
   "version": "4.1.0-beta.11",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/extend2/CHANGELOG.md
+++ b/packages/extend2/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 5.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [4.0.0](https://github.com/eggjs/extend2/compare/v3.0.0...v4.0.0) (2024-06-15)
 
 

--- a/packages/extend2/package.json
+++ b/packages/extend2/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@eggjs/extend2",
   "author": "popomore <sakura9515@gmail.com>",
-  "version": "4.1.0-beta.11",
+  "version": "5.0.0-beta.11",
   "engines": {
-    "node": ">=18.7.0"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/koa-static-cache/CHANGELOG.md
+++ b/packages/koa-static-cache/CHANGELOG.md
@@ -9,7 +9,12 @@
 
 ### ⚠ BREAKING CHANGES
 
-* drop Node.js < 20.19.0 support
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
 
 ## [6.1.0](https://github.com/eggjs/koa-static-cache/compare/v6.0.0...v6.1.0) (2025-03-12)
 

--- a/packages/koa-static-cache/package.json
+++ b/packages/koa-static-cache/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/koa-static-cache",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "@eggjs/compressible": "^3.0.0",

--- a/packages/koa/CHANGELOG.md
+++ b/packages/koa/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 3.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## <small>3.0.1 (2025-08-08)</small>
 
 * fix: remove --experimental-strip-types (#25) ([0866329](https://github.com/eggjs/koa/commit/0866329)), closes [#25](https://github.com/eggjs/koa/issues/25)

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -2,7 +2,7 @@
   "name": "@eggjs/koa",
   "version": "3.1.0-beta.11",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/supertest/CHANGELOG.md
+++ b/packages/supertest/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 9.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [8.2.0](https://github.com/eggjs/supertest/compare/v8.1.1...v8.2.0) (2025-01-17)
 
 

--- a/packages/supertest/package.json
+++ b/packages/supertest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eggjs/supertest",
   "description": "SuperAgent driven library for testing HTTP servers",
-  "version": "8.3.0-beta.11",
+  "version": "9.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/supertest",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "@types/superagent": "catalog:",

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 3.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [3.0.0](https://github.com/eggjs/tsconfig/compare/v2.0.0...v3.0.0) (2025-07-30)
 
 

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -26,7 +26,7 @@
     "directory": "packages/tsconfig"
   },
   "engines": {
-    "node": ">=22.17.1"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 5.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [4.4.1](https://github.com/eggjs/utils/compare/v4.4.0...v4.4.1) (2025-03-05)
 
 ### Bug Fixes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@eggjs/utils",
-  "version": "4.5.0-beta.11",
+  "version": "5.0.0-beta.11",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "publishConfig": {
     "access": "public",

--- a/plugins/development/CHANGELOG.md
+++ b/plugins/development/CHANGELOG.md
@@ -3,6 +3,19 @@
 >[!IMPORTANT]
 >Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
 
+---
+
+## 5.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [4.0.0](https://github.com/eggjs/development/compare/v3.0.2...v4.0.0) (2025-01-11)
 
 

--- a/plugins/development/package.json
+++ b/plugins/development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/development",
-  "version": "4.1.0-beta.11",
+  "version": "5.0.0-beta.11",
   "description": "development tool for egg",
   "publishConfig": {
     "access": "public",
@@ -63,7 +63,7 @@
     "typescript": "catalog:"
   },
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "scripts": {
     "lint": "oxlint --type-aware",

--- a/plugins/mock/CHANGELOG.md
+++ b/plugins/mock/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## 7.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [6.0.7](https://github.com/eggjs/mock/compare/v6.0.6...v6.0.7) (2025-02-08)
 
 

--- a/plugins/mock/package.json
+++ b/plugins/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mock",
-  "version": "6.1.0-beta.11",
+  "version": "7.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -96,7 +96,7 @@
   ],
   "author": "popomore <sakura9515@gmail.com>",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "@eggjs/extend2": "workspace:*",

--- a/plugins/onerror/CHANGELOG.md
+++ b/plugins/onerror/CHANGELOG.md
@@ -3,6 +3,19 @@
 > [!IMPORTANT]
 > Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
 
+---
+
+## 4.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [3.0.0](https://github.com/eggjs/onerror/compare/v2.4.0...v3.0.0) (2025-02-02)
 
 

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/onerror",
-  "version": "3.1.0-beta.11",
+  "version": "4.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -34,7 +34,7 @@
   ],
   "author": "dead_horse",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "cookie": "catalog:",

--- a/plugins/schedule/CHANGELOG.md
+++ b/plugins/schedule/CHANGELOG.md
@@ -7,10 +7,14 @@
 
 ## 6.0.0+
 
-
 ### ⚠ BREAKING CHANGES
-* drop Node.js < 20.19.0 support
 
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
 
 ## [5.0.2](https://github.com/eggjs/schedule/compare/v5.0.1...v5.0.2) (2024-12-20)
 

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -23,7 +23,7 @@
     }
   },
   "engines": {
-    "node": ">=18.19.0"
+    "node": ">=22.18.0"
   },
   "description": "schedule plugin for egg, support corn job.",
   "eggPlugin": {

--- a/plugins/static/CHANGELOG.md
+++ b/plugins/static/CHANGELOG.md
@@ -8,7 +8,13 @@
 ## 4.0.0+
 
 ### ⚠ BREAKING CHANGES
+
 * drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
 
 ## [3.0.0](https://github.com/eggjs/static/compare/v2.3.1...v3.0.0) (2025-01-12)
 

--- a/plugins/watcher/CHANGELOG.md
+++ b/plugins/watcher/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 5.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
+
 ## [4.0.4](https://github.com/eggjs/watcher/compare/v4.0.3...v4.0.4) (2025-01-11)
 
 

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/watcher",
-  "version": "4.1.0-beta.11",
+  "version": "5.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -45,7 +45,7 @@
     "watch"
   ],
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "@eggjs/utils": "workspace:*",

--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,6 @@
     "prettier": "prettier --config .prettierrc --ignore-path .prettierignore --write \"**/*.{js,jsx,tsx,ts,less,md,json}\""
   },
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   }
 }

--- a/tools/create-egg/CHANGELOG.md
+++ b/tools/create-egg/CHANGELOG.md
@@ -3,6 +3,18 @@
 > [!IMPORTANT]
 > Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
 
+## 4.1.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
+
 ## [3.0.0](https://github.com/eggjs/create-egg/compare/v2.0.1...v3.0.0) (2023-11-28)
 
 

--- a/tools/create-egg/src/templates/egg3-simple-js/package.json
+++ b/tools/create-egg/src/templates/egg3-simple-js/package.json
@@ -17,7 +17,7 @@
     "eslint-config-egg": "14"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.18.0"
   },
   "scripts": {
     "start": "egg-scripts start --daemon --title=egg-server-{{name}}",

--- a/tools/create-egg/src/templates/egg3-simple-ts/package.json
+++ b/tools/create-egg/src/templates/egg3-simple-ts/package.json
@@ -34,7 +34,7 @@
     "typescript": "5"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.18.0"
   },
   "repository": {
     "type": "git",

--- a/tools/create-egg/src/templates/egg3-tegg/package.json
+++ b/tools/create-egg/src/templates/egg3-tegg/package.json
@@ -43,7 +43,7 @@
     "typescript": "5"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.18.0"
   },
   "homepage": "https://github.com/YOUR_USERNAME/YOUR_REPO#readme",
   "bugs": {

--- a/tools/create-egg/src/templates/simple-ts/package.json
+++ b/tools/create-egg/src/templates/simple-ts/package.json
@@ -36,7 +36,7 @@
     "vitest": "beta"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.18.0"
   },
   "homepage": "https://github.com/YOUR_USERNAME/YOUR_REPO#readme",
   "bugs": {

--- a/tools/create-egg/src/templates/tegg/package.json
+++ b/tools/create-egg/src/templates/tegg/package.json
@@ -47,7 +47,7 @@
     "@vitest/coverage-v8": "beta"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.18.0"
   },
   "homepage": "https://github.com/YOUR_USERNAME/YOUR_REPO#readme",
   "bugs": {

--- a/tools/egg-bin/CHANGELOG.md
+++ b/tools/egg-bin/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ---
 
+## 8.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
+
 ## [7.3.1](https://github.com/eggjs/bin/compare/v7.3.0...v7.3.1) (2025-04-19)
 
 

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/bin",
-  "version": "7.4.0-beta.11",
+  "version": "8.0.0-beta.11",
   "publishConfig": {
     "access": "public",
     "exports": {
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bin",
   "author": "fengmk2 <fengmk2@gmail.com> (https://github.com/fengmk2)",
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">=22.18.0"
   },
   "dependencies": {
     "@eggjs/utils": "workspace:*",


### PR DESCRIPTION
Update minimum Node.js version to 22.18.0 across all packages in the monorepo to leverage native TypeScript execution support introduced in Node.js 22.18.0.

Exception: create-egg CLI tool remains at >=20.19.0 for backward compatibility, while its templates require >=22.18.0.

Closes https://github.com/eggjs/egg/issues/5549

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated changelogs across packages to announce breaking changes: require Node.js 22.18.0+ and egg@4, with references for more details.
  - Refreshed migration guidance to reflect the new Node.js minimum.

- Chores
  - Raised minimum supported Node.js version to 22.18.0+ across the monorepo, including examples, templates, and site.
  - Bumped package versions (several major beta releases) to align with new compatibility policy.

- Notes
  - No functional or runtime changes; this update adjusts documentation and compatibility metadata only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->