### PR TITLE
feat(jsonp): merge jsonp plugin into monorepo

### DIFF
--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -123,7 +123,7 @@
     "@eggjs/development": "workspace:*",
     "@eggjs/extend2": "workspace:*",
     "@eggjs/i18n": "catalog:",
-    "@eggjs/jsonp": "catalog:",
+    "@eggjs/jsonp": "workspace:*",
     "@eggjs/logrotator": "catalog:",
     "@eggjs/multipart": "catalog:",
     "@eggjs/onerror": "workspace:*",

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -136,7 +136,6 @@
     "@eggjs/watcher": "workspace:*",
     "circular-json-for-egg": "catalog:",
     "cluster-client": "catalog:",
-    "egg-errors": "catalog:",
     "egg-logger": "catalog:",
     "graceful": "catalog:",
     "humanize-ms": "catalog:",

--- a/packages/egg/src/lib/types.plugin.ts
+++ b/packages/egg/src/lib/types.plugin.ts
@@ -1,14 +1,15 @@
 // import plugins types
-import '@eggjs/watcher';
-import '@eggjs/jsonp';
 import '@eggjs/i18n';
 import '@eggjs/security';
 import '@eggjs/session';
 import '@eggjs/logrotator';
 import '@eggjs/multipart';
 import '@eggjs/view';
+// FIXME: can't use reference types here, development plugin depends on watcher plugin
+import '@eggjs/watcher';
 
 /// <reference types="@eggjs/schedule" />
 /// <reference types="@eggjs/development" />
 /// <reference types="@eggjs/static" />
 /// <reference types="@eggjs/onerror" />
+/// <reference types="@eggjs/jsonp" />

--- a/plugins/jsonp/CHANGELOG.md
+++ b/plugins/jsonp/CHANGELOG.md
@@ -1,0 +1,110 @@
+# Changelog
+
+> [!IMPORTANT]
+> Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
+
+---
+
+## 4.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
+## [3.0.0](https://github.com/eggjs/jsonp/compare/v2.0.0...v3.0.0) (2025-01-11)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 18.19.0 support
+
+part of https://github.com/eggjs/egg/issues/3644
+
+https://github.com/eggjs/egg/issues/5257
+
+<!-- This is an auto-generated comment: release notes by coderabbit.ai
+-->
+## Summary by CodeRabbit
+
+## Release Notes
+
+- **New Features**
+  - Added TypeScript support for the JSONP plugin
+  - Modernized project structure with ES module syntax
+  - Enhanced type definitions and configuration
+  - Introduced new GitHub Actions workflows for CI/CD
+  - Added a new class for JSONP error handling
+
+- **Breaking Changes**
+  - Renamed package from `egg-jsonp` to `@eggjs/jsonp`
+  - Dropped support for Node.js versions below 18.19.0
+  - Refactored configuration and middleware approach
+
+- **Improvements**
+  - Updated GitHub Actions workflows for CI/CD
+  - Improved security checks for JSONP requests
+  - Added more robust error handling
+  - Enhanced logging configuration
+
+- **Dependency Updates**
+  - Updated core dependencies
+  - Migrated to modern TypeScript tooling
+<!-- end of auto-generated comment: release notes by coderabbit.ai -->
+
+### Features
+
+* support cjs and esm both by tshy ([#12](https://github.com/eggjs/jsonp/issues/12)) ([9136768](https://github.com/eggjs/jsonp/commit/9136768ba518dcec765f86af3e7259d131b6917b))
+
+2.0.0 / 2017-11-11
+==================
+
+**others**
+  * [[`a9cadba`](http://github.com/eggjs/egg-jsonp/commit/a9cadba740dc54b9c3dd0593495b66b5a98383e8)] - refactor: use async function and support egg@2 (#10) (Yiyu He <<dead_horse@qq.com>>)
+
+1.2.2 / 2017-11-10
+==================
+
+**fixes**
+  * [[`d14d2d6`](http://github.com/eggjs/egg-jsonp/commit/d14d2d6aa1cdc50ff084f801fa741221667ee577)] - fix: rename to createJsonpBody (#9) (Yiyu He <<dead_horse@qq.com>>)
+
+**others**
+  * [[`f7137a0`](http://github.com/eggjs/egg-jsonp/commit/f7137a011b202882fbfd48a4ee434031a9b950d2)] - chore: add pkgfiles check in ci (dead-horse <<dead_horse@qq.com>>)
+
+1.2.1 / 2017-10-11
+==================
+
+**fixes**
+  * [[`a19f450`](http://github.com/eggjs/egg-jsonp/commit/a19f45089ed8229a3ee0099a730a2be9ea57b114)] - fix: add lib into files (dead-horse <<dead_horse@qq.com>>)
+
+1.2.0 / 2017-10-11
+==================
+
+**features**
+  * [[`ee98948`](http://github.com/eggjs/egg-jsonp/commit/ee9894834ed8de081b26680a58506896d736cb61)] - feat: add acceptJSONP and open jsonp wrap function (#8) (Gao Peng <<ggjqzjgp103@qq.com>>)
+
+1.1.2 / 2017-07-21
+==================
+
+  * fix: should not throw when referrer illegal (#5)
+
+1.1.1 / 2017-06-04
+==================
+
+  * docs: fix License url (#4)
+
+1.1.0 / 2017-06-01
+==================
+
+  * test: test on node 8
+  * feat: support _callback and callback
+
+1.0.0 / 2017-01-23
+==================
+
+  * fix: refine jsonp (#1)
+  * feat: init jsonp

--- a/plugins/jsonp/LICENSE
+++ b/plugins/jsonp/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Alibaba Group Holding Limited and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/jsonp/README.md
+++ b/plugins/jsonp/README.md
@@ -1,0 +1,141 @@
+# @eggjs/jsonp
+
+[![NPM version][npm-image]][npm-url]
+[![Node.js CI](https://github.com/eggjs/jsonp/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/jsonp/actions/workflows/nodejs.yml)
+[![Test coverage][codecov-image]][codecov-url]
+[![Known Vulnerabilities][snyk-image]][snyk-url]
+[![npm download][download-image]][download-url]
+[![Node.js Version](https://img.shields.io/node/v/@eggjs/jsonp.svg?style=flat)](https://nodejs.org/en/download/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
+
+[npm-image]: https://img.shields.io/npm/v/@eggjs/jsonp.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/@eggjs/jsonp
+[codecov-image]: https://img.shields.io/codecov/c/github/eggjs/jsonp.svg?style=flat-square
+[codecov-url]: https://codecov.io/github/eggjs/jsonp?branch=master
+[snyk-image]: https://snyk.io/test/npm/@eggjs/jsonp/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/@eggjs/jsonp
+[download-image]: https://img.shields.io/npm/dm/@eggjs/jsonp.svg?style=flat-square
+[download-url]: https://npmjs.org/package/@eggjs/jsonp
+
+An egg plugin for jsonp support.
+
+## Requirements
+
+- egg >= 4.x
+
+## Install
+
+```bash
+npm i @eggjs/jsonp
+```
+
+## Usage
+
+```ts
+// {app_root}/config/plugin.ts
+
+export default {
+  jsonp: {
+    enable: true,
+    package: '@eggjs/jsonp',
+  },
+};
+```
+
+## Configuration
+
+- {String|Array} callback - jsonp callback method key, default to `[ '_callback', 'callback' ]`
+- {Number} limit - callback method name's max length, default to `50`
+- {Boolean} csrf - enable csrf check or not. default to false
+- {String|RegExp|Array} whiteList - referrer white list
+
+if whiteList's type is `RegExp`, referrer must match `whiteList`, pay attention to the first `^` and last `/`.
+
+```ts
+export default {
+  jsonp: {
+    whiteList: /^https?:\/\/test.com\//,
+  },
+};
+
+// matchs referrer:
+// https://test.com/hello
+// http://test.com/
+```
+
+if whiteList's type is `String` and starts with `.`:
+
+```ts
+export default {
+  jsonp: {
+    whiteList: '.test.com',
+  },
+};
+
+// matchs domain test.com:
+// https://test.com/hello
+// http://test.com/
+
+// matchs subdomain
+// https://sub.test.com/hello
+// http://sub.sub.test.com/
+```
+
+if whiteList's type is `String` and not starts with `.`:
+
+```ts
+export default {
+  jsonp: {
+    whiteList: 'sub.test.com',
+  },
+};
+
+// only matchs domain sub.test.com:
+// https://sub.test.com/hello
+// http://sub.test.com/
+```
+
+whiteList also can be an array:
+
+```ts
+export default {
+  jsonp: {
+    whiteList: ['.foo.com', '.bar.com'],
+  },
+};
+```
+
+see [config/config.default.ts](https://github.com/eggjs/jsonp/blob/master/src/config/config.default.ts) for more detail.
+
+## API
+
+- ctx.acceptJSONP - detect if response should be jsonp, readonly
+
+## Example
+
+In `app/router.ts`
+
+```ts
+// Create once and use in any router you want to support jsonp.
+const jsonp = app.jsonp();
+
+app.get('/default', jsonp, 'jsonp.index');
+app.get('/another', jsonp, 'jsonp.another');
+
+// Customize by create another jsonp middleware with specific configurations.
+app.get('/customize', app.jsonp({ callback: 'fn' }), 'jsonp.customize');
+```
+
+## Questions & Suggestions
+
+Please open an issue [here](https://github.com/eggjs/egg/issues).
+
+## License
+
+[MIT](LICENSE)
+
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=eggjs/jsonp)](https://github.com/eggjs/jsonp/graphs/contributors)
+
+Made with [contributors-img](https://contrib.rocks).

--- a/plugins/jsonp/README.md
+++ b/plugins/jsonp/README.md
@@ -1,8 +1,6 @@
 # @eggjs/jsonp
 
 [![NPM version][npm-image]][npm-url]
-[![Node.js CI](https://github.com/eggjs/jsonp/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/jsonp/actions/workflows/nodejs.yml)
-[![Test coverage][codecov-image]][codecov-url]
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
 [![Node.js Version](https://img.shields.io/node/v/@eggjs/jsonp.svg?style=flat)](https://nodejs.org/en/download/)
@@ -10,8 +8,6 @@
 
 [npm-image]: https://img.shields.io/npm/v/@eggjs/jsonp.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/@eggjs/jsonp
-[codecov-image]: https://img.shields.io/codecov/c/github/eggjs/jsonp.svg?style=flat-square
-[codecov-url]: https://codecov.io/github/eggjs/jsonp?branch=master
 [snyk-image]: https://snyk.io/test/npm/@eggjs/jsonp/badge.svg?style=flat-square
 [snyk-url]: https://snyk.io/test/npm/@eggjs/jsonp
 [download-image]: https://img.shields.io/npm/dm/@eggjs/jsonp.svg?style=flat-square
@@ -136,6 +132,6 @@ Please open an issue [here](https://github.com/eggjs/egg/issues).
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=eggjs/jsonp)](https://github.com/eggjs/jsonp/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg)](https://github.com/eggjs/egg/graphs/contributors)
 
 Made with [contributors-img](https://contrib.rocks).

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -1,0 +1,90 @@
+{
+  "name": "@eggjs/jsonp",
+  "version": "4.0.0-beta.13",
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/index.js",
+      "./app": "./dist/app.js",
+      "./app/extend/application": "./dist/app/extend/application.js",
+      "./app/extend/context": "./dist/app/extend/context.js",
+      "./config/config.default": "./dist/config/config.default.js",
+      "./error/JSONPForbiddenReferrerError": "./dist/error/JSONPForbiddenReferrerError.js",
+      "./lib/private_key": "./dist/lib/private_key.js",
+      "./types": "./dist/types.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./app": "./src/app.ts",
+    "./app/extend/application": "./src/app/extend/application.ts",
+    "./app/extend/context": "./src/app/extend/context.ts",
+    "./config/config.default": "./src/config/config.default.ts",
+    "./error/JSONPForbiddenReferrerError": "./src/error/JSONPForbiddenReferrerError.ts",
+    "./lib/private_key": "./src/lib/private_key.ts",
+    "./types": "./src/types.ts",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist"
+  ],
+  "description": "jsonp support for egg",
+  "eggPlugin": {
+    "name": "jsonp",
+    "optionalDependencies": [
+      "security"
+    ]
+  },
+  "keywords": [
+    "egg",
+    "egg-plugin",
+    "jsonp",
+    "security"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/eggjs/egg.git",
+    "directory": "plugins/jsonp"
+  },
+  "bugs": {
+    "url": "https://github.com/eggjs/egg/issues"
+  },
+  "homepage": "https://github.com/eggjs/egg/tree/next/plugins/jsonp",
+  "author": "dead-horse",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "dependencies": {
+    "@eggjs/core": "workspace:*",
+    "jsonp-body": "catalog:"
+  },
+  "peerDependencies": {
+    "egg": "workspace:*"
+  },
+  "devDependencies": {
+    "@eggjs/mock": "workspace:*",
+    "@eggjs/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "oxlint": "catalog:",
+    "oxlint-tsgolint": "catalog:",
+    "rimraf": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rimraf dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint --type-aware",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "npm run lint:fix && vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts"
+}

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -58,7 +58,6 @@
     "node": ">=22.18.0"
   },
   "dependencies": {
-    "@eggjs/core": "workspace:*",
     "jsonp-body": "catalog:"
   },
   "peerDependencies": {
@@ -68,16 +67,12 @@
     "@eggjs/mock": "workspace:*",
     "@eggjs/tsconfig": "workspace:*",
     "@types/node": "catalog:",
-    "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:",
-    "rimraf": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "scripts": {
     "build": "tsdown",
-    "clean": "rimraf dist",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/jsonp/src/app.ts
+++ b/plugins/jsonp/src/app.ts
@@ -1,0 +1,3 @@
+// Re-export extensions for plugin loading
+export * from './app/extend/application.js';
+export * from './app/extend/context.js';

--- a/plugins/jsonp/src/app.ts
+++ b/plugins/jsonp/src/app.ts
@@ -1,3 +1,3 @@
 // Re-export extensions for plugin loading
-export * from './app/extend/application.js';
-export * from './app/extend/context.js';
+export * from './app/extend/application.ts';
+export * from './app/extend/context.ts';

--- a/plugins/jsonp/src/app/extend/application.ts
+++ b/plugins/jsonp/src/app/extend/application.ts
@@ -2,7 +2,7 @@ import { debuglog } from 'node:util';
 import { parse as urlParse, type UrlWithStringQuery } from 'node:url';
 import type { ParsedUrlQuery } from 'node:querystring';
 
-import { Application, type MiddlewareFunc } from 'egg';
+import { Application, type MiddlewareFunc, type Context } from 'egg';
 
 import { JSONP_CONFIG } from '../../lib/private_key.ts';
 import type { JSONPConfig } from '../../types.ts';
@@ -112,9 +112,10 @@ function createValidateReferer(whiteList: Required<JSONPConfig>['whiteList']) {
   };
 }
 
-function validateCsrf(ctx: any) {
+function validateCsrf(ctx: Context) {
   try {
     // TODO(fengmk2): remove this when @eggjs/security support ctx.assertCsrf type define
+    // @ts-expect-error TODO: fix this
     ctx.assertCsrf();
     return true;
   } catch (err) {

--- a/plugins/jsonp/src/app/extend/application.ts
+++ b/plugins/jsonp/src/app/extend/application.ts
@@ -1,15 +1,17 @@
 import { debuglog } from 'node:util';
 import { parse as urlParse, type UrlWithStringQuery } from 'node:url';
 import type { ParsedUrlQuery } from 'node:querystring';
-import { EggCore, type MiddlewareFunc } from '@eggjs/core';
-import { JSONP_CONFIG } from '../../lib/private_key.js';
-import type { JSONPConfig } from '../../types.js';
-import { JSONPForbiddenReferrerError } from '../../error/JSONPForbiddenReferrerError.js';
-import JSONPContext from './context.js';
 
-const debug = debuglog('@egg/jsonp/app/extend/application');
+import { Application, type MiddlewareFunc } from 'egg';
 
-export default class JSONPApplication extends EggCore {
+import { JSONP_CONFIG } from '../../lib/private_key.ts';
+import type { JSONPConfig } from '../../types.ts';
+import { JSONPForbiddenReferrerError } from '../../error/JSONPForbiddenReferrerError.ts';
+import JSONPContext from './context.ts';
+
+const debug = debuglog('egg/jsonp/app/extend/application');
+
+export default class JSONPApplication extends Application {
   /**
    * return a middleware to enable jsonp response.
    * will do some security check inside.

--- a/plugins/jsonp/src/app/extend/application.ts
+++ b/plugins/jsonp/src/app/extend/application.ts
@@ -1,0 +1,130 @@
+import { debuglog } from 'node:util';
+import { parse as urlParse, type UrlWithStringQuery } from 'node:url';
+import type { ParsedUrlQuery } from 'node:querystring';
+import { EggCore, type MiddlewareFunc } from '@eggjs/core';
+import { JSONP_CONFIG } from '../../lib/private_key.js';
+import type { JSONPConfig } from '../../types.js';
+import { JSONPForbiddenReferrerError } from '../../error/JSONPForbiddenReferrerError.js';
+import JSONPContext from './context.js';
+
+const debug = debuglog('@egg/jsonp/app/extend/application');
+
+export default class JSONPApplication extends EggCore {
+  /**
+   * return a middleware to enable jsonp response.
+   * will do some security check inside.
+   * @public
+   */
+  jsonp(initOptions: Partial<JSONPConfig> = {}): MiddlewareFunc {
+    const options = {
+      ...this.config.jsonp,
+      ...initOptions,
+    } as JSONPConfig & { callback: string[] };
+    if (!Array.isArray(options.callback)) {
+      options.callback = [options.callback];
+    }
+
+    const csrfEnable =
+      this.plugins.security &&
+      this.plugins.security.enable && // security enable
+      this.config.security.csrf &&
+      this.config.security.csrf.enable !== false && // csrf enable
+      options.csrf; // jsonp csrf enabled
+
+    const validateReferrer = options.whiteList && createValidateReferer(options.whiteList);
+
+    if (!csrfEnable && !validateReferrer) {
+      this.coreLogger.warn('[@eggjs/jsonp] SECURITY WARNING!! csrf check and referrer check are both closed!');
+    }
+    /**
+     * jsonp request security check, pass if
+     *
+     * 1. hit referrer white list
+     * 2. or pass csrf check
+     * 3. both check are disabled
+     *
+     * @param {Context} ctx request context
+     */
+    function securityAssert(ctx: JSONPContext) {
+      // all disabled. don't need check
+      if (!csrfEnable && !validateReferrer) return;
+
+      // pass referrer check
+      const referrer = ctx.get<string>('referrer');
+      if (validateReferrer && validateReferrer(referrer)) return;
+      if (csrfEnable && validateCsrf(ctx)) return;
+
+      throw new JSONPForbiddenReferrerError('jsonp request security validate failed', referrer, 403);
+    }
+
+    return async function jsonp(ctx: JSONPContext, next) {
+      const jsonpFunction = getJsonpFunction(ctx.query, options.callback);
+
+      ctx[JSONP_CONFIG] = {
+        jsonpFunction,
+        options,
+      };
+
+      // before handle request, must do some security checks
+      securityAssert(ctx);
+
+      await next();
+
+      // generate jsonp body
+      ctx.createJsonpBody(ctx.body);
+    };
+  }
+}
+
+function createValidateReferer(whiteList: Required<JSONPConfig>['whiteList']) {
+  if (!Array.isArray(whiteList)) {
+    whiteList = [whiteList];
+  }
+
+  return (referrer: string) => {
+    let parsed: UrlWithStringQuery | undefined;
+    for (const rule of whiteList) {
+      if (rule instanceof RegExp) {
+        if (rule.test(referrer)) {
+          // regexp(/^https?:\/\/github.com\//): test the referrer with rule
+          return true;
+        }
+        continue;
+      }
+
+      parsed = parsed ?? urlParse(referrer);
+      const hostname = parsed.hostname || '';
+
+      // check if referrer's hostname match the string rule
+      if (rule[0] === '.' && (hostname.endsWith(rule) || hostname === rule.slice(1))) {
+        // string start with `.`(.github.com): referrer's hostname must ends with rule
+        return true;
+      } else if (hostname === rule) {
+        // string not start with `.`(github.com): referrer's hostname must strict equal to rule
+        return true;
+      }
+    }
+
+    // no rule matched
+    return false;
+  };
+}
+
+function validateCsrf(ctx: any) {
+  try {
+    // TODO(fengmk2): remove this when @eggjs/security support ctx.assertCsrf type define
+    ctx.assertCsrf();
+    return true;
+  } catch (err) {
+    debug('validate csrf failed: %s', err);
+    return false;
+  }
+}
+
+function getJsonpFunction(query: ParsedUrlQuery, callbacks: string[]) {
+  for (const callback of callbacks) {
+    if (query[callback]) {
+      return query[callback] as string;
+    }
+  }
+}

--- a/plugins/jsonp/src/app/extend/context.ts
+++ b/plugins/jsonp/src/app/extend/context.ts
@@ -1,0 +1,34 @@
+import { jsonp as jsonpBody } from 'jsonp-body';
+import { Context } from '@eggjs/core';
+import { JSONP_CONFIG } from '../../lib/private_key.js';
+
+export default class JSONPContext extends Context {
+  /**
+   * detect if response should be jsonp
+   */
+  get acceptJSONP() {
+    const jsonpConfig = Reflect.get(this, JSONP_CONFIG) as any;
+    return !!jsonpConfig?.jsonpFunction;
+  }
+
+  /**
+   * JSONP wrap body function
+   * Set jsonp response wrap function, other plugin can use it.
+   * If not necessary, please don't use this method in your application code.
+   * @param {Object} body response body
+   * @private
+   */
+  createJsonpBody(body: any) {
+    const jsonpConfig = Reflect.get(this, JSONP_CONFIG) as any;
+    if (!jsonpConfig?.jsonpFunction) {
+      this.body = body;
+      return;
+    }
+
+    this.set('x-content-type-options', 'nosniff');
+    this.type = 'js';
+    body = body === undefined ? null : body;
+    // protect from jsonp xss
+    this.body = jsonpBody(body, jsonpConfig.jsonpFunction, jsonpConfig.options);
+  }
+}

--- a/plugins/jsonp/src/app/extend/context.ts
+++ b/plugins/jsonp/src/app/extend/context.ts
@@ -1,13 +1,20 @@
 import { jsonp as jsonpBody } from 'jsonp-body';
-import { Context } from '@eggjs/core';
-import { JSONP_CONFIG } from '../../lib/private_key.js';
+import { Context } from 'egg';
+
+import { JSONP_CONFIG } from '../../lib/private_key.ts';
+import type { JSONPConfig } from '../../types.ts';
 
 export default class JSONPContext extends Context {
+  declare [JSONP_CONFIG]?: {
+    jsonpFunction?: string;
+    options?: JSONPConfig;
+  };
+
   /**
    * detect if response should be jsonp
    */
   get acceptJSONP() {
-    const jsonpConfig = Reflect.get(this, JSONP_CONFIG) as any;
+    const jsonpConfig = this[JSONP_CONFIG];
     return !!jsonpConfig?.jsonpFunction;
   }
 
@@ -19,7 +26,7 @@ export default class JSONPContext extends Context {
    * @private
    */
   createJsonpBody(body: any) {
-    const jsonpConfig = Reflect.get(this, JSONP_CONFIG) as any;
+    const jsonpConfig = this[JSONP_CONFIG];
     if (!jsonpConfig?.jsonpFunction) {
       this.body = body;
       return;

--- a/plugins/jsonp/src/config/config.default.ts
+++ b/plugins/jsonp/src/config/config.default.ts
@@ -1,4 +1,4 @@
-import type { JSONPConfig } from '../types.js';
+import type { PartialEggConfig } from 'egg';
 
 export default {
   jsonp: {
@@ -6,5 +6,5 @@ export default {
     callback: ['_callback', 'callback'],
     csrf: false,
     whiteList: undefined,
-  } as JSONPConfig,
-};
+  },
+} as PartialEggConfig;

--- a/plugins/jsonp/src/config/config.default.ts
+++ b/plugins/jsonp/src/config/config.default.ts
@@ -1,0 +1,10 @@
+import type { JSONPConfig } from '../types.js';
+
+export default {
+  jsonp: {
+    limit: 50,
+    callback: ['_callback', 'callback'],
+    csrf: false,
+    whiteList: undefined,
+  } as JSONPConfig,
+};

--- a/plugins/jsonp/src/error/JSONPForbiddenReferrerError.ts
+++ b/plugins/jsonp/src/error/JSONPForbiddenReferrerError.ts
@@ -1,0 +1,12 @@
+export class JSONPForbiddenReferrerError extends Error {
+  referrer: string;
+  status: number;
+
+  constructor(message: string, referrer: string, status: number) {
+    super(message);
+    this.name = this.constructor.name;
+    this.referrer = referrer;
+    this.status = status;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/plugins/jsonp/src/index.ts
+++ b/plugins/jsonp/src/index.ts
@@ -1,0 +1,1 @@
+import './types.js';

--- a/plugins/jsonp/src/index.ts
+++ b/plugins/jsonp/src/index.ts
@@ -1,1 +1,1 @@
-import './types.js';
+import './types.ts';

--- a/plugins/jsonp/src/lib/private_key.ts
+++ b/plugins/jsonp/src/lib/private_key.ts
@@ -1,0 +1,1 @@
+export const JSONP_CONFIG = Symbol('jsonp#config');

--- a/plugins/jsonp/src/types.ts
+++ b/plugins/jsonp/src/types.ts
@@ -1,0 +1,55 @@
+import type { MiddlewareFunc } from '@eggjs/core';
+
+/**
+ * jsonp options
+ * @member Config#jsonp
+ */
+export interface JSONPConfig {
+  /**
+   * jsonp callback methods key, default to `['_callback', 'callback' ]`
+   */
+  callback: string[] | string;
+  /**
+   * callback method name's max length, default to `50`
+   */
+  limit: number;
+  /**
+   * enable csrf check or not, default to `false`
+   */
+  csrf: boolean;
+  /**
+   * referrer white list, default to `undefined`
+   */
+  whiteList?: string | RegExp | (string | RegExp)[];
+}
+
+declare module '@eggjs/core' {
+  // add EggAppConfig overrides types
+  interface EggAppConfig {
+    jsonp?: JSONPConfig;
+  }
+
+  interface Context {
+    /**
+     * detect if response should be jsonp
+     */
+    acceptJSONP: boolean;
+    /**
+     * JSONP wrap body function
+     * Set jsonp response wrap function, other plugin can use it.
+     * If not necessary, please don't use this method in your application code.
+     * @param {Object} body response body
+     * @private
+     */
+    createJsonpBody(body: any): void;
+  }
+
+  interface EggCore {
+    /**
+     * return a middleware to enable jsonp response.
+     * will do some security check inside.
+     * @public
+     */
+    jsonp(initOptions?: Partial<JSONPConfig>): MiddlewareFunc;
+  }
+}

--- a/plugins/jsonp/src/types.ts
+++ b/plugins/jsonp/src/types.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareFunc } from '@eggjs/core';
+import type { MiddlewareFunc } from 'egg';
 
 /**
  * jsonp options
@@ -23,7 +23,7 @@ export interface JSONPConfig {
   whiteList?: string | RegExp | (string | RegExp)[];
 }
 
-declare module '@eggjs/core' {
+declare module 'egg' {
   // add EggAppConfig overrides types
   interface EggAppConfig {
     jsonp?: JSONPConfig;
@@ -44,7 +44,7 @@ declare module '@eggjs/core' {
     createJsonpBody(body: any): void;
   }
 
-  interface EggCore {
+  interface Application {
     /**
      * return a middleware to enable jsonp response.
      * will do some security check inside.

--- a/plugins/jsonp/src/typings/index.d.ts
+++ b/plugins/jsonp/src/typings/index.d.ts
@@ -1,0 +1,4 @@
+// make sure to import egg typings and let typescript know about it
+// @see https://github.com/whxaxes/blog/issues/11
+// and https://www.typescriptlang.org/docs/handbook/declaration-merging.html
+import 'egg';

--- a/plugins/jsonp/src/typings/index.d.ts
+++ b/plugins/jsonp/src/typings/index.d.ts
@@ -1,4 +1,0 @@
-// make sure to import egg typings and let typescript know about it
-// @see https://github.com/whxaxes/blog/issues/11
-// and https://www.typescriptlang.org/docs/handbook/declaration-merging.html
-import 'egg';

--- a/plugins/jsonp/test/fixtures/jsonp-test/app/controller/jsonp.js
+++ b/plugins/jsonp/test/fixtures/jsonp-test/app/controller/jsonp.js
@@ -1,0 +1,13 @@
+exports.index = ctx => {
+  ctx.body = { foo: 'bar' };
+};
+
+exports.empty = function () {};
+
+exports.mark = ctx => {
+  ctx.body = { jsonpFunction: ctx.acceptJSONP };
+};
+
+exports.error = async () => {
+  throw new Error('jsonpFunction is error');
+};

--- a/plugins/jsonp/test/fixtures/jsonp-test/app/router.js
+++ b/plugins/jsonp/test/fixtures/jsonp-test/app/router.js
@@ -1,0 +1,28 @@
+module.exports = app => {
+  app.get('/default', app.jsonp(), 'jsonp.index');
+  app.get('/empty', app.jsonp(), 'jsonp.empty');
+  app.get('/disable', 'jsonp.index');
+  app.get('/fn', app.jsonp({ callback: 'fn' }), 'jsonp.index');
+  app.get('/referrer/subdomain', app.jsonp({ whiteList: '.test.com' }), 'jsonp.index');
+  app.get('/referrer/equal', app.jsonp({ whiteList: 'test.com' }), 'jsonp.index');
+  app.get(
+    '/referrer/regexp',
+    app.jsonp({ whiteList: [/https?:\/\/test\.com\//, /https?:\/\/foo\.com\//] }),
+    'jsonp.index'
+  );
+  app.get('/csrf', app.jsonp({ csrf: true }), 'jsonp.index');
+  app.get('/both', app.jsonp({ csrf: true, whiteList: 'test.com' }), 'jsonp.index');
+  app.get('/mark', app.jsonp(), 'jsonp.mark');
+  app.get(
+    '/error',
+    async (ctx, next) => {
+      try {
+        await next();
+      } catch (error) {
+        ctx.createJsonpBody({ msg: error.message });
+      }
+    },
+    app.jsonp(),
+    'jsonp.error'
+  );
+};

--- a/plugins/jsonp/test/fixtures/jsonp-test/config/config.default.js
+++ b/plugins/jsonp/test/fixtures/jsonp-test/config/config.default.js
@@ -1,0 +1,13 @@
+module.exports = {
+  keys: 'keys',
+  jsonp: {},
+  logger: {
+    consoleLevel: 'NONE',
+    level: 'NONE',
+    coreLogger: {
+      consoleLevel: 'NONE',
+      level: 'NONE',
+    },
+    disableConsoleAfterReady: true,
+  },
+};

--- a/plugins/jsonp/test/fixtures/jsonp-test/package.json
+++ b/plugins/jsonp/test/fixtures/jsonp-test/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "jsonp-test",
+  "version": "0.0.1"
+}

--- a/plugins/jsonp/test/jsonp.test.ts
+++ b/plugins/jsonp/test/jsonp.test.ts
@@ -1,0 +1,221 @@
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
+import { mm, MockApplication } from '@eggjs/mock';
+
+describe('test/jsonp.test.ts', () => {
+  let app: MockApplication;
+  beforeAll(() => {
+    app = mm.app({
+      baseDir: 'jsonp-test',
+    });
+    return app.ready();
+  });
+
+  afterAll(() => app.close());
+  afterEach(() => mm.restore());
+
+  it('should access acceptJSONP return false by default', () => {
+    assert.equal(app.mockContext().acceptJSONP, false);
+  });
+
+  it('should support json', async () => {
+    await app.httpRequest().get('/default').expect(200).expect({ foo: 'bar' });
+  });
+
+  it('should support jsonp', async () => {
+    await app
+      .httpRequest()
+      .get('/default?callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
+  });
+
+  it('should support _callback', async () => {
+    await app
+      .httpRequest()
+      .get('/default?_callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
+  });
+
+  it('should support jsonp if response is empty', async () => {
+    await app.httpRequest().get('/empty?callback=fn').expect(200).expect("/**/ typeof fn === 'function' && fn(null);");
+  });
+
+  it('should not support jsonp if not use jsonp middleware', async () => {
+    await app.httpRequest().get('/disable?_callback=fn').expect(200).expect({ foo: 'bar' });
+  });
+
+  it('should not support custom callback name', async () => {
+    await app
+      .httpRequest()
+      .get('/fn?fn=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
+  });
+
+  it('should not pass csrf', async () => {
+    await app.httpRequest().get('/csrf').expect(403);
+  });
+
+  it('should pass csrf with cookie', async () => {
+    await app
+      .httpRequest()
+      .get('/csrf')
+      .set('cookie', 'csrfToken=token;')
+      .set('x-csrf-token', 'token')
+      .expect(200)
+      .expect({ foo: 'bar' });
+  });
+
+  it('should pass csrf with cookie and support jsonp', async () => {
+    await app
+      .httpRequest()
+      .get('/csrf')
+      .set('cookie', 'csrfToken=token;')
+      .set('x-csrf-token', 'token')
+      .expect(200)
+      .expect({ foo: 'bar' });
+  });
+
+  it('should pass referrer white list check with subdomain', async () => {
+    await app
+      .httpRequest()
+      .get('/referrer/subdomain')
+      .set('referrer', 'http://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/subdomain')
+      .set('referrer', 'http://sub.test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/subdomain')
+      .set('referrer', 'https://sub.sub.test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/subdomain')
+      .set('referrer', 'https://sub.sub.test1.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+  });
+
+  it('should pass referrer white list with domain', async () => {
+    await app
+      .httpRequest()
+      .get('/referrer/equal')
+      .set('referrer', 'http://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/equal')
+      .set('referrer', 'https://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/equal')
+      .set('referrer', 'https://sub.sub.test.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+
+    await app
+      .httpRequest()
+      .get('/referrer/equal')
+      .set('referrer', 'https://sub.sub.test1.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+  });
+
+  it('should pass referrer white array and regexp', async () => {
+    await app
+      .httpRequest()
+      .get('/referrer/regexp')
+      .set('referrer', 'http://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/regexp')
+      .set('referrer', 'https://foo.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
+
+    await app
+      .httpRequest()
+      .get('/referrer/regexp')
+      .set('referrer', 'https://sub.sub.test.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+
+    await app
+      .httpRequest()
+      .get('/referrer/regexp')
+      .set('referrer', 'https://sub.sub.test1.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+  });
+
+  it('should pass when pass csrf but not hit referrer white list', async () => {
+    await app
+      .httpRequest()
+      .get('/both')
+      .set('cookie', 'csrfToken=token;')
+      .set('x-csrf-token', 'token')
+      .expect(200)
+      .expect({ foo: 'bar' });
+  });
+
+  it('should pass when not pass csrf but hit referrer white list', async () => {
+    await app.httpRequest().get('/both').set('referrer', 'https://test.com/').expect(200).expect({ foo: 'bar' });
+  });
+
+  it('should 403 when not pass csrf and not hit referrer white list', async () => {
+    await app
+      .httpRequest()
+      .get('/both')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+  });
+
+  it('should 403 when not pass csrf and referrer illegal', async () => {
+    await app
+      .httpRequest()
+      .get('/both')
+      .set('referrer', '/hello')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
+  });
+
+  it('should pass and return is a jsonp function', async () => {
+    await app
+      .httpRequest()
+      .get('/mark?_callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"jsonpFunction":true});');
+  });
+
+  it('should pass and return is not a jsonp function', async () => {
+    await app.httpRequest().get('/mark').expect(200).expect({ jsonpFunction: false });
+  });
+
+  it('should pass and return error message', async () => {
+    await app
+      .httpRequest()
+      .get('/error?_callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"msg":"jsonpFunction is error"});');
+  });
+});

--- a/plugins/jsonp/test/jsonp.test.ts
+++ b/plugins/jsonp/test/jsonp.test.ts
@@ -49,7 +49,7 @@ describe('test/jsonp.test.ts', () => {
     await app.httpRequest().get('/disable?_callback=fn').expect(200).expect({ foo: 'bar' });
   });
 
-  it('should not support custom callback name', async () => {
+  it('should support custom callback name', async () => {
     await app
       .httpRequest()
       .get('/fn?fn=fn')

--- a/plugins/jsonp/test/jsonp.test.ts
+++ b/plugins/jsonp/test/jsonp.test.ts
@@ -1,12 +1,15 @@
 import { strict as assert } from 'node:assert';
+import path from 'node:path';
+
 import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
-import { mm, MockApplication } from '@eggjs/mock';
+
+import { mm, type MockApplication } from '@eggjs/mock';
 
 describe('test/jsonp.test.ts', () => {
   let app: MockApplication;
   beforeAll(() => {
     app = mm.app({
-      baseDir: 'jsonp-test',
+      baseDir: path.join(import.meta.dirname, 'fixtures', 'jsonp-test'),
     });
     return app.ready();
   });

--- a/plugins/jsonp/tsconfig.json
+++ b/plugins/jsonp/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./",
-    "outDir": "dist",
-    "rootDir": "src"
-  },
-  "include": ["src/**/*.ts"],
-  "exclude": ["dist", "node_modules", "test"]
+    "baseUrl": "./"
+  }
 }

--- a/plugins/jsonp/tsconfig.json
+++ b/plugins/jsonp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/plugins/jsonp/tsdown.config.ts
+++ b/plugins/jsonp/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: 'src/**/*.ts',
+  unbundle: true,
+  dts: true,
+  exports: {
+    devExports: true,
+  },
+});

--- a/plugins/jsonp/vitest.config.ts
+++ b/plugins/jsonp/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});

--- a/plugins/jsonp/vitest.config.ts
+++ b/plugins/jsonp/vitest.config.ts
@@ -2,11 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
-    globals: true,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-    },
+    include: ['test/**/*.test.ts'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ catalogs:
     js-yaml:
       specifier: ^4.1.0
       version: 4.1.0
+    jsonp-body:
+      specifier: ^2.0.0
+      version: 2.0.0
     keygrip:
       specifier: ^1.0.2
       version: 1.1.0
@@ -812,9 +815,6 @@ importers:
       cluster-client:
         specifier: 'catalog:'
         version: 3.7.0
-      egg-errors:
-        specifier: 'catalog:'
-        version: 2.3.2
       egg-logger:
         specifier: 'catalog:'
         version: 3.6.1
@@ -1198,6 +1198,46 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
+
+  plugins/jsonp:
+    dependencies:
+      '@eggjs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      egg:
+        specifier: workspace:*
+        version: link:../../packages/egg
+      jsonp-body:
+        specifier: 'catalog:'
+        version: 2.0.0
+    devDependencies:
+      '@eggjs/mock':
+        specifier: workspace:*
+        version: link:../mock
+      '@eggjs/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.5.2
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.18.0(oxlint-tsgolint@0.2.0)
+      oxlint-tsgolint:
+        specifier: 'catalog:'
+        version: 0.2.0
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.0.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.4(oxc-resolver@11.8.3)(typescript@5.9.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.13(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@4.0.0-beta.13)(esbuild@0.25.10)(jiti@2.6.0)(less@4.4.1)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
 
   plugins/mock:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@eggjs/i18n':
       specifier: ^3.0.1
       version: 3.0.1
-    '@eggjs/jsonp':
-      specifier: ^3.0.0
-      version: 3.0.0
     '@eggjs/logrotator':
       specifier: ^4.0.0
       version: 4.1.0
@@ -777,8 +774,8 @@ importers:
         specifier: 'catalog:'
         version: 3.0.1
       '@eggjs/jsonp':
-        specifier: 'catalog:'
-        version: 3.0.0
+        specifier: workspace:*
+        version: link:../../plugins/jsonp
       '@eggjs/logrotator':
         specifier: 'catalog:'
         version: 4.1.0
@@ -1201,9 +1198,6 @@ importers:
 
   plugins/jsonp:
     dependencies:
-      '@eggjs/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       egg:
         specifier: workspace:*
         version: link:../../packages/egg
@@ -1220,15 +1214,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.5.2
-      oxlint:
-        specifier: 'catalog:'
-        version: 1.18.0(oxlint-tsgolint@0.2.0)
-      oxlint-tsgolint:
-        specifier: 'catalog:'
-        version: 0.2.0
-      rimraf:
-        specifier: 'catalog:'
-        version: 6.0.1
       tsdown:
         specifier: 'catalog:'
         version: 0.15.4(oxc-resolver@11.8.3)(typescript@5.9.2)
@@ -1974,10 +1959,6 @@ packages:
   '@eggjs/ip@2.1.0':
     resolution: {integrity: sha512-jOsufOpySKBld+N1GG8IAW9EEQNmQ6bDaBnrRlYFk6AspoxG8gAzXSW93ZFfEPwscS5rL7UbDUKyIHUkmkTPyw==}
     engines: {node: '>= 14.0.0'}
-
-  '@eggjs/jsonp@3.0.0':
-    resolution: {integrity: sha512-cYq+4LI5JtvZHSoyXSKJhSLswPwFOiE4XeCjP5rqszUnFZEnSVldWlcUemtCy54iel5LdcpC+H95SmrLt4MNkw==}
-    engines: {node: '>= 18.19.0'}
 
   '@eggjs/koa@2.22.2':
     resolution: {integrity: sha512-cqubIqo5SCDPVN2qJ/ZiIPsfWl0xvNRvdLc9h1h8s5zdUk33RyNmCP83Ur9WS3GWbew+rDpVkNReJUCPbvrxkg==}
@@ -11614,11 +11595,6 @@ snapshots:
       utility: 2.5.0
 
   '@eggjs/ip@2.1.0': {}
-
-  '@eggjs/jsonp@3.0.0':
-    dependencies:
-      '@eggjs/core': 6.5.0
-      jsonp-body: 2.0.0
 
   '@eggjs/koa@2.22.2':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,6 +113,7 @@ catalog:
   husky: ^9.1.7
   is-type-of: ^2.2.0
   jest-changed-files: ^30.0.0
+  jsonp-body: ^2.0.0
   js-yaml: ^4.1.0
   keygrip: ^1.0.2
   koa-bodyparser: ^4.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,6 @@ catalog:
   '@clack/prompts': ^0.11.0
   '@eggjs/compressible': ^3.0.0
   '@eggjs/i18n': ^3.0.1
-  '@eggjs/jsonp': ^3.0.0
   '@eggjs/logrotator': ^4.0.0
   '@eggjs/multipart': ^4.0.0
   '@eggjs/router': ^3.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -179,6 +179,7 @@ minimumReleaseAgeExclude:
   - '@rolldown/*'
   - '@vitejs/*'
   - '@oxc-project/*'
+  - egg
   - rolldown
   - vitest
   - vite

--- a/tools/create-egg/test/cli.test.ts
+++ b/tools/create-egg/test/cli.test.ts
@@ -121,6 +121,8 @@ test.skipIf(process.platform === 'win32')(
     expect(generatedFiles).matchSnapshot();
 
     // run test
+    console.log('run test', projectDir);
+    // execaCommandSync(`pnpm install`, { cwd: projectDir });
     const monoRepoDir = path.join(import.meta.dirname, '../../../');
     const eggDir = path.join(monoRepoDir, 'packages/egg');
     const mockDir = path.join(monoRepoDir, 'plugins/mock');
@@ -145,6 +147,7 @@ test.skipIf(process.platform === 'win32')('successfully scaffolds a project base
   expect(generatedFiles).matchSnapshot();
 
   // run test
+  execaCommandSync(`pnpm install`, { cwd: projectDir });
   const monoRepoDir = path.join(import.meta.dirname, '../../../');
   const eggDir = path.join(monoRepoDir, 'packages/egg');
   const mockDir = path.join(monoRepoDir, 'plugins/mock');

--- a/tools/create-egg/test/cli.test.ts
+++ b/tools/create-egg/test/cli.test.ts
@@ -121,12 +121,11 @@ test.skipIf(process.platform === 'win32')(
     expect(generatedFiles).matchSnapshot();
 
     // run test
-    console.log('run test', projectDir);
-    // execaCommandSync(`pnpm install`, { cwd: projectDir });
     const monoRepoDir = path.join(import.meta.dirname, '../../../');
     const eggDir = path.join(monoRepoDir, 'packages/egg');
     const mockDir = path.join(monoRepoDir, 'plugins/mock');
-    execaCommandSync(`pnpm link ${mockDir} ${eggDir}`, { cwd: projectDir });
+    const binDir = path.join(monoRepoDir, 'tools/egg-bin');
+    execaCommandSync(`pnpm link ${mockDir} ${eggDir} ${binDir}`, { cwd: projectDir });
     const { stdout: testStdout } = execaCommandSync('pnpm test:local', { cwd: projectDir });
     expect(testStdout).toContain('2 passed');
   }
@@ -147,11 +146,11 @@ test.skipIf(process.platform === 'win32')('successfully scaffolds a project base
   expect(generatedFiles).matchSnapshot();
 
   // run test
-  execaCommandSync(`pnpm install`, { cwd: projectDir });
   const monoRepoDir = path.join(import.meta.dirname, '../../../');
   const eggDir = path.join(monoRepoDir, 'packages/egg');
   const mockDir = path.join(monoRepoDir, 'plugins/mock');
-  execaCommandSync(`pnpm link ${mockDir} ${eggDir}`, { cwd: projectDir });
+  const binDir = path.join(monoRepoDir, 'tools/egg-bin');
+  execaCommandSync(`pnpm link ${mockDir} ${eggDir} ${binDir}`, { cwd: projectDir });
   const { stdout: testStdout } = execaCommandSync('pnpm test:local', { cwd: projectDir });
   expect(testStdout).toContain('2 passed');
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,9 @@
       "path": "./plugins/development"
     },
     {
+      "path": "./plugins/jsonp"
+    },
+    {
       "path": "./plugins/watcher"
     },
     {


### PR DESCRIPTION
Migrate @eggjs/jsonp plugin into the monorepo at plugins/jsonp:
- Update to version 4.0.0-beta.13
- Convert test framework from Mocha to Vitest
- Update dependencies to use workspace references
- Add tsdown build configuration
- Update to Node.js >=22.18.0 requirement
- Follow monorepo standards from CLAUDE.md

Based on https://github.com/eggjs/jsonp

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Built-in JSONP plugin: middleware, context helpers, configurable callback names, and JSONP-aware error handling.
  - Security options: CSRF enforcement and referrer whitelist validation.

- **Documentation**
  - Added README, CHANGELOG, and license for the JSONP plugin with usage and config guidance.

- **Chores**
  - New plugin package manifest, build/test configs, TypeScript typings, test fixtures and suites.
  - Workspace/dependency mapping updated; an unused dependency removed.
  - Tooling test updated to include additional bin linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->