### PR TITLE
feat(router): merge router package into monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,12 @@ This is the **Eggjs** framework - a progressive Node.js framework for building e
 - **`packages/koa-static-cache/`** - Static file serving with cache (merged from @eggjs/koa-static-cache)
   - `src/` - TypeScript source code for static cache middleware
   - `test/` - Test suite with Vitest
+- **`packages/router/`** - Router middleware for Koa/Egg (merged from @eggjs/router)
+  - `src/` - TypeScript source code for router implementation
+  - `test/` - Test suite with Vitest
+  - Provides RESTful resource routing and middleware composition
+  - Supports route parameter matching with path-to-regexp
+  - Includes EggRouter class with additional convenience methods
 - **`plugins/`** - Egg framework plugins (all plugins should be located here)
   - `development/` - Development plugin for local development (merged from @eggjs/development)
     - Provides development tools and auto-reload functionality

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/core",
   "dependencies": {
     "@eggjs/koa": "workspace:*",
-    "@eggjs/router": "catalog:",
+    "@eggjs/router": "workspace:*",
     "@eggjs/utils": "workspace:*",
     "egg-logger": "catalog:",
     "egg-path-matching": "catalog:",

--- a/packages/router/.gitignore
+++ b/packages/router/.gitignore
@@ -1,0 +1,1 @@
+!bench/run

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,0 +1,279 @@
+# Changelog
+
+## [3.0.6](https://github.com/eggjs/router/compare/v3.0.5...v3.0.6) (2025-03-27)
+
+
+### Bug Fixes
+
+* resources should support multiple middlewares ([#21](https://github.com/eggjs/router/issues/21)) ([acb9c4b](https://github.com/eggjs/router/commit/acb9c4b3e91f7cad0f9605e3a2ca5e68dad270b9))
+
+## [3.0.5](https://github.com/eggjs/egg-router/compare/v3.0.4...v3.0.5) (2024-06-16)
+
+
+### Bug Fixes
+
+* should support urls with controller string ([#15](https://github.com/eggjs/egg-router/issues/15)) ([b645095](https://github.com/eggjs/egg-router/commit/b6450955716eb7d965c357058cf5b93f9e49353f))
+
+## [3.0.4](https://github.com/eggjs/egg-router/compare/v3.0.3...v3.0.4) (2024-06-16)
+
+
+### Bug Fixes
+
+* should bind ctx to egg router controller this context ([#14](https://github.com/eggjs/egg-router/issues/14)) ([b5b5588](https://github.com/eggjs/egg-router/commit/b5b55887b90e77f2f19033c814b604301a6308e2))
+
+## [3.0.3](https://github.com/eggjs/egg-router/compare/v3.0.2...v3.0.3) (2024-06-16)
+
+
+### Bug Fixes
+
+* debug keyword use package.name + filename ([#13](https://github.com/eggjs/egg-router/issues/13)) ([3882819](https://github.com/eggjs/egg-router/commit/38828192d453234fe93bf4f23e1f1271645e4c85))
+
+## [3.0.2](https://github.com/eggjs/egg-router/compare/v3.0.1...v3.0.2) (2024-06-16)
+
+
+### Bug Fixes
+
+* support router.verb(method, path, controllerString) ([#12](https://github.com/eggjs/egg-router/issues/12)) ([34cea74](https://github.com/eggjs/egg-router/commit/34cea74a52a6651b5a5b30c4b2aee1c0776477a2))
+
+## [3.0.1](https://github.com/eggjs/egg-router/compare/v3.0.0...v3.0.1) (2024-06-15)
+
+
+### Bug Fixes
+
+* export types like ResourcesController ([#11](https://github.com/eggjs/egg-router/issues/11)) ([83d3309](https://github.com/eggjs/egg-router/commit/83d3309f7434bbd9a5f85efc5b52fa34dd0fe81d))
+
+## [3.0.0](https://github.com/eggjs/egg-router/compare/v2.0.1...v3.0.0) (2024-06-11)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 18.19.0 support
+
+- Drop generator function support
+- Drop Node.js < 18.19.0 support
+
+<!-- This is an auto-generated comment: release notes by coderabbit.ai
+-->
+
+## Summary by CodeRabbit
+
+- **New Features**
+- Introduced `EggRouter` class for defining RESTful routes and handling
+HTTP verbs.
+- Added new utility functions and type definitions to support enhanced
+routing and middleware functionalities.
+
+- **Bug Fixes**
+- Updated test cases to ensure compatibility with new routing and
+middleware functionalities.
+
+- **Documentation**
+- Updated examples in the `README.md` to reflect TypeScript syntax and
+ES module imports.
+- Mentioned breaking changes for version 3, including dropping support
+for generator functions and Node.js versions below 18.7.0.
+
+- **Breaking Changes**
+  - Dropped support for generator functions.
+  - Dropped support for Node.js versions below 18.7.0.
+
+- **Chores**
+  - Updated Node.js versions in the GitHub Actions workflow.
+  - Modified `.gitignore` to include additional patterns.
+  - Updated dependencies and dev dependencies in `package.json`.
+- Added new scripts for linting, testing, and pre-publish actions in
+`package.json`.
+  - Introduced a new `tsconfig.json` for strict TypeScript settings.
+
+<!-- end of auto-generated comment: release notes by coderabbit.ai -->
+
+### Features
+
+* support cjs and esm both ([#10](https://github.com/eggjs/egg-router/issues/10)) ([55149bc](https://github.com/eggjs/egg-router/commit/55149bc871def88d190e856e81cb9a48f18f3979))
+
+2.0.1 / 2021-07-12
+==================
+
+**fixes**
+  * [[`2c44ec0`](http://github.com/eggjs/egg-router/commit/2c44ec0bdeff1e8f46d899ed4386d1e28a93a854)] - fix: ensure ctx._matchedRoute and ctx._matchedRouteName to be correct (#7) (Yiyu He <<dead_horse@qq.com>>)
+
+2.0.0 / 2019-02-14
+==================
+
+**features**
+  * [[`f0b29ec`](https://github.com/eggjs/egg-router/commit/f0b29ec34df32ba9d872f6318f4febd2b4ef9359)] - refactor: use class instead prototype (#4) (fengmk2 <<fengmk2@gmail.com>>)
+
+1.2.0 / 2019-02-13
+==================
+
+**features**
+  * [[`1a0036a`](http://github.com/eggjs/egg-router/commit/1a0036a64a023b6b7993fecffe8062d5d0150971)] - feat: add routerPath to respond to routerName (#2) (Khaidi Chu <<i@2333.moe>>)
+
+**others**
+  * [[`ff723fd`](http://github.com/eggjs/egg-router/commit/ff723fd03630ec49d5fe861abf129a583d214d22)] - chore: add koa-router license (#3) (fengmk2 <<fengmk2@gmail.com>>)
+
+1.1.0 / 2019-01-30
+==================
+
+**features**
+  * [[`b318dd5`](http://github.com/eggjs/egg-router/commit/b318dd5ff2eea60013ed62b2a435f803c12bf20f)] - feat: add egg-router (dead-horse <<dead_horse@qq.com>>)
+
+**fixes**
+  * [[`b3db7b4`](http://github.com/eggjs/egg-router/commit/b3db7b41988d3bf1b4e885ed76b3a8165c1d3b1d)] - fix: add missing dependencies koa-convert (dead-horse <<dead_horse@qq.com>>)
+  * [[`c280336`](http://github.com/eggjs/egg-router/commit/c2803368a8256bc9504ae3c821eefeb9d1fcbc4d)] - fix: only support node@8 (dead-horse <<dead_horse@qq.com>>)
+  * [[`7a887a2`](http://github.com/eggjs/egg-router/commit/7a887a252445e602c2ea7e1c6f4cde52a433644d)] - fix: update license (dead-horse <<dead_horse@qq.com>>)
+
+**others**
+  * [[`ae40168`](http://github.com/eggjs/egg-router/commit/ae4016862fb8bdaf30e730a9278fbb1455d8b75d)] - docs: clean doc (dead-horse <<dead_horse@qq.com>>)
+  * [[`e4f21a8`](http://github.com/eggjs/egg-router/commit/e4f21a8ed6dfd72c4d6f4a13bbda9a4e90b0401c)] - chore: fix history (dead-horse <<dead_horse@qq.com>>)
+
+1.0.0 / 2019-01-30
+==================
+
+**others**
+  * [[`d6496e0`](http://github.com/eggjs/egg-router/commit/d6496e09be6b0f91dcb96611f31ec5ab6ad8ac78)] - refactor: rename to @eggjs/router (dead-horse <<dead_horse@qq.com>>)
+
+-------------------------------
+
+# Release History from koa-router
+
+## 7.4.0
+
+- Fix router.url() for multiple nested routers [#407](https://github.com/alexmingoia/koa-router/pull/407)
+- `layer.name` added to `ctx` at `ctx.routerName` during routing [#412](https://github.com/alexmingoia/koa-router/pull/412)
+- Router.use() was erroneously settings `(.*)` as a prefix to all routers nested with .use that did not pass an explicit prefix string as the first argument. This resulted in routes being matched that should not have been, included the running of multiple route handlers in error. [#369](https://github.com/alexmingoia/koa-router/issues/369) and [#410](https://github.com/alexmingoia/koa-router/issues/410) include information on this issue.
+
+## 7.3.0
+
+- Router#url() now accepts query parameters to add to generated urls [#396](https://github.com/alexmingoia/koa-router/pull/396)
+
+## 7.2.1
+
+- Respond to CORS preflights with 200, 0 length body [#359](https://github.com/alexmingoia/koa-router/issues/359)
+
+## 7.2.0
+
+- Fix a bug in Router#url and append Router object to ctx. [#350](https://github.com/alexmingoia/koa-router/pull/350)
+- Adds `_matchedRouteName` to context [#337](https://github.com/alexmingoia/koa-router/pull/337)
+- Respond to CORS preflights with 200, 0 length body [#359](https://github.com/alexmingoia/koa-router/issues/359)
+
+## 7.1.1
+
+- Fix bug where param handlers were run out of order [#282](https://github.com/alexmingoia/koa-router/pull/282)
+
+## 7.1.0
+
+- Backports: merge 5.4 work into the 7.x upstream. See 5.4.0 updates for more details.
+
+## 7.0.1
+
+- Fix: allowedMethods should be ctx.method not this.method [#215](https://github.com/alexmingoia/koa-router/pull/215)
+
+## 7.0.0
+
+- The API has changed to match the new promise-based middleware
+  signature of koa 2. See the
+  [koa 2.x readme](https://github.com/koajs/koa/tree/2.0.0-alpha.3) for more
+  information.
+- Middleware is now always run in the order declared by `.use()` (or `.get()`,
+  etc.), which matches Express 4 API.
+
+## 5.4.0
+
+- Expose matched route at `ctx._matchedRoute`.
+
+## 5.3.0
+
+- Register multiple routes with array of paths [#203](https://github.com/alexmingoia/koa-router/issue/143).
+- Improved router.url() [#143](https://github.com/alexmingoia/koa-router/pull/143)
+- Adds support for named routes and regular expressions
+  [#152](https://github.com/alexmingoia/koa-router/pull/152)
+- Add support for custom throw functions for 405 and 501 responses [#206](https://github.com/alexmingoia/koa-router/pull/206)
+
+## 5.2.3
+
+- Fix for middleware running twice when nesting routes [#184](https://github.com/alexmingoia/koa-router/issues/184)
+
+## 5.2.2
+
+- Register routes without params before those with params [#183](https://github.com/alexmingoia/koa-router/pull/183)
+- Fix for allowed methods [#182](https://github.com/alexmingoia/koa-router/issues/182)
+
+## 5.2.0
+
+- Add support for async/await. Resolves [#130](https://github.com/alexmingoia/koa-router/issues/130).
+- Add support for array of paths by Router#use(). Resolves [#175](https://github.com/alexmingoia/koa-router/issues/175).
+- Inherit param middleware when nesting routers. Fixes [#170](https://github.com/alexmingoia/koa-router/issues/170).
+- Default router middleware without path to root. Fixes [#161](https://github.com/alexmingoia/koa-router/issues/161), [#155](https://github.com/alexmingoia/koa-router/issues/155), [#156](https://github.com/alexmingoia/koa-router/issues/156).
+- Run nested router middleware after parent's. Fixes [#156](https://github.com/alexmingoia/koa-router/issues/156).
+- Remove dependency on koa-compose.
+
+## 5.1.1
+
+- Match routes in order they were defined. Fixes #131.
+
+## 5.1.0
+
+- Support mounting router middleware at a given path.
+
+## 5.0.1
+
+- Fix bug with missing parameters when nesting routers.
+
+## 5.0.0
+
+- Remove confusing API for extending koa app with router methods. Router#use()
+  does not have the same behavior as app#use().
+- Add support for nesting routes.
+- Remove support for regular expression routes to achieve nestable routers and
+  enable future trie-based routing optimizations.
+
+## 4.3.2
+
+- Do not send 405 if route matched but status is 404. Fixes #112, closes #114.
+
+## 4.3.1
+
+- Do not run middleware if not yielded to by previous middleware. Fixes #115.
+
+## 4.3.0
+
+- Add support for router prefixes.
+- Add MIT license.
+
+## 4.2.0
+
+- Fixed issue with router middleware being applied even if no route was
+matched.
+- Router.url - new static method to generate url from url pattern and data
+
+## 4.1.0
+
+Private API changed to separate context parameter decoration from route
+matching. `Router#match` and `Route#match` are now pure functions that return
+an array of routes that match the URL path.
+
+For modules using this private API that need to determine if a method and path
+match a route, `route.methods` must be checked against the routes returned from
+`router.match()`:
+
+```javascript
+var matchedRoute = router.match(path).filter(function (route) {
+  return ~route.methods.indexOf(method);
+}).shift();
+```
+
+## 4.0.0
+
+405, 501, and OPTIONS response handling was moved into separate middleware
+`router.allowedMethods()`. This resolves incorrect 501 or 405 responses when
+using multiple routers.
+
+### Breaking changes
+
+4.x is mostly backwards compatible with 3.x, except for the following:
+
+- Instantiating a router with `new` and `app` returns the router instance,
+  whereas 3.x returns the router middleware. When creating a router in 4.x, the
+  only time router middleware is returned is when creating using the
+  `Router(app)` signature (with `app` and without `new`).

--- a/packages/router/CHANGELOG.md
+++ b/packages/router/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+> [!IMPORTANT]
+> Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
+
+---
+
+## 4.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
 ## [3.0.6](https://github.com/eggjs/router/compare/v3.0.5...v3.0.6) (2025-03-27)
 
 

--- a/packages/router/LICENSE
+++ b/packages/router/LICENSE
@@ -1,0 +1,48 @@
+The MIT License (MIT)
+
+Copyright (c) 2019-present Alibaba Group Holding Limited and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+egg-router is a fork of koa-router with some additional features.
+
+- koa-router is licensed as follows:
+  """
+    The MIT License (MIT)
+
+    Copyright (c) 2015 Alexander C. Mingoia
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  """

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,0 +1,466 @@
+# @eggjs/router
+
+[![NPM version](https://img.shields.io/npm/v/@eggjs/router.svg?style=flat-square)](https://npmjs.org/package/@eggjs/router)
+[![NPM download](https://img.shields.io/npm/dm/@eggjs/router.svg?style=flat-square)](https://npmjs.org/package/@eggjs/router)
+[![Node.js CI](https://github.com/eggjs/router/actions/workflows/nodejs.yml/badge.svg?branch=master)](https://github.com/eggjs/router/actions/workflows/nodejs.yml)
+[![Test coverage](https://img.shields.io/codecov/c/github/eggjs/router.svg?style=flat-square)](https://codecov.io/gh/eggjs/router)
+[![Known Vulnerabilities](https://snyk.io/test/npm/@eggjs/router/badge.svg?style=flat-square)](https://snyk.io/test/npm/@eggjs/router)
+[![Node.js Version](https://img.shields.io/node/v/@eggjs/router.svg?style=flat)](https://nodejs.org/en/download/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/eggjs/router)
+
+Router core component for [Egg.js](https://github.com/eggjs).
+
+> **This repository is a fork of [koa-router](https://github.com/alexmingoia/koa-router).** with some additional features.
+> And thanks for the great work of @alexmingoia and the original team.
+
+## API Reference
+
+- [@eggjs/router](#eggjsrouter)
+  - [API Reference](#api-reference)
+    - [Router ⏏](#router-)
+      - [new Router(\[opts\])](#new-routeropts)
+      - [router.get|put|post|patch|delete|del ⇒ Router](#routergetputpostpatchdeletedel--router)
+      - [Named routes](#named-routes)
+      - [Multiple middleware](#multiple-middleware)
+    - [Nested routers](#nested-routers)
+      - [Router prefixes](#router-prefixes)
+      - [URL parameters](#url-parameters)
+      - [router.routes ⇒ function](#routerroutes--function)
+      - [router.use(\[path\], middleware) ⇒ Router](#routerusepath-middleware--router)
+      - [router.prefix(prefix) ⇒ Router](#routerprefixprefix--router)
+      - [router.allowedMethods(\[options\]) ⇒ function](#routerallowedmethodsoptions--function)
+      - [router.redirect(source, destination, \[code\]) ⇒ Router](#routerredirectsource-destination-code--router)
+      - [router.route(name) ⇒ Layer | false](#routerroutename--layer--false)
+      - [router.url(name, params, \[options\]) ⇒ String | Error](#routerurlname-params-options--string--error)
+      - [router.param(param, middleware) ⇒ Router](#routerparamparam-middleware--router)
+      - [Router.url(path, params \[, options\]) ⇒ String](#routerurlpath-params--options--string)
+  - [Tests](#tests)
+  - [Breaking changes on v3](#breaking-changes-on-v3)
+  - [License](#license)
+  - [Contributors](#contributors)
+
+<a name="exp_module_egg-router--Router"></a>
+
+### Router ⏏
+
+**Kind**: Exported class
+<a name="new_module_egg-router--Router_new"></a>
+
+#### new Router([opts])
+
+Create a new router.
+
+| Param         | Type                | Description         |
+| ------------- | ------------------- | ------------------- |
+| [opts]        | <code>Object</code> |                     |
+| [opts.prefix] | <code>String</code> | prefix router paths |
+
+**Example**
+Basic usage:
+
+```ts
+import Koa from '@eggjs/koa';
+import Router from '@eggjs/router';
+
+const app = new Koa();
+const router = new Router();
+
+router.get('/', async (ctx, next) => {
+  // ctx.router available
+});
+
+app.use(router.routes()).use(router.allowedMethods());
+```
+
+<a name="module_egg-router--Router+get|put|post|patch|delete|del"></a>
+
+#### router.get|put|post|patch|delete|del ⇒ <code>Router</code>
+
+Create `router.verb()` methods, where _verb_ is one of the HTTP verbs such
+as `router.get()` or `router.post()`.
+
+Match URL patterns to callback functions or controller actions using `router.verb()`,
+where **verb** is one of the HTTP verbs such as `router.get()` or `router.post()`.
+
+Additionaly, `router.all()` can be used to match against all methods.
+
+```ts
+router
+  .get('/', (ctx, next) => {
+    ctx.body = 'Hello World!';
+  })
+  .post('/users', (ctx, next) => {
+    // ...
+  })
+  .put('/users/:id', (ctx, next) => {
+    // ...
+  })
+  .del('/users/:id', (ctx, next) => {
+    // ...
+  })
+  .all('/users/:id', (ctx, next) => {
+    // ...
+  });
+```
+
+When a route is matched, its path is available at `ctx.routePath` and if named,
+the name is available at `ctx.routeName`
+
+Route paths will be translated to regular expressions using
+[path-to-regexp](https://github.com/pillarjs/path-to-regexp).
+
+Query strings will not be considered when matching requests.
+
+#### Named routes
+
+Routes can optionally have names. This allows generation of URLs and easy
+renaming of URLs during development.
+
+```ts
+router.get('user', '/users/:id', (ctx, next) => {
+  // ...
+});
+
+router.url('user', 3);
+// => "/users/3"
+```
+
+#### Multiple middleware
+
+Multiple middleware may be given:
+
+```ts
+router.get(
+  '/users/:id',
+  (ctx, next) => {
+    return User.findOne(ctx.params.id).then(function (user) {
+      ctx.user = user;
+      next();
+    });
+  },
+  ctx => {
+    console.log(ctx.user);
+    // => { id: 17, name: "Alex" }
+  }
+);
+```
+
+### Nested routers
+
+Nesting routers is supported:
+
+```ts
+const forums = new Router();
+const posts = new Router();
+
+posts.get('/', (ctx, next) => {...});
+posts.get('/:pid', (ctx, next) => {...});
+forums.use('/forums/:fid/posts', posts.routes(), posts.allowedMethods());
+
+// responds to "/forums/123/posts" and "/forums/123/posts/123"
+app.use(forums.routes());
+```
+
+#### Router prefixes
+
+Route paths can be prefixed at the router level:
+
+```ts
+const router = new Router({
+  prefix: '/users'
+});
+
+router.get('/', ...); // responds to "/users"
+router.get('/:id', ...); // responds to "/users/:id"
+```
+
+#### URL parameters
+
+Named route parameters are captured and added to `ctx.params`.
+
+```ts
+router.get('/:category/:title', (ctx, next) => {
+  console.log(ctx.params);
+  // => { category: 'programming', title: 'how-to-node' }
+});
+```
+
+The [path-to-regexp](https://github.com/pillarjs/path-to-regexp) module is
+used to convert paths to regular expressions.
+
+**Kind**: instance property of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param        | Type                  | Description         |
+| ------------ | --------------------- | ------------------- |
+| path         | <code>String</code>   |                     |
+| [middleware] | <code>function</code> | route middleware(s) |
+| callback     | <code>function</code> | route callback      |
+
+<a name="module_egg-router--Router+routes"></a>
+
+#### router.routes ⇒ <code>function</code>
+
+Returns router middleware which dispatches a route matching the request.
+
+**Kind**: instance property of <code>[Router](#exp_module_egg-router--Router)</code>
+<a name="module_egg-router--Router+use"></a>
+
+#### router.use([path], middleware) ⇒ <code>Router</code>
+
+Use given middleware.
+
+Middleware run in the order they are defined by `.use()`. They are invoked
+sequentially, requests start at the first middleware and work their way
+"down" the middleware stack.
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param      | Type                  |
+| ---------- | --------------------- |
+| [path]     | <code>String</code>   |
+| middleware | <code>function</code> |
+| [...]      | <code>function</code> |
+
+**Example**
+
+```ts
+// session middleware will run before authorize
+router.use(session()).use(authorize());
+
+// use middleware only with given path
+router.use('/users', userAuth());
+
+// or with an array of paths
+router.use(['/users', '/admin'], userAuth());
+
+app.use(router.routes());
+```
+
+<a name="module_egg-router--Router+prefix"></a>
+
+#### router.prefix(prefix) ⇒ <code>Router</code>
+
+Set the path prefix for a Router instance that was already initialized.
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param  | Type                |
+| ------ | ------------------- |
+| prefix | <code>String</code> |
+
+**Example**
+
+```ts
+router.prefix('/things/:thing_id');
+```
+
+<a name="module_egg-router--Router+allowedMethods"></a>
+
+#### router.allowedMethods([options]) ⇒ <code>function</code>
+
+Returns separate middleware for responding to `OPTIONS` requests with
+an `Allow` header containing the allowed methods, as well as responding
+with `405 Method Not Allowed` and `501 Not Implemented` as appropriate.
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param                      | Type                  | Description                                                             |
+| -------------------------- | --------------------- | ----------------------------------------------------------------------- |
+| [options]                  | <code>Object</code>   |                                                                         |
+| [options.throw]            | <code>Boolean</code>  | throw error instead of setting status and header                        |
+| [options.notImplemented]   | <code>function</code> | throw the returned value in place of the default NotImplemented error   |
+| [options.methodNotAllowed] | <code>function</code> | throw the returned value in place of the default MethodNotAllowed error |
+
+**Example**
+
+```ts
+import Koa from '@eggjs/koa';
+import Router from '@eggjs/router';
+
+const app = new Koa();
+const router = new Router();
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+```
+
+**Example with [Boom](https://github.com/hapijs/boom)**
+
+```ts
+import Koa from '@eggjs/koa';
+import Router from '@eggjs/router';
+import Boom from 'boom';
+
+const app = new Koa();
+const router = new Router();
+
+app.use(router.routes());
+app.use(
+  router.allowedMethods({
+    throw: true,
+    notImplemented: () => new Boom.notImplemented(),
+    methodNotAllowed: () => new Boom.methodNotAllowed(),
+  })
+);
+```
+
+<a name="module_egg-router--Router+redirect"></a>
+
+#### router.redirect(source, destination, [code]) ⇒ <code>Router</code>
+
+Redirect `source` to `destination` URL with optional 30x status `code`.
+
+Both `source` and `destination` can be route names.
+
+```javascript
+router.redirect('/login', 'sign-in');
+```
+
+This is equivalent to:
+
+```ts
+router.all('/login', ctx => {
+  ctx.redirect('/sign-in');
+  ctx.status = 301;
+});
+```
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param       | Type                | Description                      |
+| ----------- | ------------------- | -------------------------------- |
+| source      | <code>String</code> | URL or route name.               |
+| destination | <code>String</code> | URL or route name.               |
+| [code]      | <code>Number</code> | HTTP status code (default: 301). |
+
+<a name="module_egg-router--Router+route"></a>
+
+#### router.route(name) ⇒ <code>Layer</code> &#124; <code>false</code>
+
+Lookup route with given `name`.
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param | Type                |
+| ----- | ------------------- |
+| name  | <code>String</code> |
+
+<a name="module_egg-router--Router+url"></a>
+
+#### router.url(name, params, [options]) ⇒ <code>String</code> &#124; <code>Error</code>
+
+Generate URL for route. Takes a route name and map of named `params`.
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param           | Type                                           | Description       |
+| --------------- | ---------------------------------------------- | ----------------- |
+| name            | <code>String</code>                            | route name        |
+| params          | <code>Object</code>                            | url parameters    |
+| [options]       | <code>Object</code>                            | options parameter |
+| [options.query] | <code>Object</code> &#124; <code>String</code> | query options     |
+
+**Example**
+
+```ts
+router.get('user', '/users/:id', (ctx, next) => {
+  // ...
+});
+
+router.url('user', 3);
+// => "/users/3"
+
+router.url('user', { id: 3 });
+// => "/users/3"
+
+router.use((ctx, next) => {
+  // redirect to named route
+  ctx.redirect(ctx.router.url('sign-in'));
+});
+
+router.url('user', { id: 3 }, { query: { limit: 1 } });
+// => "/users/3?limit=1"
+
+router.url('user', { id: 3 }, { query: 'limit=1' });
+// => "/users/3?limit=1"
+```
+
+<a name="module_egg-router--Router+param"></a>
+
+#### router.param(param, middleware) ⇒ <code>Router</code>
+
+Run middleware for named route parameters. Useful for auto-loading or
+validation.
+
+**Kind**: instance method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param      | Type                  |
+| ---------- | --------------------- |
+| param      | <code>String</code>   |
+| middleware | <code>function</code> |
+
+**Example**
+
+```ts
+router
+  .param('user', (id, ctx, next) => {
+    ctx.user = users[id];
+    if (!ctx.user) return (ctx.status = 404);
+    return next();
+  })
+  .get('/users/:user', ctx => {
+    ctx.body = ctx.user;
+  })
+  .get('/users/:user/friends', ctx => {
+    return ctx.user.getFriends().then(function (friends) {
+      ctx.body = friends;
+    });
+  });
+// /users/3 => {"id": 3, "name": "Alex"}
+// /users/3/friends => [{"id": 4, "name": "TJ"}]
+```
+
+<a name="module_egg-router--Router.url"></a>
+
+#### Router.url(path, params [, options]) ⇒ <code>String</code>
+
+Generate URL from url pattern and given `params`.
+
+**Kind**: static method of <code>[Router](#exp_module_egg-router--Router)</code>
+
+| Param           | Type                                           | Description       |
+| --------------- | ---------------------------------------------- | ----------------- |
+| path            | <code>String</code>                            | url pattern       |
+| params          | <code>Object</code>                            | url parameters    |
+| [options]       | <code>Object</code>                            | options parameter |
+| [options.query] | <code>Object</code> &#124; <code>String</code> | query options     |
+
+**Example**
+
+```ts
+const url = Router.url('/users/:id', { id: 1 });
+// => "/users/1"
+
+const url = Router.url('/users/:id', { id: 1 }, { query: { active: true } });
+// => "/users/1?active=true"
+```
+
+## Tests
+
+Run tests using `npm test`.
+
+## Breaking changes on v3
+
+- Drop generator function support
+- Drop Node.js < 18.19.0 support
+
+## License
+
+[MIT](LICENSE)
+
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=eggjs/router)](https://github.com/eggjs/router/graphs/contributors)
+
+Made with [contributors-img](https://contrib.rocks).

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -2,8 +2,6 @@
 
 [![NPM version](https://img.shields.io/npm/v/@eggjs/router.svg?style=flat-square)](https://npmjs.org/package/@eggjs/router)
 [![NPM download](https://img.shields.io/npm/dm/@eggjs/router.svg?style=flat-square)](https://npmjs.org/package/@eggjs/router)
-[![Node.js CI](https://github.com/eggjs/router/actions/workflows/nodejs.yml/badge.svg?branch=master)](https://github.com/eggjs/router/actions/workflows/nodejs.yml)
-[![Test coverage](https://img.shields.io/codecov/c/github/eggjs/router.svg?style=flat-square)](https://codecov.io/gh/eggjs/router)
 [![Known Vulnerabilities](https://snyk.io/test/npm/@eggjs/router/badge.svg?style=flat-square)](https://snyk.io/test/npm/@eggjs/router)
 [![Node.js Version](https://img.shields.io/node/v/@eggjs/router.svg?style=flat)](https://nodejs.org/en/download/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
@@ -461,6 +459,6 @@ Run tests using `npm test`.
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=eggjs/router)](https://github.com/eggjs/router/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg)](https://github.com/eggjs/egg/graphs/contributors)
 
 Made with [contributors-img](https://contrib.rocks).

--- a/packages/router/bench/Makefile
+++ b/packages/router/bench/Makefile
@@ -1,0 +1,23 @@
+all: middleware
+
+middleware:
+	@./run 1 false
+	@./run 5 false
+	@./run 10 false
+	@./run 20 false
+	@./run 50 false
+	@./run 100 false
+	@./run 200 false
+	@./run 500 false
+	@./run 1000 false
+	@./run 1 true
+	@./run 5 true
+	@./run 10 true
+	@./run 20 true
+	@./run 50 true
+	@./run 100 true
+	@./run 200 true
+	@./run 500 true
+	@./run 1000 true
+
+.PHONY: all middleware

--- a/packages/router/bench/run
+++ b/packages/router/bench/run
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+export FACTOR=$1
+export USE_MIDDLEWARE=$2
+export PORT=3333
+
+host="http://localhost:$PORT"
+
+node "$(dirname $0)/server.cjs" &
+
+pid=$!
+
+curl \
+  --retry-connrefused \
+  --retry 5 \
+  --retry-delay 0 \
+  -s \
+  "$host/_health" \
+  > /dev/null
+
+# siege -c 50 -t 8 "$host/10/child/grandchild/%40"
+wrk "$host/10/child/grandchild/%40" \
+  -d 3 \
+  -c 50 \
+  -t 8 \
+  | grep 'Requests/sec' \
+  | awk '{ print "  " $2 }'
+
+kill $pid

--- a/packages/router/bench/server.cjs
+++ b/packages/router/bench/server.cjs
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { Application } = require('@eggjs/koa');
+const { Router } = require('../dist/commonjs');
+
+const app = new Application();
+const router = new Router();
+
+const ok = ctx => {
+  ctx.status = 200;
+};
+const n = parseInt(process.env.FACTOR || '10', 10);
+const useMiddleware = process.env.USE_MIDDLEWARE === 'true';
+
+router.get('/_health', ok);
+
+for (let i = n; i > 0; i--) {
+  if (useMiddleware) router.use((ctx, next) => next());
+  router.get(`/${i}/one`, ok);
+  router.get(`/${i}/one/two`, ok);
+  router.get(`/${i}/one/two/:three`, ok);
+  router.get(`/${i}/one/two/:three/:four?`, ok);
+  router.get(`/${i}/one/two/:three/:four?/five`, ok);
+  router.get(`/${i}/one/two/:three/:four?/five/six`, ok);
+}
+
+const grandchild = new Router();
+
+if (useMiddleware) grandchild.use((ctx, next) => next());
+grandchild.get('/', ok);
+grandchild.get('/:id', ok);
+grandchild.get('/:id/seven', ok);
+grandchild.get('/:id/seven(/eight)?', ok);
+
+for (let i = n; i > 0; i--) {
+  const child = new Router();
+  if (useMiddleware) child.use((ctx, next) => next());
+  child.get(`/:${''.padStart(i, 'a')}`, ok);
+  // child.use('/grandchild', grandchild);
+  // router.use(`/${i}/child`, child);
+}
+
+if (process.env.DEBUG) {
+  console.log(require('../lib/utils').inspect(router));
+}
+
+app.use(router.routes());
+
+process.stdout.write(`mw: ${useMiddleware} factor: ${n}`);
+
+app.listen(process.env.PORT);

--- a/packages/router/bench/server.cjs
+++ b/packages/router/bench/server.cjs
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const { Application } = require('@eggjs/koa');
-const { Router } = require('../dist/commonjs');
+const { Router } = require('..');
 
 const app = new Application();
 const router = new Router();

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@eggjs/router",
+  "version": "4.0.0-beta.15",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Router middleware for egg/koa. Provides RESTful resource routing.",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/eggjs/egg.git",
+    "directory": "packages/router"
+  },
+  "bugs": {
+    "url": "https://github.com/eggjs/egg/issues"
+  },
+  "author": "eggjs",
+  "keywords": [
+    "koa",
+    "middleware",
+    "router",
+    "route"
+  ],
+  "dependencies": {
+    "http-errors": "catalog:",
+    "inflection": "catalog:",
+    "is-type-of": "catalog:",
+    "koa-compose": "catalog:",
+    "methods": "catalog:",
+    "path-to-regexp": "catalog:",
+    "urijs": "catalog:",
+    "utility": "catalog:"
+  },
+  "devDependencies": {
+    "@eggjs/koa": "workspace:*",
+    "@eggjs/tsconfig": "workspace:*",
+    "@types/http-errors": "catalog:",
+    "@types/koa-compose": "catalog:",
+    "@types/methods": "catalog:",
+    "@types/urijs": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "scripts": {
+    "lint": "oxlint --type-aware",
+    "lint:fix": "npm run lint -- --fix",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run lint:fix && vitest run",
+    "clean": "rimraf dist",
+    "build": "tsdown",
+    "prepublishOnly": "npm run build",
+    "bench": "cd bench && make"
+  },
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "module": "./dist/index.js"
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -4,9 +4,6 @@
   "engines": {
     "node": ">=22.18.0"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "description": "Router middleware for egg/koa. Provides RESTful resource routing.",
   "repository": {
     "type": "git",
@@ -16,6 +13,7 @@
   "bugs": {
     "url": "https://github.com/eggjs/egg/issues"
   },
+  "homepage": "https://github.com/eggjs/egg/tree/next/packages/router",
   "author": "eggjs",
   "keywords": [
     "koa",
@@ -35,6 +33,7 @@
   },
   "devDependencies": {
     "@eggjs/koa": "workspace:*",
+    "@eggjs/supertest": "workspace:*",
     "@eggjs/tsconfig": "workspace:*",
     "@types/http-errors": "catalog:",
     "@types/koa-compose": "catalog:",
@@ -46,12 +45,11 @@
   },
   "scripts": {
     "lint": "oxlint --type-aware",
-    "lint:fix": "npm run lint -- --fix",
     "typecheck": "tsc --noEmit",
-    "test": "npm run lint:fix && vitest run",
-    "clean": "rimraf dist",
+    "test": "vitest run",
     "build": "tsdown",
     "prepublishOnly": "npm run build",
+    "prebench": "npm run build",
     "bench": "cd bench && make"
   },
   "license": "MIT",
@@ -61,12 +59,20 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./EggRouter": "./src/EggRouter.ts",
+    "./Layer": "./src/Layer.ts",
+    "./Router": "./src/Router.ts",
+    "./types": "./src/types.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public",
     "exports": {
       ".": "./dist/index.js",
+      "./EggRouter": "./dist/EggRouter.js",
+      "./Layer": "./dist/Layer.js",
+      "./Router": "./dist/Router.js",
+      "./types": "./dist/types.js",
       "./package.json": "./package.json"
     }
   },

--- a/packages/router/src/EggRouter.ts
+++ b/packages/router/src/EggRouter.ts
@@ -1,10 +1,12 @@
 import assert from 'node:assert';
+
 import { encodeURIComponent as safeEncodeURIComponent } from 'utility';
 import inflection from 'inflection';
 import methods from 'methods';
 import { isGeneratorFunction } from 'is-type-of';
-import { RegisterOptions, Router, RouterMethod, RouterOptions } from './Router.js';
-import { MiddlewareFunc, Next, ResourcesController } from './types.js';
+
+import { type RegisterOptions, Router, type RouterMethod, type RouterOptions } from './Router.ts';
+import { type MiddlewareFunc, type Next, type ResourcesController } from './types.ts';
 
 interface RestfulOptions {
   suffix?: string;

--- a/packages/router/src/EggRouter.ts
+++ b/packages/router/src/EggRouter.ts
@@ -1,0 +1,382 @@
+import assert from 'node:assert';
+import { encodeURIComponent as safeEncodeURIComponent } from 'utility';
+import inflection from 'inflection';
+import methods from 'methods';
+import { isGeneratorFunction } from 'is-type-of';
+import { RegisterOptions, Router, RouterMethod, RouterOptions } from './Router.js';
+import { MiddlewareFunc, Next, ResourcesController } from './types.js';
+
+interface RestfulOptions {
+  suffix?: string;
+  namePrefix?: string;
+  method: string | string[];
+  member?: true;
+}
+
+const REST_MAP: Record<string, RestfulOptions> = {
+  index: {
+    suffix: '',
+    method: 'GET',
+  },
+  new: {
+    namePrefix: 'new_',
+    member: true,
+    suffix: 'new',
+    method: 'GET',
+  },
+  create: {
+    suffix: '',
+    method: 'POST',
+  },
+  show: {
+    member: true,
+    suffix: ':id',
+    method: 'GET',
+  },
+  edit: {
+    member: true,
+    namePrefix: 'edit_',
+    suffix: ':id/edit',
+    method: 'GET',
+  },
+  update: {
+    member: true,
+    namePrefix: '',
+    suffix: ':id',
+    method: ['PATCH', 'PUT'],
+  },
+  destroy: {
+    member: true,
+    namePrefix: 'destroy_',
+    suffix: ':id',
+    method: 'DELETE',
+  },
+};
+
+interface Application {
+  controller: Record<string, any>;
+}
+
+/**
+ * FIXME: move these patch into @eggjs/router
+ */
+export class EggRouter extends Router {
+  readonly app: Application;
+
+  /**
+   * @class
+   * @param {Object} opts - Router options.
+   * @param {Application} app - Application object.
+   */
+  constructor(opts: RouterOptions, app: Application) {
+    super(opts);
+    this.app = app;
+  }
+
+  verb(
+    method: RouterMethod | RouterMethod[],
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middleware: (MiddlewareFunc | string)[]
+  ) {
+    const { path, middlewares, options } = this._formatRouteParams(nameOrPath, pathOrMiddleware, middleware);
+    if (typeof method === 'string') {
+      method = [method];
+    }
+    this.register(path, method, middlewares, options);
+    return this;
+  }
+
+  // const METHODS = [ 'head', 'options', 'get', 'put', 'patch', 'post', 'delete', 'all' ];
+  head(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  head(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  head(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('head', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  options(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  options(
+    name: string,
+    path: string | RegExp | (string | RegExp)[],
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router;
+  options(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('options', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  get(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  get(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  get(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('get', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  put(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  put(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  put(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('put', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  patch(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  patch(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  patch(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('patch', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  post(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  post(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  post(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('post', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  delete(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  delete(
+    name: string,
+    path: string | RegExp | (string | RegExp)[],
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router;
+  delete(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb('delete', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+  all(path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  all(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: (MiddlewareFunc | string)[]): Router;
+  all(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: (MiddlewareFunc | string)[]
+  ): Router {
+    return this.verb(methods, nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  register(
+    path: string | RegExp | (string | RegExp)[],
+    methods: string[],
+    middleware: MiddlewareFunc | string | (MiddlewareFunc | string | ResourcesController)[],
+    opts?: RegisterOptions
+  ) {
+    // patch register to support bind ctx function middleware and string controller
+    middleware = Array.isArray(middleware) ? middleware : [middleware];
+    for (const mw of middleware) {
+      if (isGeneratorFunction(mw)) {
+        throw new TypeError(
+          methods.toString() + ' `' + path + '`: Please use async function instead of generator function'
+        );
+      }
+    }
+    const middlewares = convertMiddlewares(middleware, this.app);
+    return super.register(path, methods, middlewares, opts);
+  }
+
+  /**
+   * restful router api
+   * @param {String} name - Router name
+   * @param {String} prefix - url prefix
+   * @param {Function} middleware - middleware or controller
+   * @example
+   * ```js
+   * app.resources('/posts', 'posts')
+   * app.resources('posts', '/posts', 'posts')
+   * app.resources('posts', '/posts', app.role.can('user'), app.controller.posts)
+   * app.resources('posts', '/posts', middleware1, middleware2, app.controller.posts)
+   * ```
+   *
+   * Examples:
+   *
+   * ```js
+   * app.resources('/posts', 'posts')
+   * ```
+   *
+   * yield router mapping
+   *
+   * Method | Path            | Route Name     | Controller.Action
+   * -------|-----------------|----------------|-----------------------------
+   * GET    | /posts          | posts          | app.controller.posts.index
+   * GET    | /posts/new      | new_post       | app.controller.posts.new
+   * GET    | /posts/:id      | post           | app.controller.posts.show
+   * GET    | /posts/:id/edit | edit_post      | app.controller.posts.edit
+   * POST   | /posts          | posts          | app.controller.posts.create
+   * PATCH  | /posts/:id      | post           | app.controller.posts.update
+   * DELETE | /posts/:id      | post           | app.controller.posts.destroy
+   *
+   * app.router.url can generate url based on arguments
+   * ```js
+   * app.router.url('posts')
+   * => /posts
+   * app.router.url('post', { id: 1 })
+   * => /posts/1
+   * app.router.url('new_post')
+   * => /posts/new
+   * app.router.url('edit_post', { id: 1 })
+   * => /posts/1/edit
+   * ```
+   * @return {Router} return route object.
+   * @since 1.0.0
+   */
+  resources(prefix: string, controller: string | ResourcesController): Router;
+  resources(prefix: string, middleware: MiddlewareFunc, controller: string | ResourcesController): Router;
+  resources(name: string, prefix: string, controller: string | ResourcesController): Router;
+  resources(name: string, prefix: string, middleware: MiddlewareFunc, controller: string | ResourcesController): Router;
+  resources(nameOrPath: string | RegExp, ...middleware: (MiddlewareFunc | string | ResourcesController)[]): Router;
+  resources(
+    nameOrPath: string | RegExp,
+    pathOrMiddleware: string | RegExp | MiddlewareFunc | ResourcesController,
+    ...middleware: (MiddlewareFunc | string | ResourcesController)[]
+  ): Router {
+    const { path, middlewares, options } = this._formatRouteParams(nameOrPath, pathOrMiddleware, middleware);
+    // last argument is Controller object
+    const controller = resolveController(middlewares.pop()!, this.app);
+    for (const key in REST_MAP) {
+      const action = controller[key] as MiddlewareFunc;
+      if (!action) continue;
+
+      const opts = REST_MAP[key];
+      let routeName;
+      if (opts.member) {
+        routeName = inflection.singularize(options.name ?? '');
+      } else {
+        routeName = inflection.pluralize(options.name ?? '');
+      }
+      if (opts.namePrefix) {
+        routeName = opts.namePrefix + routeName;
+      }
+      const prefix = (path as string).replace(/\/$/, '');
+      const urlPath = opts.suffix ? `${prefix}/${opts.suffix}` : prefix;
+      const method = Array.isArray(opts.method) ? opts.method : [opts.method];
+      this.register(urlPath, method, middlewares.concat(action), { name: routeName });
+    }
+    return this;
+  }
+
+  /**
+   * @param {String} name - Router name
+   * @param {Object} params - more parameters
+   * @example
+   * ```js
+   * router.url('edit_post', { id: 1, name: 'foo', page: 2 })
+   * => /posts/1/edit?name=foo&page=2
+   * router.url('posts', { name: 'foo&1', page: 2 })
+   * => /posts?name=foo%261&page=2
+   * ```
+   * @return {String} url by path name and query params.
+   * @since 1.0.0
+   */
+  url(name: string, params?: Record<string, string | number | (string | number)[]>): string {
+    const route = this.route(name);
+    if (!route) return '';
+
+    const args = params;
+    let url = route.path;
+
+    assert(!(url instanceof RegExp), `Can't get the url for regExp ${url} for by name '${name}'`);
+
+    const queries = [];
+    if (typeof args === 'object' && args !== null) {
+      const replacedParams: string[] = [];
+      url = url.replace(/:([a-zA-Z_]\w*)/g, ($0, key) => {
+        if (key in args) {
+          const values = args[key];
+          replacedParams.push(key);
+          return safeEncodeURIComponent(Array.isArray(values) ? String(values[0]) : String(values));
+        }
+        return $0;
+      });
+
+      for (const key in args) {
+        if (replacedParams.includes(key)) {
+          continue;
+        }
+        const values = args[key];
+        const encodedKey = safeEncodeURIComponent(key);
+        if (Array.isArray(values)) {
+          for (const val of values) {
+            queries.push(`${encodedKey}=${safeEncodeURIComponent(String(val))}`);
+          }
+        } else {
+          queries.push(`${encodedKey}=${safeEncodeURIComponent(String(values))}`);
+        }
+      }
+    }
+
+    if (queries.length > 0) {
+      const queryStr = queries.join('&');
+      if (!url.includes('?')) {
+        url = `${url}?${queryStr}`;
+      } else {
+        url = `${url}&${queryStr}`;
+      }
+    }
+
+    return url;
+  }
+
+  /**
+   * @alias to url()
+   */
+  pathFor(name: string, params?: Record<string, string | number | (string | number)[]>) {
+    return this.url(name, params);
+  }
+}
+
+/**
+ * resolve controller from string to function
+ * @param {String|Function} controller input controller
+ * @param {Application} app egg application instance
+ */
+function resolveController(controller: string | MiddlewareFunc | ResourcesController, app: Application) {
+  if (typeof controller === 'string') {
+    // resolveController('foo.bar.Home', app)
+    const actions = controller.split('.');
+    let obj = app.controller;
+    actions.forEach(key => {
+      obj = obj[key];
+      if (!obj) throw new Error(`app.controller.${controller} not exists`);
+    });
+    controller = obj as any;
+  }
+  // ensure controller is exists
+  if (!controller) throw new Error('controller not exists');
+  return controller as any;
+}
+
+/**
+ * 1. ensure controller(last argument) support string
+ * - [url, controller]: app.get('/home', 'home');
+ * - [name, url, controller(string)]: app.get('posts', '/posts', 'posts.list');
+ * - [name, url, controller]: app.get('posts', '/posts', app.controller.posts.list);
+ * - [name, url(regexp), controller]: app.get('regRouter', /\/home\/index/, 'home.index');
+ * - [name, url, middleware, [...], controller]: `app.get(/user/:id', hasLogin, canGetUser, 'user.show');`
+ *
+ * 2. bind ctx to controller `this`
+ *
+ * @param  {Array} middlewares middlewares and controller(last middleware)
+ * @param  {Application} app  egg application instance
+ */
+function convertMiddlewares(middlewares: (MiddlewareFunc | string | ResourcesController)[], app: Application) {
+  // ensure controller is resolved
+  const controller = resolveController(middlewares.pop()!, app);
+  function wrappedController(ctx: any, next: Next) {
+    return controller.apply(ctx, [ctx, next]);
+  }
+  return [...(middlewares as MiddlewareFunc[]), wrappedController];
+}

--- a/packages/router/src/Layer.ts
+++ b/packages/router/src/Layer.ts
@@ -1,0 +1,282 @@
+import { debuglog } from 'node:util';
+import pathToRegExp, { type Key } from 'path-to-regexp';
+import URI from 'urijs';
+import { decodeURIComponent as safeDecodeURIComponent } from 'utility';
+import { isGeneratorFunction } from 'is-type-of';
+import type { MiddlewareFunc, MiddlewareFuncWithParamProperty, ParamMiddlewareFunc } from './types.js';
+
+const debug = debuglog('@eggjs/router:Layer');
+
+export interface LayerOptions {
+  prefix?: string;
+  /** route name */
+  name?: string;
+  /** case sensitive (default: false) */
+  sensitive?: boolean;
+  /** require the trailing slash (default: false) */
+  strict?: boolean;
+  ignoreCaptures?: boolean;
+  end?: boolean;
+}
+
+export interface LayerURLOptions {
+  query?: string | object;
+}
+
+export class Layer {
+  readonly opts: LayerOptions;
+  readonly name?: string;
+  readonly methods: string[] = [];
+  readonly stack: MiddlewareFuncWithParamProperty[];
+  path: string | RegExp;
+  regexp: RegExp;
+  paramNames: Key[] = [];
+
+  /**
+   * Initialize a new routing Layer with given `method`, `path`, and `middleware`.
+   *
+   * @param {String|RegExp} path Path string or regular expression.
+   * @param {Array} methods Array of HTTP verbs.
+   * @param {Array|Function} middlewares Layer callback/middleware or series of.
+   * @param {Object=} opts optional params
+   * @param {String=} opts.name route name
+   * @param {String=} opts.sensitive case sensitive (default: false)
+   * @param {String=} opts.strict require the trailing slash (default: false)
+   * @private
+   */
+  constructor(
+    path: string | RegExp,
+    methods: string[],
+    middlewares: MiddlewareFunc | MiddlewareFunc[],
+    opts?: LayerOptions | string
+  ) {
+    if (typeof opts === 'string') {
+      // new Layer(path, methods, middlewares, name);
+      opts = { name: opts };
+    }
+    this.opts = opts ?? {};
+    this.opts.prefix = this.opts.prefix ?? '';
+    this.name = this.opts.name;
+    this.stack = Array.isArray(middlewares) ? middlewares : [middlewares];
+
+    for (const method of methods) {
+      const l = this.methods.push(method.toUpperCase());
+      if (this.methods[l - 1] === 'GET') {
+        this.methods.unshift('HEAD');
+      }
+    }
+
+    // ensure middleware is a function
+    this.stack.forEach(fn => {
+      const type = typeof fn;
+      if (type !== 'function') {
+        throw new TypeError(
+          methods.toString() +
+            ' `' +
+            (this.opts.name || path) +
+            '`: `middleware` ' +
+            'must be a function, not `' +
+            type +
+            '`'
+        );
+      }
+      if (isGeneratorFunction(fn)) {
+        throw new TypeError(
+          methods.toString() +
+            ' `' +
+            (this.opts.name || path) +
+            '`: Please use async function instead of generator function'
+        );
+      }
+    });
+
+    this.path = path;
+    this.regexp = pathToRegExp(path, this.paramNames, this.opts);
+
+    debug('defined route %s %s', this.methods, this.opts.prefix + this.path);
+  }
+
+  /**
+   * Returns whether request `path` matches route.
+   *
+   * @param {String} path path string
+   * @return {Boolean} matched or not
+   * @private
+   */
+  match(path: string): boolean {
+    return this.regexp.test(path);
+  }
+
+  /**
+   * Returns map of URL parameters for given `path` and `paramNames`.
+   *
+   * @param {String} _path path string
+   * @param {Array.<String>} captures captures strings
+   * @param {Object=} [existingParams] existing params
+   * @return {Object} params object
+   * @private
+   */
+  params(_path: string, captures: Array<string>, existingParams?: Record<string, string>): Record<string, string> {
+    const params = existingParams ?? {};
+
+    for (let len = captures.length, i = 0; i < len; i++) {
+      const paramName = this.paramNames[i];
+      if (paramName) {
+        const c = captures[i];
+        params[paramName.name] = c ? safeDecodeURIComponent(c) : c;
+      }
+    }
+    return params;
+  }
+
+  /**
+   * Returns array of regexp url path captures.
+   *
+   * @param {String} path path string
+   * @return {Array.<String>} captures strings
+   * @private
+   */
+  captures(path: string): Array<string> {
+    if (this.opts.ignoreCaptures) return [];
+    const m = path.match(this.regexp);
+    return m ? m.slice(1) : [];
+  }
+
+  /**
+   * Generate URL for route using given `params`.
+   *
+   * @example
+   *
+   * ```javascript
+   * var route = new Layer(['GET'], '/users/:id', fn);
+   *
+   * route.url(123); // => "/users/123"
+   * route.url('123'); // => "/users/123"
+   * route.url({ id: 123 }); // => "/users/123"
+   * ```
+   *
+   * @param {Object} params url parameters
+   * @param {Object} paramsOrOptions optional parameters
+   * @return {String} url string
+   * @private
+   */
+  url(params?: string | number | object, ...paramsOrOptions: (string | number | object | LayerURLOptions)[]): string {
+    let args: Array<string | number | object> | object = params as object;
+    const url = (this.path as string).replace(/\(\.\*\)/g, '');
+    const toPath = pathToRegExp.compile(url);
+    let options: LayerURLOptions | undefined;
+
+    if (params !== undefined && typeof params !== 'object') {
+      args = [params, ...paramsOrOptions];
+      // route.url(stringOrNumber, params1, ..., options);
+      if (Array.isArray(args)) {
+        const lastIndex = args.length - 1;
+        if (typeof args[lastIndex] === 'object') {
+          options = args[lastIndex];
+          args = args.slice(0, lastIndex);
+        }
+      }
+    } else if (typeof params === 'object') {
+      if (typeof paramsOrOptions[0] === 'object' && 'query' in paramsOrOptions[0]) {
+        // route.url(param, options);
+        options = paramsOrOptions[0];
+      }
+    }
+
+    const tokens = pathToRegExp.parse(url);
+    let replace: Record<string, any> = {};
+
+    if (Array.isArray(args)) {
+      for (let len = tokens.length, i = 0, j = 0; i < len; i++) {
+        const token = tokens[i];
+        if (typeof token === 'object' && token.name) {
+          replace[token.name] = args[j++];
+        }
+      }
+    } else if (tokens.some(token => typeof token === 'object' && token.name)) {
+      // route.url(params);
+      replace = params as object;
+    } else {
+      // route.url(options);
+      options = params as LayerURLOptions;
+    }
+
+    const replaced = toPath(replace);
+
+    if (options?.query) {
+      const urlObject = new URI(replaced);
+      urlObject.search(options.query);
+      return urlObject.toString();
+    }
+
+    return replaced;
+  }
+
+  /**
+   * Run validations on route named parameters.
+   *
+   * @example
+   *
+   * ```javascript
+   * router
+   *   .param('user', function (id, ctx, next) {
+   *     ctx.user = users[id];
+   *     if (!user) return ctx.status = 404;
+   *     next();
+   *   })
+   *   .get('/users/:user', function (ctx, next) {
+   *     ctx.body = ctx.user;
+   *   });
+   * ```
+   *
+   * @param {String} param param string
+   * @param {Function} fn middleware function
+   * @return {Layer} layer instance
+   * @private
+   */
+  param(param: string, fn: ParamMiddlewareFunc): Layer {
+    const stack = this.stack;
+    const params = this.paramNames;
+    const middleware: MiddlewareFuncWithParamProperty = function (this: any, ctx, next) {
+      return fn.call(this, ctx.params[param], ctx, next);
+    };
+    middleware.param = param;
+
+    const names = params.map(p => {
+      return p.name;
+    });
+
+    const x = names.indexOf(param);
+    if (x > -1) {
+      // iterate through the stack, to figure out where to place the handler fn
+      stack.some(function (fn, i) {
+        // param handlers are always first, so when we find an fn w/o a param property, stop here
+        // if the param handler at this part of the stack comes after the one we are adding, stop here
+        if (!fn.param || names.indexOf(fn.param) > x) {
+          // inject this param handler right before the current item
+          stack.splice(i, 0, middleware);
+          return true; // then break the loop
+        }
+        return false;
+      });
+    }
+
+    return this;
+  }
+
+  /**
+   * Prefix route path.
+   *
+   * @param {String} prefix prefix string
+   * @return {Layer} layer instance
+   * @private
+   */
+  setPrefix(prefix: string): Layer {
+    if (this.path) {
+      this.path = prefix + this.path;
+      this.paramNames = [];
+      this.regexp = pathToRegExp(this.path, this.paramNames, this.opts);
+    }
+    return this;
+  }
+}

--- a/packages/router/src/Layer.ts
+++ b/packages/router/src/Layer.ts
@@ -1,11 +1,13 @@
 import { debuglog } from 'node:util';
+
 import pathToRegExp, { type Key } from 'path-to-regexp';
 import URI from 'urijs';
 import { decodeURIComponent as safeDecodeURIComponent } from 'utility';
 import { isGeneratorFunction } from 'is-type-of';
-import type { MiddlewareFunc, MiddlewareFuncWithParamProperty, ParamMiddlewareFunc } from './types.js';
 
-const debug = debuglog('@eggjs/router:Layer');
+import type { MiddlewareFunc, MiddlewareFuncWithParamProperty, ParamMiddlewareFunc } from './types.ts';
+
+const debug = debuglog('egg/router:Layer');
 
 export interface LayerOptions {
   prefix?: string;

--- a/packages/router/src/Router.ts
+++ b/packages/router/src/Router.ts
@@ -7,10 +7,16 @@ import assert from 'node:assert';
 import compose from 'koa-compose';
 import HttpError from 'http-errors';
 import methods from 'methods';
-import { Layer, LayerURLOptions } from './Layer.js';
-import { MiddlewareFunc, MiddlewareFuncWithRouter, Next, ParamMiddlewareFunc, ResourcesController } from './types.js';
+import { Layer, type LayerURLOptions } from './Layer.ts';
+import {
+  type MiddlewareFunc,
+  type MiddlewareFuncWithRouter,
+  type Next,
+  type ParamMiddlewareFunc,
+  type ResourcesController,
+} from './types.ts';
 
-const debug = debuglog('@eggjs/router:Router');
+const debug = debuglog('egg/router:Router');
 
 export type RouterMethod = (typeof methods)[0];
 

--- a/packages/router/src/Router.ts
+++ b/packages/router/src/Router.ts
@@ -1,0 +1,1167 @@
+/**
+ * RESTful resource routing middleware for eggjs.
+ */
+
+import { debuglog } from 'node:util';
+import assert from 'node:assert';
+import compose from 'koa-compose';
+import HttpError from 'http-errors';
+import methods from 'methods';
+import { Layer, LayerURLOptions } from './Layer.js';
+import { MiddlewareFunc, MiddlewareFuncWithRouter, Next, ParamMiddlewareFunc, ResourcesController } from './types.js';
+
+const debug = debuglog('@eggjs/router:Router');
+
+export type RouterMethod = (typeof methods)[0];
+
+export interface RouterOptions {
+  methods?: string[];
+  prefix?: string;
+  sensitive?: boolean;
+  strict?: boolean;
+  routerPath?: string;
+}
+
+export interface RegisterOptions {
+  name?: string;
+  prefix?: string;
+  sensitive?: boolean;
+  strict?: boolean;
+  ignoreCaptures?: boolean;
+  end?: boolean;
+}
+
+export interface AllowedMethodsOptions {
+  throw?: boolean;
+  notImplemented?: () => Error;
+  methodNotAllowed?: () => Error;
+}
+
+export interface MatchedResult {
+  // matched path
+  path: Layer[];
+  // matched path and method(including none method)
+  pathAndMethod: Layer[];
+  // method matched or not
+  route: boolean;
+}
+
+export class Router {
+  readonly opts: RouterOptions;
+  readonly methods: string[];
+  /** Layer stack */
+  readonly stack: Layer[] = [];
+  readonly params: Record<string, ParamMiddlewareFunc> = {};
+
+  /**
+   * Create a new router.
+   *
+   * @example
+   *
+   * Basic usage:
+   *
+   * ```javascript
+   * var Koa = require('koa');
+   * var Router = require('koa-router');
+   *
+   * var app = new Koa();
+   * var router = new Router();
+   *
+   * router.get('/', (ctx, next) => {
+   *   // ctx.router available
+   * });
+   *
+   * app
+   *   .use(router.routes())
+   *   .use(router.allowedMethods());
+   * ```
+   *
+   * @alias module:koa-router
+   * @param {Object=} opts optional
+   * @param {String=} opts.prefix prefix router paths
+   * @class
+   */
+  constructor(opts?: RouterOptions) {
+    this.opts = opts ?? {};
+    this.methods = this.opts.methods ?? ['HEAD', 'OPTIONS', 'GET', 'PUT', 'PATCH', 'POST', 'DELETE'];
+  }
+
+  /**
+   * Use given middleware.
+   *
+   * Middleware run in the order they are defined by `.use()`. They are invoked
+   * sequentially, requests start at the first middleware and work their way
+   * "down" the middleware stack.
+   *
+   * @example
+   *
+   * ```javascript
+   * // session middleware will run before authorize
+   * router
+   *   .use(session())
+   *   .use(authorize());
+   *
+   * // use middleware only with given path
+   * router.use('/users', userAuth());
+   *
+   * // or with an array of paths
+   * router.use(['/users', '/admin'], userAuth());
+   *
+   * app.use(router.routes());
+   * ```
+   *
+   * @param {String=} path path string
+   * @param {Function} middleware middleware function
+   * @return {Router} router instance
+   */
+  use(...middlewares: MiddlewareFunc[]): Router;
+  use(path: string | string[], ...middlewares: MiddlewareFunc[]): Router;
+  use(pathOrMiddleware: string | string[] | MiddlewareFunc, ...middlewares: MiddlewareFunc[]): Router {
+    // support array of paths
+    // use(paths, ...middlewares)
+    if (Array.isArray(pathOrMiddleware) && typeof pathOrMiddleware[0] === 'string') {
+      for (const path of pathOrMiddleware) {
+        this.use(path, ...middlewares);
+      }
+      return this;
+    }
+
+    let path = '';
+    let hasPath = false;
+    if (typeof pathOrMiddleware === 'string') {
+      // use(path, ...middlewares)
+      path = pathOrMiddleware;
+      hasPath = true;
+    } else if (typeof pathOrMiddleware === 'function') {
+      // use(...middlewares)
+      middlewares = [pathOrMiddleware, ...middlewares];
+    }
+
+    for (const m of middlewares as MiddlewareFuncWithRouter<Router>[]) {
+      if (m.router) {
+        for (const nestedLayer of m.router.stack) {
+          if (path) {
+            nestedLayer.setPrefix(path);
+          }
+          if (this.opts.prefix) {
+            nestedLayer.setPrefix(this.opts.prefix);
+          }
+          this.stack.push(nestedLayer);
+        }
+
+        if (this.params) {
+          for (const key in this.params) {
+            m.router.param(key, this.params[key]);
+          }
+        }
+      } else {
+        this.register(path || '(.*)', [], m, { end: false, ignoreCaptures: !hasPath });
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   * Set the path prefix for a Router instance that was already initialized.
+   *
+   * @example
+   *
+   * ```javascript
+   * router.prefix('/things/:thing_id')
+   * ```
+   *
+   * @param {String} prefix prefix string
+   * @return {Router} router instance
+   */
+  prefix(prefix: string): Router {
+    prefix = prefix.replace(/\/$/, '');
+    this.opts.prefix = prefix;
+
+    for (const layer of this.stack) {
+      layer.setPrefix(prefix);
+    }
+
+    return this;
+  }
+
+  /**
+   * Returns router middleware which dispatches a route matching the request.
+   *
+   * @return {Function} middleware function
+   */
+  routes(): MiddlewareFuncWithRouter<Router> {
+    const dispatch = (ctx: any, next: Next) => {
+      const routerPath: string = this.opts.routerPath || ctx.routerPath || ctx.path;
+      const matched = this.match(routerPath, ctx.method);
+      debug('dispatch: %s %s, routerPath: %s, matched: %s', ctx.method, ctx.path, routerPath, matched.route);
+
+      if (ctx.matched) {
+        (ctx.matched as Layer[]).push(...matched.path);
+      } else {
+        ctx.matched = matched.path;
+      }
+      ctx.router = this;
+
+      if (!matched.route) {
+        return next();
+      }
+
+      const matchedLayers = matched.pathAndMethod;
+      const layerChain = matchedLayers.reduce<MiddlewareFunc[]>((memo, layer) => {
+        memo.push((ctx, next) => {
+          // ctx.captures = layer.captures(routerPath, ctx.captures);
+          ctx.captures = layer.captures(routerPath);
+          ctx.params = layer.params(routerPath, ctx.captures, ctx.params);
+          // ctx._matchedRouteName & ctx._matchedRoute for compatibility
+          ctx._matchedRouteName = ctx.routerName = layer.name;
+          if (!layer.name) {
+            ctx._matchedRouteName = undefined;
+          }
+          ctx._matchedRoute = ctx.routerPath = layer.path;
+          return next();
+        });
+        return memo.concat(layer.stack);
+      }, []);
+
+      return compose(layerChain)(ctx, next);
+    };
+
+    dispatch.router = this;
+    return dispatch;
+  }
+
+  /**
+   * @alias to routes()
+   */
+  middleware() {
+    return this.routes();
+  }
+
+  /**
+   * Returns separate middleware for responding to `OPTIONS` requests with
+   * an `Allow` header containing the allowed methods, as well as responding
+   * with `405 Method Not Allowed` and `501 Not Implemented` as appropriate.
+   *
+   * @example
+   *
+   * ```javascript
+   * var Koa = require('koa');
+   * var Router = require('koa-router');
+   *
+   * var app = new Koa();
+   * var router = new Router();
+   *
+   * app.use(router.routes());
+   * app.use(router.allowedMethods());
+   * ```
+   *
+   * **Example with [Boom](https://github.com/hapijs/boom)**
+   *
+   * ```javascript
+   * var Koa = require('koa');
+   * var Router = require('koa-router');
+   * var Boom = require('boom');
+   *
+   * var app = new Koa();
+   * var router = new Router();
+   *
+   * app.use(router.routes());
+   * app.use(router.allowedMethods({
+   *   throw: true,
+   *   notImplemented: () => new Boom.notImplemented(),
+   *   methodNotAllowed: () => new Boom.methodNotAllowed()
+   * }));
+   * ```
+   *
+   * @param {Object=} options optional params
+   * @param {Boolean=} options.throw throw error instead of setting status and header
+   * @param {Function=} options.notImplemented throw the returned value in place of the default NotImplemented error
+   * @param {Function=} options.methodNotAllowed throw the returned value in place of the default MethodNotAllowed error
+   * @return {Function} middleware function
+   */
+  allowedMethods(options?: AllowedMethodsOptions): MiddlewareFunc {
+    const implemented = this.methods;
+
+    return async function allowedMethods(ctx: any, next: Next) {
+      await next();
+      if (ctx.status && ctx.status !== 404) return;
+
+      const allowed: Record<string, string> = {};
+      ctx.matched.forEach((route: Router) => {
+        route.methods.forEach(method => {
+          allowed[method] = method;
+        });
+      });
+      const allowedMethods = Object.keys(allowed);
+
+      if (!implemented.includes(ctx.method)) {
+        if (options?.throw) {
+          let notImplementedThrowable: Error;
+          if (typeof options?.notImplemented === 'function') {
+            notImplementedThrowable = options.notImplemented(); // set whatever the user returns from their function
+          } else {
+            notImplementedThrowable = new HttpError.NotImplemented();
+          }
+          throw notImplementedThrowable;
+        } else {
+          ctx.status = 501;
+          ctx.set('Allow', allowedMethods.join(', '));
+        }
+      } else if (allowedMethods.length > 0) {
+        if (ctx.method === 'OPTIONS') {
+          ctx.status = 200;
+          ctx.body = '';
+          ctx.set('Allow', allowedMethods.join(', '));
+        } else if (!allowed[ctx.method]) {
+          if (options?.throw) {
+            let notAllowedThrowable: Error;
+            if (typeof options?.methodNotAllowed === 'function') {
+              notAllowedThrowable = options.methodNotAllowed(); // set whatever the user returns from their function
+            } else {
+              notAllowedThrowable = new HttpError.MethodNotAllowed();
+            }
+            throw notAllowedThrowable;
+          } else {
+            ctx.status = 405;
+            ctx.set('Allow', allowedMethods.join(', '));
+          }
+        }
+      }
+    };
+  }
+
+  /**
+   * Redirect `source` to `destination` URL with optional 30x status `code`.
+   *
+   * Both `source` and `destination` can be route names.
+   *
+   * ```javascript
+   * router.redirect('/login', 'sign-in');
+   * ```
+   *
+   * This is equivalent to:
+   *
+   * ```javascript
+   * router.all('/login', ctx => {
+   *   ctx.redirect('/sign-in');
+   *   ctx.status = 301;
+   * });
+   * ```
+   *
+   * @param {String} source URL or route name.
+   * @param {String} destination URL or route name.
+   * @param {Number=} status HTTP status code (default: 301).
+   * @return {Router} router instance
+   */
+  redirect(source: string, destination: string, status: number = 301): Router {
+    // lookup source route by name
+    if (source[0] !== '/') {
+      const routeUrl = this.url(source);
+      if (routeUrl instanceof Error) {
+        throw routeUrl;
+      }
+      source = routeUrl;
+    }
+
+    // lookup destination route by name
+    if (destination[0] !== '/') {
+      const routeUrl = this.url(destination);
+      if (routeUrl instanceof Error) {
+        throw routeUrl;
+      }
+      destination = routeUrl;
+    }
+
+    return this.all(source, ctx => {
+      ctx.redirect(destination);
+      ctx.status = status;
+    });
+  }
+
+  /**
+   * Create and register a route.
+   *
+   * @param {String|RegExp|(String|RegExp)[]} path Path string.
+   * @param {String[]} methods Array of HTTP verbs.
+   * @param {Function|Function[]} middleware Multiple middleware also accepted.
+   * @param {Object} [opts] optional params
+   * @private
+   */
+  register(
+    path: string | RegExp | (string | RegExp)[],
+    methods: string[],
+    middleware: MiddlewareFunc | MiddlewareFunc[],
+    opts?: RegisterOptions
+  ): Layer | Layer[] {
+    // support array of paths
+    if (Array.isArray(path)) {
+      const routes: Layer[] = [];
+      for (const p of path) {
+        const route = this.#register(p, methods, middleware, opts);
+        routes.push(route);
+      }
+      return routes;
+    }
+
+    // create route
+    const route = this.#register(path, methods, middleware, opts);
+    return route;
+  }
+
+  #register(
+    path: string | RegExp,
+    methods: string[],
+    middleware: MiddlewareFunc | MiddlewareFunc[],
+    opts?: RegisterOptions
+  ): Layer {
+    opts = opts ?? {};
+    // create route
+    const route = new Layer(path, methods, middleware, {
+      end: opts.end === false ? opts.end : true,
+      name: opts.name,
+      sensitive: opts.sensitive ?? this.opts.sensitive ?? false,
+      strict: opts.strict ?? this.opts.strict ?? false,
+      prefix: opts.prefix ?? this.opts.prefix ?? '',
+      ignoreCaptures: opts.ignoreCaptures,
+    });
+
+    // FIXME: why???
+    if (this.opts.prefix) {
+      route.setPrefix(this.opts.prefix);
+    }
+
+    // add parameter middleware to the new route layer
+    for (const param in this.params) {
+      route.param(param, this.params[param]);
+    }
+
+    this.stack.push(route);
+    return route;
+  }
+
+  /**
+   * Lookup route with given `name`.
+   *
+   * @param {String} name route name
+   * @return {Layer|false} layer instance of false
+   */
+  route(name: string): Layer | false {
+    for (const route of this.stack) {
+      if (route.name === name) {
+        return route;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Generate URL for route. Takes a route name and map of named `params`.
+   *
+   * @example
+   *
+   * ```javascript
+   * router.get('user', '/users/:id', (ctx, next) => {
+   *   // ...
+   * });
+   *
+   * router.url('user', 3);
+   * // => "/users/3"
+   *
+   * router.url('user', { id: 3 });
+   * // => "/users/3"
+   *
+   * router.use((ctx, next) => {
+   *   // redirect to named route
+   *   ctx.redirect(ctx.router.url('sign-in'));
+   * })
+   *
+   * router.url('user', { id: 3 }, { query: { limit: 1 } });
+   * // => "/users/3?limit=1"
+   *
+   * router.url('user', { id: 3 }, { query: "limit=1" });
+   * // => "/users/3?limit=1"
+   * ```
+   */
+  url(
+    name: string,
+    params?: string | number | object,
+    ...paramsOrOptions: (string | number | object | LayerURLOptions)[]
+  ): string | Error {
+    const route = this.route(name);
+    if (route) {
+      return route.url(params, ...paramsOrOptions);
+    }
+    return new Error(`No route found for name: ${name}`);
+  }
+
+  /**
+   * Generate URL from url pattern and given `params`.
+   *
+   * @example
+   *
+   * ```javascript
+   * var url = Router.url('/users/:id', { id: 1 });
+   * // => "/users/1"
+   * ```
+   *
+   * @param {String} path url pattern
+   * @param {Object} params url parameters
+   * @return {String} url string
+   */
+  static url(
+    path: string,
+    params?: string | number | object,
+    ...paramsOrOptions: (string | number | object | LayerURLOptions)[]
+  ): string {
+    return Layer.prototype.url.call({ path }, params, ...paramsOrOptions);
+  }
+
+  /**
+   * Match given `path` and return corresponding routes.
+   *
+   * @param {String} path path string
+   * @param {String} method method name
+   * @return {Object.<path, pathAndMethod>} returns layers that matched path and
+   * path and method.
+   * @private
+   */
+  match(path: string, method: string): MatchedResult {
+    const matched: MatchedResult = {
+      // matched path
+      path: [],
+      // matched path and method(including none method)
+      pathAndMethod: [],
+      // method matched or not
+      route: false,
+    };
+
+    for (const layer of this.stack) {
+      debug('test %s %s', layer.path, layer.regexp);
+
+      if (layer.match(path)) {
+        matched.path.push(layer);
+
+        if (layer.methods.length === 0 || layer.methods.includes(method)) {
+          matched.pathAndMethod.push(layer);
+          if (layer.methods.length > 0) {
+            matched.route = true;
+          }
+        }
+        // if (layer.methods.length === 0) {
+        //   matched.pathAndMethod.push(layer);
+        // } else if (layer.methods.includes(method)) {
+        //   matched.pathAndMethod.push(layer);
+        //   matched.route = true;
+        // }
+      }
+    }
+
+    return matched;
+  }
+
+  /**
+   * Run middleware for named route parameters. Useful for auto-loading or
+   * validation.
+   *
+   * @example
+   *
+   * ```javascript
+   * router
+   *   .param('user', (id, ctx, next) => {
+   *     ctx.user = users[id];
+   *     if (!ctx.user) return ctx.status = 404;
+   *     return next();
+   *   })
+   *   .get('/users/:user', ctx => {
+   *     ctx.body = ctx.user;
+   *   })
+   *   .get('/users/:user/friends', ctx => {
+   *     return ctx.user.getFriends().then(function(friends) {
+   *       ctx.body = friends;
+   *     });
+   *   })
+   *   // /users/3 => {"id": 3, "name": "Alex"}
+   *   // /users/3/friends => [{"id": 4, "name": "TJ"}]
+   * ```
+   *
+   * @param {String} param param
+   * @param {Function} middleware route middleware
+   * @return {Router} instance
+   */
+  param(param: string, middleware: ParamMiddlewareFunc): Router {
+    this.params[param] = middleware;
+    for (const route of this.stack) {
+      route.param(param, middleware);
+    }
+    return this;
+  }
+
+  protected _formatRouteParams(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc | ResourcesController,
+    middlewares: (MiddlewareFunc | string | ResourcesController)[]
+  ) {
+    const options: RegisterOptions = {};
+    let path: string | RegExp | (string | RegExp)[];
+    if (typeof nameOrPath === 'string' && nameOrPath.startsWith('/')) {
+      // verb(method, path, ...middlewares)
+      path = nameOrPath;
+      middlewares = [pathOrMiddleware as string, ...middlewares];
+      if (typeof pathOrMiddleware === 'string') {
+        // verb(method, path, controllerString)
+        // set controller name to router name
+        options.name = pathOrMiddleware;
+      }
+    } else if (nameOrPath instanceof RegExp) {
+      // verb(method, pathRegex, ...middlewares)
+      path = nameOrPath;
+      middlewares = [pathOrMiddleware as string, ...middlewares];
+      if (typeof pathOrMiddleware === 'string') {
+        // verb(method, pathRegex, controllerString)
+        // set controller name to router name
+        options.name = pathOrMiddleware;
+      }
+    } else if (Array.isArray(nameOrPath)) {
+      // verb(method, paths, ...middlewares)
+      path = nameOrPath;
+      middlewares = [pathOrMiddleware as string, ...middlewares];
+      if (typeof pathOrMiddleware === 'string') {
+        // verb(method, pathRegex, controllerString)
+        // set controller name to router name
+        options.name = pathOrMiddleware;
+      }
+    } else if (typeof pathOrMiddleware === 'string' || pathOrMiddleware instanceof RegExp) {
+      // verb(method, name, path, ...middlewares)
+      path = pathOrMiddleware;
+      assert(typeof nameOrPath === 'string', 'route name should be string');
+      options.name = nameOrPath;
+    } else if (Array.isArray(pathOrMiddleware)) {
+      // verb(method, name, paths, ...middlewares)
+      path = pathOrMiddleware;
+      assert(typeof nameOrPath === 'string', 'route name should be string');
+      options.name = nameOrPath;
+    } else {
+      // verb(method, path, ...middlewares)
+      path = nameOrPath;
+      middlewares = [pathOrMiddleware, ...middlewares];
+    }
+    return {
+      path,
+      middlewares,
+      options,
+    };
+  }
+
+  /**
+   * Create `router.verb()` methods, where *verb* is one of the HTTP verbs such
+   * as `router.get()` or `router.post()`.
+   *
+   * Match URL patterns to callback functions or controller actions using `router.verb()`,
+   * where **verb** is one of the HTTP verbs such as `router.get()` or `router.post()`.
+   *
+   * Additionally, `router.all()` can be used to match against all methods.
+   *
+   * ```javascript
+   * router
+   *   .get('/', (ctx, next) => {
+   *     ctx.body = 'Hello World!';
+   *   })
+   *   .post('/users', (ctx, next) => {
+   *     // ...
+   *   })
+   *   .put('/users/:id', (ctx, next) => {
+   *     // ...
+   *   })
+   *   .del('/users/:id', (ctx, next) => {
+   *     // ...
+   *   })
+   *   .all('/users/:id', (ctx, next) => {
+   *     // ...
+   *   });
+   * ```
+   *
+   * When a route is matched, its path is available at `ctx._matchedRoute` and if named,
+   * the name is available at `ctx._matchedRouteName`
+   *
+   * Route paths will be translated to regular expressions using
+   * [path-to-regexp](https://github.com/pillarjs/path-to-regexp).
+   *
+   * Query strings will not be considered when matching requests.
+   *
+   * #### Named routes
+   *
+   * Routes can optionally have names. This allows generation of URLs and easy
+   * renaming of URLs during development.
+   *
+   * ```javascript
+   * router.get('user', '/users/:id', (ctx, next) => {
+   *  // ...
+   * });
+   *
+   * router.url('user', 3);
+   * // => "/users/3"
+   * ```
+   *
+   * #### Multiple middleware
+   *
+   * Multiple middleware may be given:
+   *
+   * ```javascript
+   * router.get(
+   *   '/users/:id',
+   *   (ctx, next) => {
+   *     return User.findOne(ctx.params.id).then(function(user) {
+   *       ctx.user = user;
+   *       next();
+   *     });
+   *   },
+   *   ctx => {
+   *     console.log(ctx.user);
+   *     // => { id: 17, name: "Alex" }
+   *   }
+   * );
+   * ```
+   *
+   * ### Nested routers
+   *
+   * Nesting routers is supported:
+   *
+   * ```javascript
+   * var forums = new Router();
+   * var posts = new Router();
+   *
+   * posts.get('/', (ctx, next) => {...});
+   * posts.get('/:pid', (ctx, next) => {...});
+   * forums.use('/forums/:fid/posts', posts.routes(), posts.allowedMethods());
+   *
+   * // responds to "/forums/123/posts" and "/forums/123/posts/123"
+   * app.use(forums.routes());
+   * ```
+   *
+   * #### Router prefixes
+   *
+   * Route paths can be prefixed at the router level:
+   *
+   * ```javascript
+   * var router = new Router({
+   *   prefix: '/users'
+   * });
+   *
+   * router.get('/', ...); // responds to "/users"
+   * router.get('/:id', ...); // responds to "/users/:id"
+   * ```
+   *
+   * #### URL parameters
+   *
+   * Named route parameters are captured and added to `ctx.params`.
+   *
+   * ```javascript
+   * router.get('/:category/:title', (ctx, next) => {
+   *   console.log(ctx.params);
+   *   // => { category: 'programming', title: 'how-to-node' }
+   * });
+   * ```
+   *
+   * The [path-to-regexp](https://github.com/pillarjs/path-to-regexp) module is
+   * used to convert paths to regular expressions.
+   *
+   */
+  verb(
+    method: string | string[],
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middleware: MiddlewareFunc[]
+  ): Router {
+    const { options, path, middlewares } = this._formatRouteParams(nameOrPath, pathOrMiddleware, middleware);
+    if (typeof method === 'string') {
+      method = [method];
+    }
+    this.register(path, method, middlewares as MiddlewareFunc[], options);
+    return this;
+  }
+
+  /**
+   * Register route with all methods.
+   *
+   * @param {String} name Optional.
+   * @param {String} path path string
+   * @param {Function=} middleware You may also pass multiple middleware.
+   * @return {Router} router instance
+   * @private
+   */
+  all(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  all(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  all(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb(methods, nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  // "acl", "bind", "checkout", "connect", "copy", "delete", "get", "head", "link", "lock",
+  // "m-search", "merge", "mkactivity", "mkcalendar", "mkcol", "move", "notify", "options",
+  // "patch", "post", "propfind", "proppatch", "purge", "put", "rebind", "report", "search",
+  // "source", "subscribe", "trace", "unbind", "unlink", "unlock", "unsubscribe"
+  acl(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  acl(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  acl(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('acl', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  bind(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  bind(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  bind(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('bind', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  checkout(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  checkout(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  checkout(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('checkout', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  connect(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  connect(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  connect(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('connect', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  copy(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  copy(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  copy(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('copy', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  delete(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  delete(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  delete(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('delete', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  /** Alias for `router.delete()` because delete is a reserved word */
+  del(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  del(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  del(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('delete', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  get(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  get(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  get(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('get', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  query(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  query(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  query(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('query', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  head(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  head(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  head(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('head', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  link(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  link(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  link(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('link', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  lock(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  lock(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  lock(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('lock', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  ['m-search'](path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  ['m-search'](name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  ['m-search'](
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('m-search', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  merge(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  merge(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  merge(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('merge', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  mkactivity(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  mkactivity(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  mkactivity(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('mkactivity', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  mkcalendar(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  mkcalendar(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  mkcalendar(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('mkcalendar', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  mkcol(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  mkcol(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  mkcol(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('mkcol', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  move(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  move(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  move(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('move', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  notify(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  notify(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  notify(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('notify', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  options(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  options(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  options(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('options', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  patch(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  patch(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  patch(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('patch', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  post(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  post(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  post(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('post', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  propfind(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  propfind(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  propfind(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('propfind', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  proppatch(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  proppatch(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  proppatch(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('proppatch', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  purge(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  purge(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  purge(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('purge', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  put(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  put(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  put(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('put', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  rebind(path: string | RegExp, ...middlewares: MiddlewareFunc[]): Router;
+  rebind(name: string, path: string | RegExp, ...middlewares: MiddlewareFunc[]): Router;
+  rebind(
+    nameOrPath: string | RegExp,
+    pathOrMiddleware: string | RegExp | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('rebind', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  report(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  report(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  report(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('report', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  search(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  search(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  search(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('search', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  source(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  source(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  source(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('source', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  subscribe(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  subscribe(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  subscribe(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('subscribe', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  trace(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  trace(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  trace(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('trace', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  unbind(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unbind(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unbind(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('unbind', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  unlink(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unlink(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unlink(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('unlink', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  unlock(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unlock(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unlock(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('unlock', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+
+  unsubscribe(path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unsubscribe(name: string, path: string | RegExp | (string | RegExp)[], ...middlewares: MiddlewareFunc[]): Router;
+  unsubscribe(
+    nameOrPath: string | RegExp | (string | RegExp)[],
+    pathOrMiddleware: string | RegExp | (string | RegExp)[] | MiddlewareFunc,
+    ...middlewares: MiddlewareFunc[]
+  ): Router {
+    return this.verb('unsubscribe', nameOrPath, pathOrMiddleware, ...middlewares);
+  }
+}

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,0 +1,9 @@
+import { Router } from './Router.js';
+
+export type * from './types.js';
+export * from './Layer.js';
+export * from './Router.js';
+export * from './EggRouter.js';
+
+export const KoaRouter = Router;
+export default Router;

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,9 +1,9 @@
-import { Router } from './Router.js';
+import { Router } from './Router.ts';
 
-export type * from './types.js';
-export * from './Layer.js';
-export * from './Router.js';
-export * from './EggRouter.js';
+export type * from './types.ts';
+export * from './Layer.ts';
+export * from './Router.ts';
+export * from './EggRouter.ts';
 
 export const KoaRouter = Router;
 export default Router;

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -1,0 +1,15 @@
+export type Next = () => Promise<void>;
+export type MiddlewareFunc = (ctx: any, next: Next) => Promise<void> | void;
+export type MiddlewareFuncWithParamProperty = MiddlewareFunc & { param?: string };
+export type ParamMiddlewareFunc = (param: string, ctx: any, next: Next) => Promise<void> | void;
+export type MiddlewareFuncWithRouter<T> = MiddlewareFunc & { router: T };
+
+export interface ResourcesController {
+  index?: MiddlewareFunc;
+  new?: MiddlewareFunc;
+  create?: MiddlewareFunc;
+  show?: MiddlewareFunc;
+  edit?: MiddlewareFunc;
+  update?: MiddlewareFunc;
+  destroy?: MiddlewareFunc;
+}

--- a/packages/router/test/EggRouter.test.ts
+++ b/packages/router/test/EggRouter.test.ts
@@ -1,0 +1,458 @@
+import { strict as assert } from 'node:assert';
+import is from 'is-type-of';
+import { Application } from '@eggjs/koa';
+import request from 'supertest';
+import { EggRouter } from '../src/index.js';
+
+describe('test/EggRouter.test.ts', () => {
+  it('auto bind ctx to this on controller', async () => {
+    const app = new Application();
+    const router = new EggRouter({}, app as any);
+    router.get('home', '/', function (this: any) {
+      this.body = {
+        url: this.router.url('home'),
+        method: this.method,
+      };
+    });
+    app.use(router.routes());
+    const res = await request(app.callback()).get('/').expect(200);
+    assert.equal(res.body.url, '/');
+    assert.equal(res.body.method, 'GET');
+  });
+
+  it('creates new router with egg app', () => {
+    const app = { controller: {} };
+    const router = new EggRouter({}, app);
+    assert(router);
+    ['head', 'options', 'get', 'put', 'patch', 'post', 'delete', 'all', 'resources'].forEach(method => {
+      assert.equal(typeof Reflect.get(router, method), 'function');
+    });
+  });
+
+  it('should throw error on generator function', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          *world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get('/foo', app.controller.foo);
+    assert.throws(
+      () => {
+        router.post('/hello/world', app.controller.hello.world as any);
+      },
+      (err: TypeError) => {
+        assert(err instanceof TypeError);
+        assert.equal(err.message, 'post `/hello/world`: Please use async function instead of generator function');
+        return true;
+      }
+    );
+  });
+
+  it('should app.verb(url, controller) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get('/foo', app.controller.foo);
+    router.post('/hello/world', app.controller.hello.world);
+
+    assert(router.stack[0].path === '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert(router.stack[0].stack.length === 1);
+    assert(router.stack[1].path === '/hello/world');
+    assert.deepEqual(router.stack[1].methods, ['POST']);
+    assert(router.stack[1].stack.length === 1);
+
+    router.head('/foo-head', app.controller.foo);
+    router.options('/foo-options', app.controller.foo);
+    router.put('/foo-put', app.controller.foo);
+    router.patch('/foo-patch', app.controller.foo);
+    router.delete('/foo-delete', app.controller.foo);
+    router.all('/foo-all', app.controller.foo);
+  });
+
+  it('should app.verb([url1, url2], controller) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get(['/foo', '/bar'], app.controller.foo);
+    router.post('/hello/world', app.controller.hello.world);
+
+    assert(router.stack[0].path === '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert(router.stack[0].stack.length === 1);
+    assert(router.stack[1].path === '/bar');
+    assert.deepEqual(router.stack[1].methods, ['HEAD', 'GET']);
+    assert(router.stack[2].stack.length === 1);
+    assert(router.stack[2].path === '/hello/world');
+    assert.deepEqual(router.stack[2].methods, ['POST']);
+    assert(router.stack[2].stack.length === 1);
+  });
+
+  it('should app.verb(name, url, controller) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get('foo', '/foo', app.controller.foo);
+    router.post('hello', '/hello/world', app.controller.hello.world);
+
+    assert(router.stack[0].name === 'foo');
+    assert(router.stack[0].path === '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert(router.stack[0].stack.length === 1);
+    assert(router.stack[1].name === 'hello');
+    assert(router.stack[1].path === '/hello/world');
+    assert.deepEqual(router.stack[1].methods, ['POST']);
+    assert(router.stack[1].stack.length === 1);
+  });
+
+  it('should app.verb(name, url, controllerString) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get('foo', '/foo', 'foo');
+    router.post('hello', '/hello/world', 'hello.world');
+
+    assert(router.stack[0].name === 'foo');
+    assert(router.stack[0].path === '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert(router.stack[0].stack.length === 1);
+    assert(router.stack[1].name === 'hello');
+    assert(router.stack[1].path === '/hello/world');
+    assert.deepEqual(router.stack[1].methods, ['POST']);
+    assert(router.stack[1].stack.length === 1);
+  });
+
+  it('should app.verb(url, controllerString) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get('/foo', 'foo');
+    router.post('/hello/world', 'hello.world');
+
+    assert.equal(router.stack[0].name, 'foo');
+    assert.equal(router.stack[0].path, '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert.equal(router.stack[0].stack.length, 1);
+    assert.equal(router.stack[1].name, 'hello.world');
+    assert.equal(router.stack[1].path, '/hello/world');
+    assert.deepEqual(router.stack[1].methods, ['POST']);
+    assert.equal(router.stack[1].stack.length, 1);
+  });
+
+  it('should app.verb(urls, controllerString) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get(['/foo', '/bar'], 'foo');
+    router.post('/hello/world', 'hello.world');
+    router.put('other', ['/other1', '/other2'], 'foo');
+
+    assert.equal(router.stack[0].name, 'foo');
+    assert.equal(router.stack[0].path, '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert.equal(router.stack[0].stack.length, 1);
+    assert.equal(router.stack[1].name, 'foo');
+    assert.equal(router.stack[1].path, '/bar');
+    assert.deepEqual(router.stack[1].methods, ['HEAD', 'GET']);
+    assert.equal(router.stack[1].stack.length, 1);
+    assert.equal(router.stack[2].name, 'hello.world');
+    assert.equal(router.stack[2].path, '/hello/world');
+    assert.deepEqual(router.stack[2].methods, ['POST']);
+    assert.equal(router.stack[2].stack.length, 1);
+
+    assert.equal(router.stack[3].name, 'other');
+    assert.equal(router.stack[3].path, '/other1');
+    assert.deepEqual(router.stack[3].methods, ['PUT']);
+    assert.equal(router.stack[3].stack.length, 1);
+    assert.equal(router.stack[4].name, 'other');
+    assert.equal(router.stack[4].path, '/other2');
+    assert.deepEqual(router.stack[4].methods, ['PUT']);
+    assert.equal(router.stack[4].stack.length, 1);
+  });
+
+  it('should app.verb(urlRegex, controllerString) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    router.get(/^\/foo/, 'foo');
+    router.post(/^\/hello\/world/, 'hello.world');
+    router.post(/^\/hello\/world2/, () => {}, 'hello.world');
+
+    assert.equal(router.stack[0].name, 'foo');
+    assert(router.stack[0].path instanceof RegExp);
+    assert.equal(router.stack[0].path.toString(), String(/^\/foo/));
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert.equal(router.stack[0].stack.length, 1);
+    assert.equal(router.stack[1].name, 'hello.world');
+    assert(router.stack[1].path instanceof RegExp);
+    assert.equal(router.stack[1].path.toString(), String(/^\/hello\/world/));
+    assert.deepEqual(router.stack[1].methods, ['POST']);
+    assert.equal(router.stack[1].stack.length, 1);
+
+    assert.equal(router.stack[2].name, undefined);
+    assert(router.stack[2].path instanceof RegExp);
+    assert.equal(router.stack[2].path.toString(), String(/^\/hello\/world2/));
+    assert.deepEqual(router.stack[2].methods, ['POST']);
+    assert.equal(router.stack[2].stack.length, 2);
+  });
+
+  it('should app.verb() throw if not found controller', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const router = new EggRouter({}, app);
+    assert.throws(() => {
+      router.get('foo', '/foo', 'foobar');
+    }, /app.controller.foobar not exists/);
+
+    assert.throws(() => {
+      router.get('/foo', (app as any).bar);
+    }, /controller not exists/);
+  });
+
+  it('should app.verb(name, url, [middlewares], controllerString) work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+
+    const asyncMiddleware1 = async function () {
+      return;
+    };
+    const asyncMiddleware = async function () {
+      return;
+    };
+    const commonMiddleware = function () {};
+
+    const router = new EggRouter({}, app);
+    router.get('foo', '/foo', asyncMiddleware1, asyncMiddleware, commonMiddleware, 'foo');
+    router.post('hello', '/hello/world', asyncMiddleware1, asyncMiddleware, commonMiddleware, 'hello.world');
+    router.get('foo', '/foo', asyncMiddleware1, asyncMiddleware, commonMiddleware, 'foo');
+    router.post('hello', '/hello/world', asyncMiddleware1, asyncMiddleware, commonMiddleware, 'hello.world');
+
+    assert(router.stack[0].name === 'foo');
+    assert(router.stack[0].path === '/foo');
+    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
+    assert(router.stack[0].stack.length === 4);
+    assert(!is.generatorFunction(router.stack[0].stack[0]));
+    assert(is.asyncFunction(router.stack[0].stack[1]));
+    assert(!is.generatorFunction(router.stack[0].stack[3]));
+    assert(router.stack[1].name === 'hello');
+    assert(router.stack[1].path === '/hello/world');
+    assert.deepEqual(router.stack[1].methods, ['POST']);
+    assert(router.stack[1].stack.length === 4);
+    assert(!is.generatorFunction(router.stack[1].stack[0]));
+    assert(is.asyncFunction(router.stack[1].stack[1]));
+    assert(!is.generatorFunction(router.stack[1].stack[3]));
+  });
+
+  it('should app.resource() work', () => {
+    const app = {
+      controller: {
+        post: {
+          async index() {
+            return;
+          },
+          async show() {
+            return;
+          },
+          async create() {
+            return;
+          },
+          async update() {
+            return;
+          },
+          async new() {
+            return;
+          },
+        },
+      },
+    };
+
+    const asyncMiddleware = async function () {
+      return;
+    };
+
+    const router = new EggRouter({}, app);
+    router.resources('/post', asyncMiddleware, app.controller.post);
+    assert.equal(router.stack.length, 5);
+    assert.equal(router.stack[0].stack.length, 2);
+
+    router.resources('api_post', '/api/post', app.controller.post);
+    assert.equal(router.stack.length, 10);
+    assert.equal(router.stack[5].stack.length, 1);
+    assert.equal(router.stack[5].name, 'api_posts');
+  });
+
+  it('should app.resources() with multiple middlewares work', () => {
+    const app = {
+      controller: {
+        post: {
+          async index() {
+            return;
+          },
+          async show() {
+            return;
+          },
+          async create() {
+            return;
+          },
+          async update() {
+            return;
+          },
+          async new() {
+            return;
+          },
+        },
+      },
+    };
+
+    const asyncMiddleware1 = async function () {
+      return;
+    };
+    const asyncMiddleware2 = async function () {
+      return;
+    };
+
+    const router = new EggRouter({}, app);
+    router.resources('/post', asyncMiddleware1, asyncMiddleware2, app.controller.post);
+    assert.equal(router.stack.length, 5);
+    assert.equal(router.stack[0].stack.length, 3);
+
+    router.resources('api_post', '/api/post', asyncMiddleware1, asyncMiddleware2, app.controller.post);
+    assert.equal(router.stack.length, 10);
+    assert.equal(router.stack[5].stack.length, 3);
+    assert.equal(router.stack[5].name, 'api_posts');
+  });
+
+  it('should router.url work', () => {
+    const app = {
+      controller: {
+        async foo() {
+          return;
+        },
+        hello: {
+          world() {
+            return;
+          },
+        },
+      },
+    };
+    const router = new EggRouter({}, app);
+    router.get('post', '/post/:id', app.controller.foo);
+    router.get('hello', '/hello/world', app.controller.hello.world);
+
+    assert.equal(router.url('post', { id: 1, foo: [1, 2], bar: 'bar' }), '/post/1?foo=1&foo=2&bar=bar');
+    assert.equal(router.url('post', { foo: [1, 2], bar: 'bar' }), '/post/:id?foo=1&foo=2&bar=bar');
+    assert.equal(router.url('fooo'), '');
+    assert.equal(router.url('hello'), '/hello/world');
+
+    assert.equal(router.pathFor('post', { id: 1, foo: [1, 2], bar: 'bar' }), '/post/1?foo=1&foo=2&bar=bar');
+    assert.equal(router.pathFor('fooo'), '');
+    assert.equal(router.pathFor('hello'), '/hello/world');
+  });
+});

--- a/packages/router/test/EggRouter.test.ts
+++ b/packages/router/test/EggRouter.test.ts
@@ -1,8 +1,9 @@
-import { strict as assert } from 'node:assert';
 import is from 'is-type-of';
 import { Application } from '@eggjs/koa';
-import request from 'supertest';
-import { EggRouter } from '../src/index.js';
+import request from '@eggjs/supertest';
+import { describe, it, expect } from 'vitest';
+
+import { EggRouter } from '../src/index.ts';
 
 describe('test/EggRouter.test.ts', () => {
   it('auto bind ctx to this on controller', async () => {
@@ -16,16 +17,16 @@ describe('test/EggRouter.test.ts', () => {
     });
     app.use(router.routes());
     const res = await request(app.callback()).get('/').expect(200);
-    assert.equal(res.body.url, '/');
-    assert.equal(res.body.method, 'GET');
+    expect(res.body.url).toBe('/');
+    expect(res.body.method).toBe('GET');
   });
 
   it('creates new router with egg app', () => {
     const app = { controller: {} };
     const router = new EggRouter({}, app);
-    assert(router);
+    expect(router).toBeDefined();
     ['head', 'options', 'get', 'put', 'patch', 'post', 'delete', 'all', 'resources'].forEach(method => {
-      assert.equal(typeof Reflect.get(router, method), 'function');
+      expect(Reflect.get(router, method)).toBeInstanceOf(Function);
     });
   });
 
@@ -45,16 +46,9 @@ describe('test/EggRouter.test.ts', () => {
 
     const router = new EggRouter({}, app);
     router.get('/foo', app.controller.foo);
-    assert.throws(
-      () => {
-        router.post('/hello/world', app.controller.hello.world as any);
-      },
-      (err: TypeError) => {
-        assert(err instanceof TypeError);
-        assert.equal(err.message, 'post `/hello/world`: Please use async function instead of generator function');
-        return true;
-      }
-    );
+    expect(() => {
+      router.post('/hello/world', app.controller.hello.world as any);
+    }).toThrow(/post `\/hello\/world`: Please use async function instead of generator function/);
   });
 
   it('should app.verb(url, controller) work', () => {
@@ -75,12 +69,12 @@ describe('test/EggRouter.test.ts', () => {
     router.get('/foo', app.controller.foo);
     router.post('/hello/world', app.controller.hello.world);
 
-    assert(router.stack[0].path === '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert(router.stack[0].stack.length === 1);
-    assert(router.stack[1].path === '/hello/world');
-    assert.deepEqual(router.stack[1].methods, ['POST']);
-    assert(router.stack[1].stack.length === 1);
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].path).toBe('/hello/world');
+    expect(router.stack[1].methods).toEqual(['POST']);
+    expect(router.stack[1].stack.length).toBe(1);
 
     router.head('/foo-head', app.controller.foo);
     router.options('/foo-options', app.controller.foo);
@@ -108,15 +102,15 @@ describe('test/EggRouter.test.ts', () => {
     router.get(['/foo', '/bar'], app.controller.foo);
     router.post('/hello/world', app.controller.hello.world);
 
-    assert(router.stack[0].path === '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert(router.stack[0].stack.length === 1);
-    assert(router.stack[1].path === '/bar');
-    assert.deepEqual(router.stack[1].methods, ['HEAD', 'GET']);
-    assert(router.stack[2].stack.length === 1);
-    assert(router.stack[2].path === '/hello/world');
-    assert.deepEqual(router.stack[2].methods, ['POST']);
-    assert(router.stack[2].stack.length === 1);
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].path).toBe('/bar');
+    expect(router.stack[1].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[2].stack.length).toBe(1);
+    expect(router.stack[2].path).toBe('/hello/world');
+    expect(router.stack[2].methods).toEqual(['POST']);
+    expect(router.stack[2].stack.length).toBe(1);
   });
 
   it('should app.verb(name, url, controller) work', () => {
@@ -137,14 +131,14 @@ describe('test/EggRouter.test.ts', () => {
     router.get('foo', '/foo', app.controller.foo);
     router.post('hello', '/hello/world', app.controller.hello.world);
 
-    assert(router.stack[0].name === 'foo');
-    assert(router.stack[0].path === '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert(router.stack[0].stack.length === 1);
-    assert(router.stack[1].name === 'hello');
-    assert(router.stack[1].path === '/hello/world');
-    assert.deepEqual(router.stack[1].methods, ['POST']);
-    assert(router.stack[1].stack.length === 1);
+    expect(router.stack[0].name).toBe('foo');
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].name).toBe('hello');
+    expect(router.stack[1].path).toBe('/hello/world');
+    expect(router.stack[1].methods).toEqual(['POST']);
+    expect(router.stack[1].stack.length).toBe(1);
   });
 
   it('should app.verb(name, url, controllerString) work', () => {
@@ -165,14 +159,14 @@ describe('test/EggRouter.test.ts', () => {
     router.get('foo', '/foo', 'foo');
     router.post('hello', '/hello/world', 'hello.world');
 
-    assert(router.stack[0].name === 'foo');
-    assert(router.stack[0].path === '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert(router.stack[0].stack.length === 1);
-    assert(router.stack[1].name === 'hello');
-    assert(router.stack[1].path === '/hello/world');
-    assert.deepEqual(router.stack[1].methods, ['POST']);
-    assert(router.stack[1].stack.length === 1);
+    expect(router.stack[0].name).toBe('foo');
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].name).toBe('hello');
+    expect(router.stack[1].path).toBe('/hello/world');
+    expect(router.stack[1].methods).toEqual(['POST']);
+    expect(router.stack[1].stack.length).toBe(1);
   });
 
   it('should app.verb(url, controllerString) work', () => {
@@ -193,14 +187,14 @@ describe('test/EggRouter.test.ts', () => {
     router.get('/foo', 'foo');
     router.post('/hello/world', 'hello.world');
 
-    assert.equal(router.stack[0].name, 'foo');
-    assert.equal(router.stack[0].path, '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert.equal(router.stack[0].stack.length, 1);
-    assert.equal(router.stack[1].name, 'hello.world');
-    assert.equal(router.stack[1].path, '/hello/world');
-    assert.deepEqual(router.stack[1].methods, ['POST']);
-    assert.equal(router.stack[1].stack.length, 1);
+    expect(router.stack[0].name).toBe('foo');
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].name).toBe('hello.world');
+    expect(router.stack[1].path).toBe('/hello/world');
+    expect(router.stack[1].methods).toEqual(['POST']);
+    expect(router.stack[1].stack.length).toBe(1);
   });
 
   it('should app.verb(urls, controllerString) work', () => {
@@ -222,27 +216,27 @@ describe('test/EggRouter.test.ts', () => {
     router.post('/hello/world', 'hello.world');
     router.put('other', ['/other1', '/other2'], 'foo');
 
-    assert.equal(router.stack[0].name, 'foo');
-    assert.equal(router.stack[0].path, '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert.equal(router.stack[0].stack.length, 1);
-    assert.equal(router.stack[1].name, 'foo');
-    assert.equal(router.stack[1].path, '/bar');
-    assert.deepEqual(router.stack[1].methods, ['HEAD', 'GET']);
-    assert.equal(router.stack[1].stack.length, 1);
-    assert.equal(router.stack[2].name, 'hello.world');
-    assert.equal(router.stack[2].path, '/hello/world');
-    assert.deepEqual(router.stack[2].methods, ['POST']);
-    assert.equal(router.stack[2].stack.length, 1);
+    expect(router.stack[0].name).toBe('foo');
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].name).toBe('foo');
+    expect(router.stack[1].path).toBe('/bar');
+    expect(router.stack[1].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[1].stack.length).toBe(1);
+    expect(router.stack[2].name).toBe('hello.world');
+    expect(router.stack[2].path).toBe('/hello/world');
+    expect(router.stack[2].methods).toEqual(['POST']);
+    expect(router.stack[2].stack.length).toBe(1);
 
-    assert.equal(router.stack[3].name, 'other');
-    assert.equal(router.stack[3].path, '/other1');
-    assert.deepEqual(router.stack[3].methods, ['PUT']);
-    assert.equal(router.stack[3].stack.length, 1);
-    assert.equal(router.stack[4].name, 'other');
-    assert.equal(router.stack[4].path, '/other2');
-    assert.deepEqual(router.stack[4].methods, ['PUT']);
-    assert.equal(router.stack[4].stack.length, 1);
+    expect(router.stack[3].name).toBe('other');
+    expect(router.stack[3].path).toBe('/other1');
+    expect(router.stack[3].methods).toEqual(['PUT']);
+    expect(router.stack[3].stack.length).toBe(1);
+    expect(router.stack[4].name).toBe('other');
+    expect(router.stack[4].path).toBe('/other2');
+    expect(router.stack[4].methods).toEqual(['PUT']);
+    expect(router.stack[4].stack.length).toBe(1);
   });
 
   it('should app.verb(urlRegex, controllerString) work', () => {
@@ -264,22 +258,22 @@ describe('test/EggRouter.test.ts', () => {
     router.post(/^\/hello\/world/, 'hello.world');
     router.post(/^\/hello\/world2/, () => {}, 'hello.world');
 
-    assert.equal(router.stack[0].name, 'foo');
-    assert(router.stack[0].path instanceof RegExp);
-    assert.equal(router.stack[0].path.toString(), String(/^\/foo/));
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert.equal(router.stack[0].stack.length, 1);
-    assert.equal(router.stack[1].name, 'hello.world');
-    assert(router.stack[1].path instanceof RegExp);
-    assert.equal(router.stack[1].path.toString(), String(/^\/hello\/world/));
-    assert.deepEqual(router.stack[1].methods, ['POST']);
-    assert.equal(router.stack[1].stack.length, 1);
+    expect(router.stack[0].name).toBe('foo');
+    expect(router.stack[0].path instanceof RegExp).toBe(true);
+    expect(router.stack[0].path.toString()).toBe(String(/^\/foo/));
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(1);
+    expect(router.stack[1].name).toBe('hello.world');
+    expect(router.stack[1].path instanceof RegExp).toBe(true);
+    expect(router.stack[1].path.toString()).toBe(String(/^\/hello\/world/));
+    expect(router.stack[1].methods).toEqual(['POST']);
+    expect(router.stack[1].stack.length).toBe(1);
 
-    assert.equal(router.stack[2].name, undefined);
-    assert(router.stack[2].path instanceof RegExp);
-    assert.equal(router.stack[2].path.toString(), String(/^\/hello\/world2/));
-    assert.deepEqual(router.stack[2].methods, ['POST']);
-    assert.equal(router.stack[2].stack.length, 2);
+    expect(router.stack[2].name).toBe(undefined);
+    expect(router.stack[2].path instanceof RegExp).toBe(true);
+    expect(router.stack[2].path.toString()).toBe(String(/^\/hello\/world2/));
+    expect(router.stack[2].methods).toEqual(['POST']);
+    expect(router.stack[2].stack.length).toBe(2);
   });
 
   it('should app.verb() throw if not found controller', () => {
@@ -297,13 +291,13 @@ describe('test/EggRouter.test.ts', () => {
     };
 
     const router = new EggRouter({}, app);
-    assert.throws(() => {
+    expect(() => {
       router.get('foo', '/foo', 'foobar');
-    }, /app.controller.foobar not exists/);
+    }).toThrow(/app.controller.foobar not exists/);
 
-    assert.throws(() => {
+    expect(() => {
       router.get('/foo', (app as any).bar);
-    }, /controller not exists/);
+    }).toThrow(/controller not exists/);
   });
 
   it('should app.verb(name, url, [middlewares], controllerString) work', () => {
@@ -334,20 +328,20 @@ describe('test/EggRouter.test.ts', () => {
     router.get('foo', '/foo', asyncMiddleware1, asyncMiddleware, commonMiddleware, 'foo');
     router.post('hello', '/hello/world', asyncMiddleware1, asyncMiddleware, commonMiddleware, 'hello.world');
 
-    assert(router.stack[0].name === 'foo');
-    assert(router.stack[0].path === '/foo');
-    assert.deepEqual(router.stack[0].methods, ['HEAD', 'GET']);
-    assert(router.stack[0].stack.length === 4);
-    assert(!is.generatorFunction(router.stack[0].stack[0]));
-    assert(is.asyncFunction(router.stack[0].stack[1]));
-    assert(!is.generatorFunction(router.stack[0].stack[3]));
-    assert(router.stack[1].name === 'hello');
-    assert(router.stack[1].path === '/hello/world');
-    assert.deepEqual(router.stack[1].methods, ['POST']);
-    assert(router.stack[1].stack.length === 4);
-    assert(!is.generatorFunction(router.stack[1].stack[0]));
-    assert(is.asyncFunction(router.stack[1].stack[1]));
-    assert(!is.generatorFunction(router.stack[1].stack[3]));
+    expect(router.stack[0].name).toBe('foo');
+    expect(router.stack[0].path).toBe('/foo');
+    expect(router.stack[0].methods).toEqual(['HEAD', 'GET']);
+    expect(router.stack[0].stack.length).toBe(4);
+    expect(is.generatorFunction(router.stack[0].stack[0])).toBe(false);
+    expect(is.asyncFunction(router.stack[0].stack[1])).toBe(true);
+    expect(is.generatorFunction(router.stack[0].stack[3])).toBe(false);
+    expect(router.stack[1].name).toBe('hello');
+    expect(router.stack[1].path).toBe('/hello/world');
+    expect(router.stack[1].methods).toEqual(['POST']);
+    expect(router.stack[1].stack.length).toBe(4);
+    expect(is.generatorFunction(router.stack[1].stack[0])).toBe(false);
+    expect(is.asyncFunction(router.stack[1].stack[1])).toBe(true);
+    expect(is.generatorFunction(router.stack[1].stack[3])).toBe(false);
   });
 
   it('should app.resource() work', () => {
@@ -379,13 +373,13 @@ describe('test/EggRouter.test.ts', () => {
 
     const router = new EggRouter({}, app);
     router.resources('/post', asyncMiddleware, app.controller.post);
-    assert.equal(router.stack.length, 5);
-    assert.equal(router.stack[0].stack.length, 2);
+    expect(router.stack.length).toBe(5);
+    expect(router.stack[0].stack.length).toBe(2);
 
     router.resources('api_post', '/api/post', app.controller.post);
-    assert.equal(router.stack.length, 10);
-    assert.equal(router.stack[5].stack.length, 1);
-    assert.equal(router.stack[5].name, 'api_posts');
+    expect(router.stack.length).toBe(10);
+    expect(router.stack[5].stack.length).toBe(1);
+    expect(router.stack[5].name).toBe('api_posts');
   });
 
   it('should app.resources() with multiple middlewares work', () => {
@@ -420,13 +414,13 @@ describe('test/EggRouter.test.ts', () => {
 
     const router = new EggRouter({}, app);
     router.resources('/post', asyncMiddleware1, asyncMiddleware2, app.controller.post);
-    assert.equal(router.stack.length, 5);
-    assert.equal(router.stack[0].stack.length, 3);
+    expect(router.stack.length).toBe(5);
+    expect(router.stack[0].stack.length).toBe(3);
 
     router.resources('api_post', '/api/post', asyncMiddleware1, asyncMiddleware2, app.controller.post);
-    assert.equal(router.stack.length, 10);
-    assert.equal(router.stack[5].stack.length, 3);
-    assert.equal(router.stack[5].name, 'api_posts');
+    expect(router.stack.length).toBe(10);
+    expect(router.stack[5].stack.length).toBe(3);
+    expect(router.stack[5].name).toBe('api_posts');
   });
 
   it('should router.url work', () => {
@@ -446,13 +440,13 @@ describe('test/EggRouter.test.ts', () => {
     router.get('post', '/post/:id', app.controller.foo);
     router.get('hello', '/hello/world', app.controller.hello.world);
 
-    assert.equal(router.url('post', { id: 1, foo: [1, 2], bar: 'bar' }), '/post/1?foo=1&foo=2&bar=bar');
-    assert.equal(router.url('post', { foo: [1, 2], bar: 'bar' }), '/post/:id?foo=1&foo=2&bar=bar');
-    assert.equal(router.url('fooo'), '');
-    assert.equal(router.url('hello'), '/hello/world');
+    expect(router.url('post', { id: 1, foo: [1, 2], bar: 'bar' })).toBe('/post/1?foo=1&foo=2&bar=bar');
+    expect(router.url('post', { foo: [1, 2], bar: 'bar' })).toBe('/post/:id?foo=1&foo=2&bar=bar');
+    expect(router.url('fooo')).toBe('');
+    expect(router.url('hello')).toBe('/hello/world');
 
-    assert.equal(router.pathFor('post', { id: 1, foo: [1, 2], bar: 'bar' }), '/post/1?foo=1&foo=2&bar=bar');
-    assert.equal(router.pathFor('fooo'), '');
-    assert.equal(router.pathFor('hello'), '/hello/world');
+    expect(router.pathFor('post', { id: 1, foo: [1, 2], bar: 'bar' })).toBe('/post/1?foo=1&foo=2&bar=bar');
+    expect(router.pathFor('fooo')).toBe('');
+    expect(router.pathFor('hello')).toBe('/hello/world');
   });
 });

--- a/packages/router/test/Layer.test.ts
+++ b/packages/router/test/Layer.test.ts
@@ -1,8 +1,9 @@
-import { strict as assert } from 'node:assert';
 import { Application } from '@eggjs/koa';
-import request from 'supertest';
-import { Router } from '../src/Router.js';
-import { Layer } from '../src/Layer.js';
+import request from '@eggjs/supertest';
+import { describe, it, expect } from 'vitest';
+
+import { Router } from '../src/Router.ts';
+import { Layer } from '../src/Layer.ts';
 
 describe('test/Layer.test.ts', () => {
   it('composes multiple callbacks/middleware', async () => {
@@ -29,9 +30,9 @@ describe('test/Layer.test.ts', () => {
       const router = new Router();
       app.use(router.routes());
       router.get('/:category/:title', ctx => {
-        assert(ctx.params);
-        assert.equal(ctx.params.category, 'match');
-        assert.equal(ctx.params.title, 'this');
+        expect(ctx.params).toBeDefined();
+        expect(ctx.params.category).toBe('match');
+        expect(ctx.params.title).toBe('this');
         ctx.status = 204;
       });
       await request(app.callback()).get('/match/this').expect(204);
@@ -42,9 +43,9 @@ describe('test/Layer.test.ts', () => {
       const router = new Router();
       app.use(router.routes());
       router.get('/:category/:title', ctx => {
-        assert(ctx.params);
-        assert.equal(ctx.params.category, '100%');
-        assert.equal(ctx.params.title, '101%');
+        expect(ctx.params).toBeDefined();
+        expect(ctx.params.category).toBe('100%');
+        expect(ctx.params.title).toBe('101%');
         ctx.status = 204;
       });
       await request(app.callback()).get('/100%/101%').expect(204);
@@ -57,17 +58,17 @@ describe('test/Layer.test.ts', () => {
       router.get(
         /^\/api\/([^/]+)\/?/i,
         (ctx, next) => {
-          assert(ctx.captures);
-          assert(Array.isArray(ctx.captures));
-          assert.equal(ctx.captures.length, 1);
-          assert.equal(ctx.captures[0], '1');
+          expect(ctx.captures).toBeDefined();
+          expect(Array.isArray(ctx.captures)).toBe(true);
+          expect(ctx.captures.length).toBe(1);
+          expect(ctx.captures[0]).toBe('1');
           return next();
         },
         ctx => {
-          assert(ctx.captures);
-          assert(Array.isArray(ctx.captures));
-          assert.equal(ctx.captures.length, 1);
-          assert.equal(ctx.captures[0], '1');
+          expect(ctx.captures).toBeDefined();
+          expect(Array.isArray(ctx.captures)).toBe(true);
+          expect(ctx.captures.length).toBe(1);
+          expect(ctx.captures[0]).toBe('1');
           ctx.status = 204;
         }
       );
@@ -81,15 +82,15 @@ describe('test/Layer.test.ts', () => {
       router.get(
         /^\/api\/([^/]+)\/?/i,
         (ctx, next) => {
-          assert(Array.isArray(ctx.captures));
-          assert.equal(ctx.captures.length, 1);
-          assert.equal(ctx.captures[0], '101%');
+          expect(Array.isArray(ctx.captures)).toBe(true);
+          expect(ctx.captures.length).toBe(1);
+          expect(ctx.captures[0]).toBe('101%');
           return next();
         },
         function (ctx) {
-          assert(Array.isArray(ctx.captures));
-          assert.equal(ctx.captures.length, 1);
-          assert.equal(ctx.captures[0], '101%');
+          expect(Array.isArray(ctx.captures)).toBe(true);
+          expect(ctx.captures.length).toBe(1);
+          expect(ctx.captures[0]).toBe('101%');
           ctx.status = 204;
         }
       );
@@ -103,15 +104,15 @@ describe('test/Layer.test.ts', () => {
       router.get(
         /^\/api(\/.+)?/i,
         function (ctx, next) {
-          assert(Array.isArray(ctx.captures));
-          assert.equal(ctx.captures.length, 1);
-          assert.equal(ctx.captures[0], undefined);
+          expect(Array.isArray(ctx.captures)).toBe(true);
+          expect(ctx.captures.length).toBe(1);
+          expect(ctx.captures[0]).toBe(undefined);
           return next();
         },
         function (ctx) {
-          assert(Array.isArray(ctx.captures));
-          assert.equal(ctx.captures.length, 1);
-          assert.equal(ctx.captures[0], undefined);
+          expect(Array.isArray(ctx.captures)).toBe(true);
+          expect(ctx.captures.length).toBe(1);
+          expect(ctx.captures[0]).toBe(undefined);
           ctx.status = 204;
         }
       );
@@ -124,37 +125,17 @@ describe('test/Layer.test.ts', () => {
       app.use(router.routes());
       const notExistsHandle = undefined;
 
-      assert.throws(
-        () => {
-          router.get('/foo', notExistsHandle as any);
-        },
-        (err: TypeError) => {
-          assert(err instanceof TypeError);
-          assert.equal(err.name, 'TypeError');
-          assert.equal(err.message, 'get `/foo`: `middleware` must be a function, not `undefined`');
-          return true;
-        }
-      );
+      expect(() => {
+        router.get('/foo', notExistsHandle as any);
+      }).toThrow(/get `\/foo`: `middleware` must be a function, not `undefined`/);
 
-      assert.throws(
-        () => {
-          router.get('foo router', '/foo', notExistsHandle as any);
-        },
-        (err: any) => {
-          assert.equal(err.message, 'get `foo router`: `middleware` must be a function, not `undefined`');
-          return true;
-        }
-      );
+      expect(() => {
+        router.get('foo router', '/foo', notExistsHandle as any);
+      }).toThrow(/get `foo router`: `middleware` must be a function, not `undefined`/);
 
-      assert.throws(
-        () => {
-          router.post('/foo', function () {}, notExistsHandle as any);
-        },
-        (err: any) => {
-          assert.equal(err.message, 'post `/foo`: `middleware` must be a function, not `undefined`');
-          return true;
-        }
-      );
+      expect(() => {
+        router.post('/foo', function () {}, notExistsHandle as any);
+      }).toThrow(/post `\/foo`: `middleware` must be a function, not `undefined`/);
     });
   });
 
@@ -182,7 +163,7 @@ describe('test/Layer.test.ts', () => {
       router.stack.push(route);
       app.use(router.middleware());
       const res = await request(app.callback()).get('/users/3').expect(200);
-      assert.equal(res.body.name, 'alex');
+      expect(res.body.name).toBe('alex');
     });
 
     it('ignores params which are not matched', async () => {
@@ -216,7 +197,7 @@ describe('test/Layer.test.ts', () => {
       router.stack.push(route);
       app.use(router.middleware());
       const res = await request(app.callback()).get('/users/3').expect(200);
-      assert.equal(res.body.name, 'alex');
+      expect(res.body.name).toBe('alex');
     });
   });
 
@@ -224,15 +205,15 @@ describe('test/Layer.test.ts', () => {
     it('generates route URL', () => {
       const route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
       const url1 = route.url({ category: 'programming', title: 'how-to-node' });
-      assert.equal(url1, '/programming/how-to-node');
+      expect(url1).toBe('/programming/how-to-node');
       const url2 = route.url('programming', 'how-to-node');
-      assert.equal(url2, '/programming/how-to-node');
+      expect(url2).toBe('/programming/how-to-node');
     });
 
     it('escapes using encodeURIComponent()', () => {
       const route = new Layer('/:category/:title', ['get'], [() => {}], 'books');
       const url = route.url({ category: 'programming', title: 'how to node' });
-      assert.equal(url, '/programming/how%20to%20node');
+      expect(url).toBe('/programming/how%20to%20node');
     });
   });
 });

--- a/packages/router/test/Layer.test.ts
+++ b/packages/router/test/Layer.test.ts
@@ -1,0 +1,238 @@
+import { strict as assert } from 'node:assert';
+import { Application } from '@eggjs/koa';
+import request from 'supertest';
+import { Router } from '../src/Router.js';
+import { Layer } from '../src/Layer.js';
+
+describe('test/Layer.test.ts', () => {
+  it('composes multiple callbacks/middleware', async () => {
+    const app = new Application();
+    const router = new Router();
+    app.use(router.routes());
+    router.get(
+      '/:category/:title',
+      (ctx, next) => {
+        ctx.status = 500;
+        return next();
+      },
+      (ctx, next) => {
+        ctx.status = 204;
+        return next();
+      }
+    );
+    await request(app.callback()).get('/programming/how-to-node').expect(204);
+  });
+
+  describe('Layer#match()', () => {
+    it('captures URL path parameters', async () => {
+      const app = new Application();
+      const router = new Router();
+      app.use(router.routes());
+      router.get('/:category/:title', ctx => {
+        assert(ctx.params);
+        assert.equal(ctx.params.category, 'match');
+        assert.equal(ctx.params.title, 'this');
+        ctx.status = 204;
+      });
+      await request(app.callback()).get('/match/this').expect(204);
+    });
+
+    it('return original path parameters when decodeURIComponent throw error', async () => {
+      const app = new Application();
+      const router = new Router();
+      app.use(router.routes());
+      router.get('/:category/:title', ctx => {
+        assert(ctx.params);
+        assert.equal(ctx.params.category, '100%');
+        assert.equal(ctx.params.title, '101%');
+        ctx.status = 204;
+      });
+      await request(app.callback()).get('/100%/101%').expect(204);
+    });
+
+    it('populates ctx.captures with regexp captures', async () => {
+      const app = new Application();
+      const router = new Router();
+      app.use(router.routes());
+      router.get(
+        /^\/api\/([^/]+)\/?/i,
+        (ctx, next) => {
+          assert(ctx.captures);
+          assert(Array.isArray(ctx.captures));
+          assert.equal(ctx.captures.length, 1);
+          assert.equal(ctx.captures[0], '1');
+          return next();
+        },
+        ctx => {
+          assert(ctx.captures);
+          assert(Array.isArray(ctx.captures));
+          assert.equal(ctx.captures.length, 1);
+          assert.equal(ctx.captures[0], '1');
+          ctx.status = 204;
+        }
+      );
+      await request(app.callback()).get('/api/1').expect(204);
+    });
+
+    it('return original ctx.captures when decodeURIComponent throw error', async () => {
+      const app = new Application();
+      const router = new Router();
+      app.use(router.routes());
+      router.get(
+        /^\/api\/([^/]+)\/?/i,
+        (ctx, next) => {
+          assert(Array.isArray(ctx.captures));
+          assert.equal(ctx.captures.length, 1);
+          assert.equal(ctx.captures[0], '101%');
+          return next();
+        },
+        function (ctx) {
+          assert(Array.isArray(ctx.captures));
+          assert.equal(ctx.captures.length, 1);
+          assert.equal(ctx.captures[0], '101%');
+          ctx.status = 204;
+        }
+      );
+      await request(app.callback()).get('/api/101%').expect(204);
+    });
+
+    it('populates ctx.captures with regexp captures include undefined', async () => {
+      const app = new Application();
+      const router = new Router();
+      app.use(router.routes());
+      router.get(
+        /^\/api(\/.+)?/i,
+        function (ctx, next) {
+          assert(Array.isArray(ctx.captures));
+          assert.equal(ctx.captures.length, 1);
+          assert.equal(ctx.captures[0], undefined);
+          return next();
+        },
+        function (ctx) {
+          assert(Array.isArray(ctx.captures));
+          assert.equal(ctx.captures.length, 1);
+          assert.equal(ctx.captures[0], undefined);
+          ctx.status = 204;
+        }
+      );
+      await request(app.callback()).get('/api').expect(204);
+    });
+
+    it('should throw friendly error message when handle not exists', () => {
+      const app = new Application();
+      const router = new Router();
+      app.use(router.routes());
+      const notExistsHandle = undefined;
+
+      assert.throws(
+        () => {
+          router.get('/foo', notExistsHandle as any);
+        },
+        (err: TypeError) => {
+          assert(err instanceof TypeError);
+          assert.equal(err.name, 'TypeError');
+          assert.equal(err.message, 'get `/foo`: `middleware` must be a function, not `undefined`');
+          return true;
+        }
+      );
+
+      assert.throws(
+        () => {
+          router.get('foo router', '/foo', notExistsHandle as any);
+        },
+        (err: any) => {
+          assert.equal(err.message, 'get `foo router`: `middleware` must be a function, not `undefined`');
+          return true;
+        }
+      );
+
+      assert.throws(
+        () => {
+          router.post('/foo', function () {}, notExistsHandle as any);
+        },
+        (err: any) => {
+          assert.equal(err.message, 'post `/foo`: `middleware` must be a function, not `undefined`');
+          return true;
+        }
+      );
+    });
+  });
+
+  describe('Layer#param()', () => {
+    it('composes middleware for param fn', async () => {
+      const app = new Application();
+      const router = new Router();
+      const route = new Layer(
+        '/users/:user',
+        ['GET'],
+        [
+          function (ctx) {
+            ctx.body = ctx.user;
+          },
+        ]
+      );
+      route.param('user', (id, ctx, next) => {
+        ctx.user = { name: 'alex' };
+        if (!id) {
+          ctx.status = 404;
+          return;
+        }
+        return next();
+      });
+      router.stack.push(route);
+      app.use(router.middleware());
+      const res = await request(app.callback()).get('/users/3').expect(200);
+      assert.equal(res.body.name, 'alex');
+    });
+
+    it('ignores params which are not matched', async () => {
+      const app = new Application();
+      const router = new Router();
+      const route = new Layer(
+        '/users/:user',
+        ['GET'],
+        [
+          ctx => {
+            ctx.body = ctx.user;
+          },
+        ]
+      );
+      route.param('user', function (id, ctx, next) {
+        ctx.user = { name: 'alex' };
+        if (!id) {
+          ctx.status = 404;
+          return;
+        }
+        return next();
+      });
+      route.param('title', function (id, ctx, next) {
+        ctx.user = { name: 'mark' };
+        if (!id) {
+          ctx.status = 404;
+          return;
+        }
+        return next();
+      });
+      router.stack.push(route);
+      app.use(router.middleware());
+      const res = await request(app.callback()).get('/users/3').expect(200);
+      assert.equal(res.body.name, 'alex');
+    });
+  });
+
+  describe('Layer#url()', () => {
+    it('generates route URL', () => {
+      const route = new Layer('/:category/:title', ['get'], [function () {}], 'books');
+      const url1 = route.url({ category: 'programming', title: 'how-to-node' });
+      assert.equal(url1, '/programming/how-to-node');
+      const url2 = route.url('programming', 'how-to-node');
+      assert.equal(url2, '/programming/how-to-node');
+    });
+
+    it('escapes using encodeURIComponent()', () => {
+      const route = new Layer('/:category/:title', ['get'], [() => {}], 'books');
+      const url = route.url({ category: 'programming', title: 'how to node' });
+      assert.equal(url, '/programming/how%20to%20node');
+    });
+  });
+});

--- a/packages/router/test/Router.test.ts
+++ b/packages/router/test/Router.test.ts
@@ -1,0 +1,1433 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import { Application as Koa } from '@eggjs/koa';
+import methods from 'methods';
+import request from 'supertest';
+import Router from '../src/index.js';
+import { Next } from '../src/types.js';
+
+describe('test/lib/router.test.js', () => {
+  it('creates new router', () => {
+    const router = new Router();
+    assert(router instanceof Router);
+  });
+
+  it('shares context between routers (gh-205)', async () => {
+    const app = new Koa();
+    const router1 = new Router();
+    const router2 = new Router();
+    router1.get('/', function (ctx, next) {
+      ctx.foo = 'bar';
+      return next();
+    });
+    router2.get('/', function (ctx, next) {
+      ctx.baz = 'qux';
+      ctx.body = { foo: ctx.foo };
+      return next();
+    });
+    app.use(router1.routes()).use(router2.routes());
+    const res = await request(app.callback()).get('/').expect(200);
+    assert.equal(res.body.foo, 'bar');
+  });
+
+  it('does not register middleware more than once (gh-184)', async () => {
+    const app = new Koa();
+    const parentRouter = new Router();
+    const nestedRouter = new Router();
+
+    nestedRouter
+      .get('/first-nested-route', function (ctx) {
+        ctx.body = { n: ctx.n };
+      })
+      .get('/second-nested-route', function (_ctx, next) {
+        return next();
+      })
+      .get('/third-nested-route', function (_ctx, next) {
+        return next();
+      });
+
+    parentRouter.use(
+      '/parent-route',
+      function (ctx, next) {
+        ctx.n = ctx.n ? ctx.n + 1 : 1;
+        return next();
+      },
+      nestedRouter.routes()
+    );
+
+    app.use(parentRouter.routes());
+
+    const res = await request(app.callback()).get('/parent-route/first-nested-route').expect(200);
+    assert.equal(res.body.n, 1);
+  });
+
+  it('router can be access with ctx', async () => {
+    const app = new Koa();
+    const router = new Router();
+    router.get('home', '/', function (ctx) {
+      ctx.body = {
+        url: ctx.router.url('home'),
+      };
+    });
+    app.use(router.routes());
+    const res = await request(app.callback()).get('/').expect(200);
+    assert.equal(res.body.url, '/');
+  });
+
+  it('registers multiple middleware for one route', async () => {
+    const app = new Koa();
+    const router = new Router();
+
+    router.get(
+      '/double',
+      function (ctx, next) {
+        return new Promise(function (resolve) {
+          setTimeout(function () {
+            ctx.body = { message: 'Hello' };
+            resolve(next());
+          }, 1);
+        });
+      },
+      function (ctx, next) {
+        return new Promise(function (resolve) {
+          setTimeout(function () {
+            ctx.body.message += ' World';
+            resolve(next());
+          }, 1);
+        });
+      },
+      function (ctx) {
+        ctx.body.message += '!';
+      }
+    );
+
+    app.use(router.routes());
+
+    const res = await request(app.callback()).get('/double').expect(200);
+    assert.equal(res.body.message, 'Hello World!');
+  });
+
+  it('does not break when nested-routes use regexp paths', () => {
+    const app = new Koa();
+    const parentRouter = new Router();
+    const nestedRouter = new Router();
+
+    nestedRouter
+      .get(/^\/\w$/i, function (_ctx, next) {
+        return next();
+      })
+      .get('/first-nested-route', function (_ctx, next) {
+        return next();
+      })
+      .get('/second-nested-route', function (_ctx, next) {
+        return next();
+      });
+
+    parentRouter.use(
+      '/parent-route',
+      function (_ctx, next) {
+        return next();
+      },
+      nestedRouter.routes()
+    );
+
+    app.use(parentRouter.routes());
+    assert(app);
+  });
+
+  it('exposes middleware factory', () => {
+    const router = new Router();
+    assert.equal(typeof router.routes, 'function');
+    const middleware = router.routes();
+    assert.equal(typeof middleware, 'function');
+  });
+
+  it('supports promises for async/await', async () => {
+    const app = new Koa();
+    const router = new Router();
+    router.get('/async', function (ctx) {
+      return new Promise(function (resolve) {
+        setTimeout(function () {
+          ctx.body = {
+            msg: 'promises!',
+          };
+          resolve();
+        }, 1);
+      });
+    });
+
+    app.use(router.routes()).use(router.allowedMethods());
+    const res = await request(app.callback()).get('/async').expect(200);
+    assert.equal(res.body.msg, 'promises!');
+  });
+
+  it('matches middleware only if route was matched (gh-182)', async () => {
+    const app = new Koa();
+    const router = new Router();
+    const otherRouter = new Router();
+
+    router.use(function (ctx, next) {
+      ctx.body = { bar: 'baz' };
+      return next();
+    });
+
+    otherRouter.get('/bar', function (ctx) {
+      ctx.body = ctx.body || { foo: 'bar' };
+    });
+
+    app.use(router.routes()).use(otherRouter.routes());
+
+    const res = await request(app.callback()).get('/bar').expect(200);
+    assert.equal(res.body.foo, 'bar');
+    assert.equal(res.body.bar, undefined);
+  });
+
+  it('matches first to last', async () => {
+    const app = new Koa();
+    const router = new Router();
+
+    router
+      .get('user_page', '/user/(.*).jsx', function (ctx) {
+        ctx.body = { order: 1 };
+      })
+      .all('app', '/app/(.*).jsx', function (ctx) {
+        ctx.body = { order: 2 };
+      })
+      .all('view', '(.*).jsx', function (ctx) {
+        ctx.body = { order: 3 };
+      });
+
+    const res = await request(app.use(router.routes()).callback()).get('/user/account.jsx').expect(200);
+    assert.equal(res.body.order, 1);
+  });
+
+  it('does not run subsequent middleware without calling next', async () => {
+    const app = new Koa();
+    const router = new Router();
+
+    router.get(
+      'user_page',
+      '/user/(.*).jsx',
+      function () {
+        // no next()
+      },
+      function (ctx) {
+        ctx.body = { order: 1 };
+      }
+    );
+
+    await request(app.use(router.routes()).callback()).get('/user/account.jsx').expect(404);
+  });
+
+  it('nests routers with prefixes at root', async () => {
+    const app = new Koa();
+    const forums = new Router({
+      prefix: '/forums',
+    });
+    const posts = new Router({
+      prefix: '/:fid/posts',
+    });
+
+    posts
+      .get('/', function (ctx, next) {
+        ctx.status = 204;
+        return next();
+      })
+      .get('/:pid', function (ctx, next) {
+        ctx.body = ctx.params;
+        return next();
+      });
+
+    forums.use(posts.routes());
+
+    const server = app.use(forums.routes()).callback();
+
+    await request(server).get('/forums/1/posts').expect(204);
+    await request(server).get('/forums/1').expect(404);
+    const res = await request(server).get('/forums/1/posts/2').expect(200);
+    assert.equal(res.body.fid, '1');
+    assert.equal(res.body.pid, '2');
+  });
+
+  it('nests routers with prefixes at path', async () => {
+    const app = new Koa();
+    const forums = new Router({
+      prefix: '/api',
+    });
+    const posts = new Router({
+      prefix: '/posts',
+    });
+
+    posts
+      .get('/', function (ctx, next) {
+        ctx.status = 204;
+        return next();
+      })
+      .get('/:pid', function (ctx, next) {
+        ctx.body = ctx.params;
+        return next();
+      });
+
+    forums.use('/forums/:fid', posts.routes());
+
+    const server = app.use(forums.routes()).callback();
+
+    await request(server).get('/api/forums/1/posts').expect(204);
+
+    await request(server).get('/api/forums/1').expect(404);
+
+    const res = await request(server).get('/api/forums/1/posts/2').expect(200);
+    assert.equal(res.body.fid, '1');
+    assert.equal(res.body.pid, '2');
+  });
+
+  it('runs subrouter middleware after parent', async () => {
+    const app = new Koa();
+    const subrouter = new Router()
+      .use(function (ctx, next) {
+        ctx.msg = 'subrouter';
+        return next();
+      })
+      .get('/', function (ctx) {
+        ctx.body = { msg: ctx.msg };
+      });
+    const router = new Router()
+      .use(function (ctx, next) {
+        ctx.msg = 'router';
+        return next();
+      })
+      .use(subrouter.routes());
+    const res = await request(app.use(router.routes()).callback()).get('/').expect(200);
+    assert.equal(res.body.msg, 'subrouter');
+  });
+
+  it('runs parent middleware for subrouter routes', async () => {
+    const app = new Koa();
+    const subrouter = new Router().get('/sub', function (ctx) {
+      ctx.body = { msg: ctx.msg };
+    });
+    const router = new Router()
+      .use(function (ctx, next) {
+        ctx.msg = 'router';
+        return next();
+      })
+      .use('/parent', subrouter.routes());
+    const res = await request(app.use(router.routes()).callback()).get('/parent/sub').expect(200);
+    assert.equal(res.body.msg, 'router');
+  });
+
+  it('matches corresponding requests', async () => {
+    const app = new Koa();
+    const router = new Router();
+    app.use(router.routes());
+    router.get('/:category/:title', function (ctx) {
+      assert.equal(ctx.params.category, 'programming');
+      assert.equal(ctx.params.title, 'how-to-node');
+      ctx.status = 204;
+    });
+    router.post('/:category', function (ctx) {
+      assert.equal(ctx.params.category, 'programming');
+      ctx.status = 204;
+    });
+    router.put('/:category/not-a-title', function (ctx) {
+      assert.equal(ctx.params.category, 'programming');
+      assert.equal(ctx.params.title, undefined);
+      ctx.status = 204;
+    });
+    const server = app.callback();
+    await request(server).get('/programming/how-to-node').expect(204);
+    await request(server).post('/programming').expect(204);
+    await request(server).put('/programming/not-a-title').expect(204);
+  });
+
+  it('executes route middleware using `app.context`', async () => {
+    const app = new Koa();
+    const router = new Router();
+    app.use(router.routes());
+    router.use(function (ctx, next) {
+      ctx.bar = 'baz';
+      return next();
+    });
+    router.get(
+      '/:category/:title',
+      function (ctx, next) {
+        ctx.foo = 'bar';
+        return next();
+      },
+      function (ctx) {
+        ctx.body = {
+          bar: ctx.bar,
+          foo: ctx.foo,
+        };
+      }
+    );
+    const res = await request(app.callback()).get('/match/this').expect(200);
+    assert.equal(res.body.bar, 'baz');
+    assert.equal(res.body.foo, 'bar');
+  });
+
+  it('does not match after ctx.throw()', async () => {
+    const app = new Koa();
+    let counter = 0;
+    const router = new Router();
+    app.use(router.routes());
+    router.get('/', function (ctx) {
+      counter++;
+      ctx.throw(403);
+    });
+    router.get('/', function () {
+      counter++;
+    });
+    await request(app.callback()).get('/').expect(403);
+    assert.equal(counter, 1);
+  });
+
+  it('supports promises for route middleware', async () => {
+    const app = new Koa();
+    const router = new Router();
+    app.use(router.routes());
+    const readVersion = function () {
+      return new Promise(function (resolve, reject) {
+        fs.readFile('package.json', 'utf8', function (err, data) {
+          if (err) return reject(err);
+          resolve(JSON.parse(data).version);
+        });
+      });
+    };
+    router.get(
+      '/',
+      function (_ctx, next) {
+        return next();
+      },
+      function (ctx) {
+        return readVersion().then(function () {
+          ctx.status = 204;
+        });
+      }
+    );
+    await request(app.callback()).get('/').expect(204);
+  });
+
+  describe('Router#allowedMethods()', () => {
+    it('responds to OPTIONS requests', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      const res = await request(app.callback()).options('/users').expect(200);
+      assert.equal(res.headers['content-length'], '0');
+      assert.equal(res.headers.allow, 'HEAD, GET, PUT');
+    });
+
+    it('responds with 405 Method Not Allowed', async () => {
+      const app = new Koa();
+      const router = new Router();
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      router.post('/events', function () {});
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+      const res = await request(app.callback()).post('/users').expect(405);
+      assert.equal(res.headers.allow, 'HEAD, GET, PUT');
+    });
+
+    it('responds ignore allowedMethods when status is already set', async () => {
+      const app = new Koa();
+      const router = new Router();
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      router.post('/events', function () {});
+      app.use((ctx, next) => {
+        ctx.status = 200;
+        next();
+      });
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+      const res = await request(app.callback()).post('/users').expect(200);
+      assert.equal(res.headers.allow, undefined);
+    });
+
+    it('responds with 405 Method Not Allowed using the "throw" option', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(function (ctx, next) {
+        return next().catch(function (err) {
+          // assert that the correct HTTPError was thrown
+          // err.name.should.equal('MethodNotAllowedError');
+          // err.statusCode.should.equal(405);
+
+          // translate the HTTPError to a normal response
+          ctx.body = err.name;
+          ctx.status = err.statusCode;
+        });
+      });
+      app.use(router.allowedMethods({ throw: true }));
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      router.post('/events', function () {});
+      const res = await request(app.callback()).post('/users').expect(405);
+      // the 'Allow' header is not set when throwing
+      assert.equal(res.headers.allow, undefined);
+    });
+
+    it('responds with user-provided throwable using the "throw" and "methodNotAllowed" options', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(function (ctx, next) {
+        return next().catch(function (err) {
+          // assert that the correct HTTPError was thrown
+          // err.message.should.equal('Custom Not Allowed Error');
+          // err.statusCode.should.equal(405);
+
+          // translate the HTTPError to a normal response
+          ctx.body = err.body;
+          ctx.status = err.statusCode;
+        });
+      });
+      app.use(
+        router.allowedMethods({
+          throw: true,
+          methodNotAllowed() {
+            const notAllowedErr: any = new Error('Custom Not Allowed Error');
+            notAllowedErr.type = 'custom';
+            notAllowedErr.statusCode = 405;
+            notAllowedErr.body = {
+              error: 'Custom Not Allowed Error',
+              statusCode: 405,
+              otherStuff: true,
+            };
+            return notAllowedErr;
+          },
+        })
+      );
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      router.post('/events', function () {});
+      const res = await request(app.callback()).post('/users').expect(405);
+      // the 'Allow' header is not set when throwing
+      assert.equal(res.headers.allow, undefined);
+      assert.deepEqual(res.body, {
+        error: 'Custom Not Allowed Error',
+        statusCode: 405,
+        otherStuff: true,
+      });
+    });
+
+    it('responds with 501 Not Implemented', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      await request(app.callback()).search('/users').expect(501);
+    });
+
+    it('responds with 501 Not Implemented using the "throw" option', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(function (ctx, next) {
+        return next().catch(function (err) {
+          // assert that the correct HTTPError was thrown
+          // err.name.should.equal('NotImplementedError');
+          // err.statusCode.should.equal(501);
+
+          // translate the HTTPError to a normal response
+          ctx.body = err.name;
+          ctx.status = err.statusCode;
+        });
+      });
+      app.use(router.allowedMethods({ throw: true }));
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      const res = await request(app.callback()).search('/users').expect(501);
+      // the 'Allow' header is not set when throwing
+      assert.equal(res.headers.allow, undefined);
+    });
+
+    it('responds with user-provided throwable using the "throw" and "notImplemented" options', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(function (ctx, next) {
+        return next().catch(function (err) {
+          // assert that our custom error was thrown
+          // err.message.should.equal('Custom Not Implemented Error');
+          // err.type.should.equal('custom');
+          // err.statusCode.should.equal(501);
+
+          // translate the HTTPError to a normal response
+          ctx.body = err.body;
+          ctx.status = err.statusCode;
+        });
+      });
+      app.use(
+        router.allowedMethods({
+          throw: true,
+          notImplemented() {
+            const notImplementedErr: any = new Error('Custom Not Implemented Error');
+            notImplementedErr.type = 'custom';
+            notImplementedErr.statusCode = 501;
+            notImplementedErr.body = {
+              error: 'Custom Not Implemented Error',
+              statusCode: 501,
+              otherStuff: true,
+            };
+            return notImplementedErr;
+          },
+        })
+      );
+      router.get('/users', function () {});
+      router.put('/users', function () {});
+      const res = await request(app.callback()).search('/users').expect(501);
+      // the 'Allow' header is not set when throwing
+      assert.equal(res.header.allow, undefined);
+      assert.deepEqual(res.body, {
+        error: 'Custom Not Implemented Error',
+        statusCode: 501,
+        otherStuff: true,
+      });
+    });
+
+    it('does not send 405 if route matched but status is 404', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+      router.get('/users', function (ctx) {
+        ctx.status = 404;
+      });
+      await request(app.callback()).get('/users').expect(404);
+    });
+
+    it('sets the allowed methods to a single Allow header #273', async () => {
+      // https://tools.ietf.org/html/rfc7231#section-7.4.1
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      router.get('/', function () {});
+
+      const res = await request(app.callback()).options('/').expect(200);
+      assert.equal(res.header.allow, 'HEAD, GET');
+    });
+  });
+
+  it('supports custom routing detect path: ctx.routerPath', async () => {
+    const app = new Koa();
+    const router = new Router();
+    app.use(function (ctx, next) {
+      // bind helloworld.example.com/users => example.com/helloworld/users
+      const appname = ctx.request.hostname.split('.', 1)[0];
+      ctx.routerPath = '/' + appname + ctx.path;
+      return next();
+    });
+    app.use(router.routes());
+    router.get('/helloworld/users', function (ctx) {
+      ctx.body = ctx.method + ' ' + ctx.url;
+    });
+
+    await request(app.callback()).get('/users').set('Host', 'helloworld.example.com').expect(200).expect('GET /users');
+  });
+
+  describe('Router#[verb]()', () => {
+    it('registers route specific to HTTP verb', () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      methods.forEach(function (method) {
+        assert(method in router);
+        assert(typeof Reflect.get(router, method) === 'function');
+        Reflect.get(router, method).call(router, '/', function () {});
+      });
+      assert.equal(router.stack.length, methods.length);
+    });
+
+    it('registers route with a regexp path', () => {
+      const router = new Router();
+      methods.forEach(function (method) {
+        assert.equal(
+          Reflect.get(router, method).call(router, /^\/\w$/i, function () {}),
+          router
+        );
+      });
+    });
+
+    it('registers route with a given name', () => {
+      const router = new Router();
+      methods.forEach(function (method) {
+        assert.equal(
+          Reflect.get(router, method).call(router, '/', function () {}),
+          router
+        );
+      });
+    });
+
+    it('registers route with with a given name and regexp path', () => {
+      const router = new Router();
+      methods.forEach(function (method) {
+        assert.equal(
+          Reflect.get(router, method).call(router, /^\/$/i, function () {}),
+          router
+        );
+      });
+    });
+
+    it('enables route chaining', () => {
+      const router = new Router();
+      methods.forEach(function (method) {
+        assert(Reflect.get(router, method.toLowerCase()), `${method.toLowerCase()} not exists`);
+        assert.equal(
+          Reflect.get(router, method.toLowerCase()).call(router, '/', function () {}),
+          router
+        );
+      });
+    });
+
+    it('registers array of paths (gh-203)', () => {
+      const router = new Router();
+      router.get(['/one', '/two'], function (_ctx, next) {
+        return next();
+      });
+      assert.equal(router.stack.length, 2);
+      assert.equal(router.stack[0].path, '/one');
+      assert.equal(router.stack[1].path, '/two');
+    });
+
+    it('resolves non-parameterized routes without attached parameters', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.get('/notparameter', function (ctx) {
+        ctx.body = {
+          param: ctx.params.parameter,
+          routerName: ctx.routerName,
+          routerPath: ctx.routerPath,
+        };
+      });
+
+      router.get('/:parameter', function (ctx) {
+        ctx.body = {
+          param: ctx.params.parameter,
+          routerName: ctx.routerName,
+          routerPath: ctx.routerPath,
+        };
+      });
+
+      app.use(router.routes());
+      const res = await request(app.callback()).get('/notparameter').expect(200);
+      assert.equal(res.body.param, undefined);
+      assert.equal(res.body.routerName, undefined);
+      assert.equal(res.body.routerPath, '/notparameter');
+    });
+  });
+
+  describe('Router#use()', () => {
+    it('uses router middleware without path', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.use(function (ctx, next) {
+        ctx.foo = 'baz';
+        return next();
+      });
+
+      router.use(function (ctx, next) {
+        ctx.foo = 'foo';
+        return next();
+      });
+
+      router.get('/foo/bar', function (ctx) {
+        ctx.body = {
+          foobar: ctx.foo + 'bar',
+        };
+      });
+
+      app.use(router.routes());
+      const res = await request(app.callback()).get('/foo/bar').expect(200);
+      assert.equal(res.body.foobar, 'foobar');
+    });
+
+    it('uses router middleware at given path', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.use('/foo/bar', function (ctx, next) {
+        ctx.foo = 'foo';
+        return next();
+      });
+
+      router.get('/foo/bar', function (ctx) {
+        ctx.body = {
+          foobar: ctx.foo + 'bar',
+        };
+      });
+
+      app.use(router.routes());
+      const res = await request(app.callback()).get('/foo/bar').expect(200);
+      assert.equal(res.body.foobar, 'foobar');
+    });
+
+    it('runs router middleware before subrouter middleware', async () => {
+      const app = new Koa();
+      const router = new Router();
+      const subrouter = new Router();
+
+      router.use(function (ctx, next) {
+        ctx.foo = 'boo';
+        return next();
+      });
+
+      subrouter
+        .use(function (ctx, next) {
+          ctx.foo = 'foo';
+          return next();
+        })
+        .get('/bar', function (ctx) {
+          ctx.body = {
+            foobar: ctx.foo + 'bar',
+          };
+        });
+
+      router.use('/foo', subrouter.routes());
+      app.use(router.routes());
+      const res = await request(app.callback()).get('/foo/bar').expect(200);
+      assert.equal(res.body.foobar, 'foobar');
+    });
+
+    it('assigns middleware to array of paths', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.use(['/foo', '/bar'], function (ctx, next) {
+        ctx.foo = 'foo';
+        ctx.bar = 'bar';
+        return next();
+      });
+
+      router.get('/foo', function (ctx) {
+        ctx.body = {
+          foobar: ctx.foo + 'bar',
+        };
+      });
+
+      router.get('/bar', function (ctx) {
+        ctx.body = {
+          foobar: 'foo' + ctx.bar,
+        };
+      });
+
+      app.use(router.routes());
+      let res = await request(app.callback()).get('/foo').expect(200);
+      assert.equal(res.body.foobar, 'foobar');
+      res = await request(app.callback()).get('/bar').expect(200);
+      assert.equal(res.body.foobar, 'foobar');
+    });
+
+    it('without path, does not set params.0 to the matched path - gh-247', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.use(function (_ctx, next) {
+        return next();
+      });
+
+      router.get('/foo/:id', function (ctx) {
+        ctx.body = ctx.params;
+      });
+
+      app.use(router.routes());
+      const res = await request(app.callback()).get('/foo/815').expect(200);
+      assert.equal(res.body.id, '815');
+      assert.equal(res.body['0'], undefined);
+
+      const res2 = await request(app.callback()).get('/foo/1,2,3,4,5').expect(200);
+      assert.equal(res2.body.id, '1,2,3,4,5');
+    });
+
+    it('does not add an erroneous (.*) to unprefixed nested routers - gh-369 gh-410', async () => {
+      const app = new Koa();
+      const router = new Router();
+      const nested = new Router();
+      let called = 0;
+
+      nested
+        .get('/', (ctx, next) => {
+          ctx.body = 'root';
+          called += 1;
+          return next();
+        })
+        .get('/test', (ctx, next) => {
+          ctx.body = 'test';
+          called += 1;
+          return next();
+        });
+
+      router.use(nested.routes());
+      app.use(router.routes());
+
+      await request(app.callback()).get('/test').expect(200).expect('test');
+      assert.equal(called, 1);
+    });
+  });
+
+  describe('Router#register()', () => {
+    it('registers new routes', () => {
+      const app = new Koa();
+      const router = new Router();
+      assert(typeof router.register === 'function');
+      const route = router.register('/', ['GET', 'POST'], function () {});
+      assert(route);
+      app.use(router.routes());
+      assert.equal(router.stack.length, 1);
+      assert.equal(router.stack[0].path, '/');
+    });
+  });
+
+  describe('Router#redirect()', () => {
+    it('registers redirect routes', () => {
+      const app = new Koa();
+      const router = new Router();
+      assert(typeof router.redirect === 'function');
+      router.redirect('/source', '/destination', 302);
+      app.use(router.routes());
+      assert.equal(router.stack.length, 1);
+      assert.equal(router.stack[0].path, '/source');
+    });
+
+    it('redirects using route names', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      router.get('home', '/', function () {});
+      router.get('sign-up-form', '/sign-up-form', function () {});
+      router.redirect('home', 'sign-up-form');
+      const res = await request(app.callback()).post('/').expect(301);
+      assert.equal(res.headers.location, '/sign-up-form');
+    });
+
+    it('registers redirect not exists routes', () => {
+      const router = new Router();
+      assert(typeof router.redirect === 'function');
+      assert.throws(() => {
+        router.redirect('source-not-exists', '/destination', 302);
+      }, /Error: No route found for name: source-not-exists/);
+      assert.throws(() => {
+        router.redirect('/source', 'destination-not-exists');
+      }, /Error: No route found for name: destination-not-exists/);
+    });
+  });
+
+  describe('Router#route()', () => {
+    it('inherits routes from nested router', () => {
+      const subrouter = new Router().get('child', '/hello', function (ctx) {
+        ctx.body = { hello: 'world' };
+      });
+      const router = new Router().use(subrouter.routes());
+      const route = router.route('child');
+      assert(route);
+      assert.equal(route.name, 'child');
+    });
+  });
+
+  describe('Router#url()', () => {
+    it('generates URL for given route name', () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      router.get('books', '/:category/:title', function (ctx) {
+        ctx.status = 204;
+      });
+      let url = router.url('books', { category: 'programming', title: 'how to node' });
+      assert.equal(url, '/programming/how%20to%20node');
+      url = router.url('books', 'programming', 'how to node');
+      assert.equal(url, '/programming/how%20to%20node');
+
+      const err = router.url('not-exists', { category: 'programming', title: 'how to node' });
+      assert(err instanceof Error);
+      assert.equal(err.message, 'No route found for name: not-exists');
+    });
+
+    it('generates URL for given route name within embedded routers', () => {
+      const app = new Koa();
+      const router = new Router({
+        prefix: '/books',
+      });
+
+      const embeddedRouter = new Router({
+        prefix: '/chapters',
+      });
+      embeddedRouter.get('chapters', '/:chapterName/:pageNumber', function (ctx) {
+        ctx.status = 204;
+      });
+      router.use(embeddedRouter.routes());
+      app.use(router.routes());
+      let url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
+      assert.equal(url, '/books/chapters/Learning%20ECMA6/123');
+      url = router.url('chapters', 'Learning ECMA6', 123);
+      assert.equal(url, '/books/chapters/Learning%20ECMA6/123');
+    });
+
+    it('generates URL for given route name within two embedded routers', () => {
+      const app = new Koa();
+      const router = new Router({
+        prefix: '/books',
+      });
+      const embeddedRouter = new Router({
+        prefix: '/chapters',
+      });
+      const embeddedRouter2 = new Router({
+        prefix: '/:chapterName/pages',
+      });
+      embeddedRouter2.get('chapters', '/:pageNumber', function (ctx) {
+        ctx.status = 204;
+      });
+      embeddedRouter.use(embeddedRouter2.routes());
+      router.use(embeddedRouter.routes());
+      app.use(router.routes());
+      const url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
+      assert.equal(url, '/books/chapters/Learning%20ECMA6/pages/123');
+    });
+
+    it('generates URL for given route name with params and query params', () => {
+      const router = new Router();
+      router.get('books', '/books/:category/:id', function (ctx) {
+        ctx.status = 204;
+      });
+      let url = router.url('books', 'programming', 4, {
+        query: { page: 3, limit: 10 },
+      });
+      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      url = router.url('books', { category: 'programming', id: 4 }, { query: { page: 3, limit: 10 } });
+      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      url = router.url('books', { category: 'programming', id: 4 }, { query: 'page=3&limit=10' });
+      assert.equal(url, '/books/programming/4?page=3&limit=10');
+    });
+
+    it('generates URL for given route name without params and query params', () => {
+      const router = new Router();
+      router.get('category', '/category', function (ctx) {
+        ctx.status = 204;
+      });
+      const url = router.url('category', {
+        query: { page: 3, limit: 10 },
+      });
+      assert.equal(url, '/category?page=3&limit=10');
+    });
+  });
+
+  describe('Router#param()', () => {
+    it('runs parameter middleware', async () => {
+      const app = new Koa();
+      const router = new Router();
+      app.use(router.routes());
+      router
+        .param('user', function (id, ctx, next) {
+          ctx.user = { name: 'alex' };
+          if (!id) {
+            ctx.status = 404;
+            return;
+          }
+          return next();
+        })
+        .get('/users/:user', function (ctx) {
+          ctx.body = ctx.user;
+        });
+      const res = await request(app.callback()).get('/users/3').expect(200);
+      assert.equal(res.body.name, 'alex');
+    });
+
+    it('runs parameter middleware in order of URL appearance', async () => {
+      const app = new Koa();
+      const router = new Router();
+      router
+        .param('user', function (id, ctx, next) {
+          ctx.user = { name: 'alex' };
+          if (ctx.ranFirst) {
+            ctx.user.ordered = 'parameters';
+          }
+          if (!id) {
+            ctx.status = 404;
+            return;
+          }
+          return next();
+        })
+        .param('first', function (id, ctx, next) {
+          ctx.ranFirst = true;
+          if (ctx.user) {
+            ctx.ranFirst = false;
+          }
+          if (!id) {
+            ctx.status = 404;
+            return;
+          }
+          return next();
+        })
+        .get('/:first/users/:user', function (ctx) {
+          ctx.body = ctx.user;
+        });
+
+      const res = await request(app.use(router.routes()).callback()).get('/first/users/3').expect(200);
+      assert.equal(res.body.name, 'alex');
+      assert.equal(res.body.ordered, 'parameters');
+    });
+
+    it('runs parameter middleware in order of URL appearance even when added in random order', async () => {
+      const app = new Koa();
+      const router = new Router();
+      router
+        // intentional random order
+        .param('a', function (id, ctx, next) {
+          ctx.state.loaded = [id];
+          return next();
+        })
+        .param('d', function (id, ctx, next) {
+          ctx.state.loaded.push(id);
+          return next();
+        })
+        .param('c', function (id, ctx, next) {
+          ctx.state.loaded.push(id);
+          return next();
+        })
+        .param('b', function (id, ctx, next) {
+          ctx.state.loaded.push(id);
+          return next();
+        })
+        .get('/:a/:b/:c/:d', function (ctx) {
+          ctx.body = ctx.state.loaded;
+        });
+
+      const res = await request(app.use(router.routes()).callback()).get('/1/2/3/4').expect(200);
+      assert.deepEqual(res.body, ['1', '2', '3', '4']);
+    });
+
+    it('runs parent parameter middleware for subrouter', async () => {
+      const app = new Koa();
+      const router = new Router();
+      const subrouter = new Router();
+      subrouter.get('/:cid', function (ctx) {
+        ctx.body = {
+          id: ctx.params.id,
+          cid: ctx.params.cid,
+        };
+      });
+      router
+        .param('id', function (id, ctx, next) {
+          ctx.params.id = 'ran';
+          if (!id) {
+            ctx.status = 404;
+            return;
+          }
+          return next();
+        })
+        .use('/:id/children', subrouter.routes());
+
+      const res = await request(app.use(router.routes()).callback()).get('/did-not-run/children/2').expect(200);
+      assert.deepEqual(res.body.id, 'ran');
+      assert.deepEqual(res.body.cid, '2');
+    });
+  });
+
+  describe('Router#opts', () => {
+    it('responds with 200', async () => {
+      const app = new Koa();
+      const router = new Router({
+        strict: true,
+      });
+      router.get('/info', function (ctx) {
+        ctx.body = 'hello';
+      });
+      const res = await request(app.use(router.routes()).callback()).get('/info').expect(200);
+      assert.equal(res.text, 'hello');
+    });
+
+    it('should allow setting a prefix', async () => {
+      const app = new Koa();
+      const routes = new Router({ prefix: '/things/:thing_id' });
+
+      routes.get('/list', function (ctx) {
+        ctx.body = ctx.params;
+      });
+
+      const res = await request(app.use(routes.routes()).callback()).get('/things/1/list').expect(200);
+      assert.equal(res.body.thing_id, '1');
+    });
+
+    it('responds with 404 when has a trailing slash', async () => {
+      const app = new Koa();
+      const router = new Router({
+        strict: true,
+      });
+      router.get('/info', function (ctx) {
+        ctx.body = 'hello';
+      });
+      await request(app.use(router.routes()).callback()).get('/info/').expect(404);
+    });
+  });
+
+  describe('use middleware with opts', () => {
+    it('responds with 200', async () => {
+      const app = new Koa();
+      const router = new Router({
+        strict: true,
+      });
+      router.get('/info', function (ctx) {
+        ctx.body = 'hello';
+      });
+      const res = await request(app.use(router.routes()).callback()).get('/info').expect(200);
+      assert.equal(res.text, 'hello');
+    });
+
+    it('responds with 404 when has a trailing slash', async () => {
+      const app = new Koa();
+      const router = new Router({
+        strict: true,
+      });
+      router.get('/info', function (ctx) {
+        ctx.body = 'hello';
+      });
+      await request(app.use(router.routes()).callback()).get('/info/').expect(404);
+    });
+  });
+
+  describe('router.routes()', () => {
+    it('should return composed middleware', async () => {
+      const app = new Koa();
+      const router = new Router();
+      let middlewareCount = 0;
+      const middlewareA = function (_ctx: any, next: Next) {
+        middlewareCount++;
+        return next();
+      };
+      const middlewareB = function (_ctx: any, next: Next) {
+        middlewareCount++;
+        return next();
+      };
+
+      router.use(middlewareA, middlewareB);
+      router.get('/users/:id', function (ctx) {
+        assert(ctx.params.id);
+        ctx.body = { hello: 'world' };
+      });
+
+      const routerMiddleware = router.routes();
+      assert(typeof routerMiddleware === 'function');
+
+      const res = await request(app.use(routerMiddleware).callback()).get('/users/1').expect(200);
+      assert.equal(res.body.hello, 'world');
+      assert.equal(middlewareCount, 2);
+    });
+
+    it('places a `_matchedRoute` value on context', async () => {
+      const app = new Koa();
+      const router = new Router();
+      const middleware = function (ctx: any, next: Next) {
+        assert.equal(ctx._matchedRoute, '/users/:id');
+        return next();
+      };
+
+      router.get('/users/:id', middleware, function (ctx) {
+        assert.equal(ctx._matchedRoute, '/users/:id');
+        assert(ctx.params.id);
+        ctx.body = { hello: 'world' };
+      });
+
+      const routerMiddleware = router.routes();
+
+      await request(app.use(routerMiddleware).callback()).get('/users/1').expect(200);
+    });
+
+    it('places a `_matchedRouteName` value on the context for a named route', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.get('users#show', '/users/:id', function (ctx) {
+        assert.equal(ctx._matchedRouteName, 'users#show');
+        ctx.status = 200;
+      });
+
+      await request(app.use(router.routes()).callback()).get('/users/1').expect(200);
+    });
+
+    it('does not place a `_matchedRouteName` value on the context for unnamed routes', async () => {
+      const app = new Koa();
+      const router = new Router();
+
+      router.get('/users/:id', function (ctx) {
+        assert.equal(ctx._matchedRouteName, undefined);
+        ctx.status = 200;
+      });
+
+      await request(app.use(router.routes()).callback()).get('/users/1').expect(200);
+    });
+
+    it('routerName and routerPath work with next', async () => {
+      const app = new Koa();
+      const router = new Router();
+      router.get('name1', '/users/1', function (ctx, next) {
+        assert.equal(ctx._matchedRouteName, 'name1');
+        assert.equal(ctx.routerName, 'name1');
+        assert.equal(ctx._matchedRoute, '/users/1');
+        assert.equal(ctx.routerPath, '/users/1');
+        return next();
+      });
+      router.get('name2', '/users/:id', function (ctx) {
+        assert.equal(ctx._matchedRouteName, 'name2');
+        assert.equal(ctx.routerName, 'name2');
+        assert.equal(ctx._matchedRoute, '/users/:id');
+        assert.equal(ctx.routerPath, '/users/:id');
+        ctx.status = 200;
+      });
+
+      await request(app.use(router.routes()).callback()).get('/users/1').expect(200);
+    });
+  });
+
+  describe('If no HEAD method, default to GET', () => {
+    it('should default to GET', async () => {
+      const app = new Koa();
+      const router = new Router();
+      console.log(router);
+      router.get('/users/:id', function (ctx) {
+        assert(ctx.params.id);
+        ctx.body = 'hello';
+      });
+      app.use(router.routes());
+      let res = await request(app.callback()).get('/users/1').expect(200);
+      assert.equal(res.text, 'hello');
+      res = await request(app.callback()).head('/users/1').expect(200);
+      assert.equal(res.text, '');
+    });
+  });
+
+  describe('Router#prefix', () => {
+    it('should set opts.prefix', () => {
+      const router = new Router();
+      assert.equal(router.opts.prefix, undefined);
+      router.prefix('/things/:thing_id');
+      assert.equal(router.opts.prefix, '/things/:thing_id');
+    });
+
+    it('should prefix existing routes', () => {
+      const router = new Router();
+      router.get('/users/:id', function (ctx) {
+        ctx.body = 'test';
+      });
+      router.prefix('/things/:thing_id');
+      const route = router.stack[0];
+      assert.equal(route.path, '/things/:thing_id/users/:id');
+      assert.equal(route.paramNames.length, 2);
+      assert.equal(route.paramNames[0].name, 'thing_id');
+      assert.equal(route.paramNames[1].name, 'id');
+    });
+
+    describe('when used with .use(fn) - gh-247', () => {
+      it('does not set params.0 to the matched path', async () => {
+        const app = new Koa();
+        const router = new Router();
+
+        router.use(function (_ctx, next) {
+          return next();
+        });
+
+        router.get('/foo/:id', function (ctx) {
+          ctx.body = ctx.params;
+        });
+
+        router.prefix('/things');
+
+        app.use(router.routes());
+        const res = await request(app.callback()).get('/things/foo/108').expect(200);
+        assert.equal(res.body.id, '108');
+        assert.equal(res.body['0'], undefined);
+      });
+    });
+
+    describe('with trailing slash', testPrefix('/admin/'));
+    describe('without trailing slash', testPrefix('/admin'));
+
+    function testPrefix(prefix: string) {
+      return () => {
+        let server: any;
+        let middlewareCount = 0;
+
+        before(function () {
+          const app = new Koa();
+          const router = new Router();
+
+          router.use(function (ctx, next) {
+            middlewareCount++;
+            ctx.thing = 'worked';
+            return next();
+          });
+
+          router.get('/', function (ctx) {
+            middlewareCount++;
+            ctx.body = { name: ctx.thing };
+          });
+
+          router.prefix(prefix);
+          server = app.use(router.routes()).callback();
+        });
+
+        beforeEach(() => {
+          middlewareCount = 0;
+        });
+
+        it('should support root level router middleware', async () => {
+          const res = await request(server).get(prefix).expect(200);
+          assert.equal(middlewareCount, 2);
+          assert.equal(res.body.name, 'worked');
+        });
+
+        it('should support requests with a trailing path slash', async () => {
+          const res = await request(server).get('/admin/').expect(200);
+          assert.equal(middlewareCount, 2);
+          assert.equal(res.body.name, 'worked');
+        });
+
+        it('should support requests without a trailing path slash', async () => {
+          const res = await request(server).get('/admin').expect(200);
+          assert.equal(middlewareCount, 2);
+          assert.equal(res.body.name, 'worked');
+        });
+      };
+    }
+  });
+
+  describe('Static Router#url()', () => {
+    it('generates route URL', () => {
+      const url = Router.url('/:category/:title', { category: 'programming', title: 'how-to-node' });
+      assert.equal(url, '/programming/how-to-node');
+    });
+
+    it('escapes using encodeURIComponent()', () => {
+      const url = Router.url('/:category/:title', { category: 'programming', title: 'how to node' });
+      assert.equal(url, '/programming/how%20to%20node');
+    });
+
+    it('generates route URL with params and query params', () => {
+      let url = Router.url('/books/:category/:id', 'programming', 4, {
+        query: { page: 3, limit: 10 },
+      });
+      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      url = Router.url('/books/:category/:id', { category: 'programming', id: 4 }, { query: { page: 3, limit: 10 } });
+      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      url = Router.url('/books/:category/:id', { category: 'programming', id: 4 }, { query: 'page=3&limit=10' });
+      assert.equal(url, '/books/programming/4?page=3&limit=10');
+    });
+
+    it('generates router URL without params and with with query params', () => {
+      const url = Router.url('/category', {
+        query: { page: 3, limit: 10 },
+      });
+      assert.equal(url, '/category?page=3&limit=10');
+    });
+  });
+});

--- a/packages/router/test/Router.test.ts
+++ b/packages/router/test/Router.test.ts
@@ -1,15 +1,17 @@
-import { strict as assert } from 'node:assert';
 import fs from 'node:fs';
+
 import { Application as Koa } from '@eggjs/koa';
 import methods from 'methods';
-import request from 'supertest';
-import Router from '../src/index.js';
-import { Next } from '../src/types.js';
+import request from '@eggjs/supertest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+
+import Router from '../src/index.ts';
+import type { Next } from '../src/types.ts';
 
 describe('test/lib/router.test.js', () => {
   it('creates new router', () => {
     const router = new Router();
-    assert(router instanceof Router);
+    expect(router instanceof Router).toBe(true);
   });
 
   it('shares context between routers (gh-205)', async () => {
@@ -27,7 +29,7 @@ describe('test/lib/router.test.js', () => {
     });
     app.use(router1.routes()).use(router2.routes());
     const res = await request(app.callback()).get('/').expect(200);
-    assert.equal(res.body.foo, 'bar');
+    expect(res.body.foo).toBe('bar');
   });
 
   it('does not register middleware more than once (gh-184)', async () => {
@@ -58,7 +60,7 @@ describe('test/lib/router.test.js', () => {
     app.use(parentRouter.routes());
 
     const res = await request(app.callback()).get('/parent-route/first-nested-route').expect(200);
-    assert.equal(res.body.n, 1);
+    expect(res.body.n).toBe(1);
   });
 
   it('router can be access with ctx', async () => {
@@ -71,7 +73,7 @@ describe('test/lib/router.test.js', () => {
     });
     app.use(router.routes());
     const res = await request(app.callback()).get('/').expect(200);
-    assert.equal(res.body.url, '/');
+    expect(res.body.url).toBe('/');
   });
 
   it('registers multiple middleware for one route', async () => {
@@ -104,7 +106,7 @@ describe('test/lib/router.test.js', () => {
     app.use(router.routes());
 
     const res = await request(app.callback()).get('/double').expect(200);
-    assert.equal(res.body.message, 'Hello World!');
+    expect(res.body.message).toBe('Hello World!');
   });
 
   it('does not break when nested-routes use regexp paths', () => {
@@ -132,14 +134,14 @@ describe('test/lib/router.test.js', () => {
     );
 
     app.use(parentRouter.routes());
-    assert(app);
+    expect(app).toBeDefined();
   });
 
   it('exposes middleware factory', () => {
     const router = new Router();
-    assert.equal(typeof router.routes, 'function');
+    expect(typeof router.routes).toBe('function');
     const middleware = router.routes();
-    assert.equal(typeof middleware, 'function');
+    expect(typeof middleware).toBe('function');
   });
 
   it('supports promises for async/await', async () => {
@@ -158,7 +160,7 @@ describe('test/lib/router.test.js', () => {
 
     app.use(router.routes()).use(router.allowedMethods());
     const res = await request(app.callback()).get('/async').expect(200);
-    assert.equal(res.body.msg, 'promises!');
+    expect(res.body.msg).toBe('promises!');
   });
 
   it('matches middleware only if route was matched (gh-182)', async () => {
@@ -178,8 +180,8 @@ describe('test/lib/router.test.js', () => {
     app.use(router.routes()).use(otherRouter.routes());
 
     const res = await request(app.callback()).get('/bar').expect(200);
-    assert.equal(res.body.foo, 'bar');
-    assert.equal(res.body.bar, undefined);
+    expect(res.body.foo).toBe('bar');
+    expect(res.body.bar).toBeUndefined();
   });
 
   it('matches first to last', async () => {
@@ -198,7 +200,7 @@ describe('test/lib/router.test.js', () => {
       });
 
     const res = await request(app.use(router.routes()).callback()).get('/user/account.jsx').expect(200);
-    assert.equal(res.body.order, 1);
+    expect(res.body.order).toBe(1);
   });
 
   it('does not run subsequent middleware without calling next', async () => {
@@ -245,8 +247,8 @@ describe('test/lib/router.test.js', () => {
     await request(server).get('/forums/1/posts').expect(204);
     await request(server).get('/forums/1').expect(404);
     const res = await request(server).get('/forums/1/posts/2').expect(200);
-    assert.equal(res.body.fid, '1');
-    assert.equal(res.body.pid, '2');
+    expect(res.body.fid).toBe('1');
+    expect(res.body.pid).toBe('2');
   });
 
   it('nests routers with prefixes at path', async () => {
@@ -277,8 +279,8 @@ describe('test/lib/router.test.js', () => {
     await request(server).get('/api/forums/1').expect(404);
 
     const res = await request(server).get('/api/forums/1/posts/2').expect(200);
-    assert.equal(res.body.fid, '1');
-    assert.equal(res.body.pid, '2');
+    expect(res.body.fid).toBe('1');
+    expect(res.body.pid).toBe('2');
   });
 
   it('runs subrouter middleware after parent', async () => {
@@ -298,7 +300,7 @@ describe('test/lib/router.test.js', () => {
       })
       .use(subrouter.routes());
     const res = await request(app.use(router.routes()).callback()).get('/').expect(200);
-    assert.equal(res.body.msg, 'subrouter');
+    expect(res.body.msg).toBe('subrouter');
   });
 
   it('runs parent middleware for subrouter routes', async () => {
@@ -313,7 +315,7 @@ describe('test/lib/router.test.js', () => {
       })
       .use('/parent', subrouter.routes());
     const res = await request(app.use(router.routes()).callback()).get('/parent/sub').expect(200);
-    assert.equal(res.body.msg, 'router');
+    expect(res.body.msg).toBe('router');
   });
 
   it('matches corresponding requests', async () => {
@@ -321,17 +323,17 @@ describe('test/lib/router.test.js', () => {
     const router = new Router();
     app.use(router.routes());
     router.get('/:category/:title', function (ctx) {
-      assert.equal(ctx.params.category, 'programming');
-      assert.equal(ctx.params.title, 'how-to-node');
+      expect(ctx.params.category).toBe('programming');
+      expect(ctx.params.title).toBe('how-to-node');
       ctx.status = 204;
     });
     router.post('/:category', function (ctx) {
-      assert.equal(ctx.params.category, 'programming');
+      expect(ctx.params.category).toBe('programming');
       ctx.status = 204;
     });
     router.put('/:category/not-a-title', function (ctx) {
-      assert.equal(ctx.params.category, 'programming');
-      assert.equal(ctx.params.title, undefined);
+      expect(ctx.params.category).toBe('programming');
+      expect(ctx.params.title).toBeUndefined();
       ctx.status = 204;
     });
     const server = app.callback();
@@ -362,8 +364,8 @@ describe('test/lib/router.test.js', () => {
       }
     );
     const res = await request(app.callback()).get('/match/this').expect(200);
-    assert.equal(res.body.bar, 'baz');
-    assert.equal(res.body.foo, 'bar');
+    expect(res.body.bar).toBe('baz');
+    expect(res.body.foo).toBe('bar');
   });
 
   it('does not match after ctx.throw()', async () => {
@@ -379,7 +381,7 @@ describe('test/lib/router.test.js', () => {
       counter++;
     });
     await request(app.callback()).get('/').expect(403);
-    assert.equal(counter, 1);
+    expect(counter).toBe(1);
   });
 
   it('supports promises for route middleware', async () => {
@@ -417,8 +419,8 @@ describe('test/lib/router.test.js', () => {
       router.get('/users', function () {});
       router.put('/users', function () {});
       const res = await request(app.callback()).options('/users').expect(200);
-      assert.equal(res.headers['content-length'], '0');
-      assert.equal(res.headers.allow, 'HEAD, GET, PUT');
+      expect(res.headers['content-length']).toBe('0');
+      expect(res.headers.allow).toBe('HEAD, GET, PUT');
     });
 
     it('responds with 405 Method Not Allowed', async () => {
@@ -430,7 +432,7 @@ describe('test/lib/router.test.js', () => {
       app.use(router.routes());
       app.use(router.allowedMethods());
       const res = await request(app.callback()).post('/users').expect(405);
-      assert.equal(res.headers.allow, 'HEAD, GET, PUT');
+      expect(res.headers.allow).toBe('HEAD, GET, PUT');
     });
 
     it('responds ignore allowedMethods when status is already set', async () => {
@@ -446,7 +448,7 @@ describe('test/lib/router.test.js', () => {
       app.use(router.routes());
       app.use(router.allowedMethods());
       const res = await request(app.callback()).post('/users').expect(200);
-      assert.equal(res.headers.allow, undefined);
+      expect(res.headers.allow).toBeUndefined();
     });
 
     it('responds with 405 Method Not Allowed using the "throw" option', async () => {
@@ -470,7 +472,7 @@ describe('test/lib/router.test.js', () => {
       router.post('/events', function () {});
       const res = await request(app.callback()).post('/users').expect(405);
       // the 'Allow' header is not set when throwing
-      assert.equal(res.headers.allow, undefined);
+      expect(res.headers.allow).toBeUndefined();
     });
 
     it('responds with user-provided throwable using the "throw" and "methodNotAllowed" options', async () => {
@@ -509,8 +511,8 @@ describe('test/lib/router.test.js', () => {
       router.post('/events', function () {});
       const res = await request(app.callback()).post('/users').expect(405);
       // the 'Allow' header is not set when throwing
-      assert.equal(res.headers.allow, undefined);
-      assert.deepEqual(res.body, {
+      expect(res.headers.allow).toBeUndefined();
+      expect(res.body).toEqual({
         error: 'Custom Not Allowed Error',
         statusCode: 405,
         otherStuff: true,
@@ -524,7 +526,9 @@ describe('test/lib/router.test.js', () => {
       app.use(router.allowedMethods());
       router.get('/users', function () {});
       router.put('/users', function () {});
-      await request(app.callback()).search('/users').expect(501);
+      // await request(app.callback()).search('/users').expect(501);
+      // @ts-expect-error protected method
+      await request(app.callback())._testRequest('search', '/users').expect(501);
     });
 
     it('responds with 501 Not Implemented using the "throw" option', async () => {
@@ -545,9 +549,10 @@ describe('test/lib/router.test.js', () => {
       app.use(router.allowedMethods({ throw: true }));
       router.get('/users', function () {});
       router.put('/users', function () {});
-      const res = await request(app.callback()).search('/users').expect(501);
+      // @ts-expect-error protected method
+      const res = await request(app.callback())._testRequest('search', '/users').expect(501);
       // the 'Allow' header is not set when throwing
-      assert.equal(res.headers.allow, undefined);
+      expect(res.headers.allow).toBeUndefined();
     });
 
     it('responds with user-provided throwable using the "throw" and "notImplemented" options', async () => {
@@ -584,10 +589,11 @@ describe('test/lib/router.test.js', () => {
       );
       router.get('/users', function () {});
       router.put('/users', function () {});
-      const res = await request(app.callback()).search('/users').expect(501);
+      // @ts-expect-error protected method
+      const res = await request(app.callback())._testRequest('search', '/users').expect(501);
       // the 'Allow' header is not set when throwing
-      assert.equal(res.header.allow, undefined);
-      assert.deepEqual(res.body, {
+      expect(res.header.allow).toBeUndefined();
+      expect(res.body).toEqual({
         error: 'Custom Not Implemented Error',
         statusCode: 501,
         otherStuff: true,
@@ -615,7 +621,7 @@ describe('test/lib/router.test.js', () => {
       router.get('/', function () {});
 
       const res = await request(app.callback()).options('/').expect(200);
-      assert.equal(res.header.allow, 'HEAD, GET');
+      expect(res.header.allow).toBe('HEAD, GET');
     });
   });
 
@@ -642,51 +648,39 @@ describe('test/lib/router.test.js', () => {
       const router = new Router();
       app.use(router.routes());
       methods.forEach(function (method) {
-        assert(method in router);
-        assert(typeof Reflect.get(router, method) === 'function');
+        expect(method in router).toBe(true);
+        expect(typeof Reflect.get(router, method) === 'function').toBe(true);
         Reflect.get(router, method).call(router, '/', function () {});
       });
-      assert.equal(router.stack.length, methods.length);
+      expect(router.stack.length).toBe(methods.length);
     });
 
     it('registers route with a regexp path', () => {
       const router = new Router();
       methods.forEach(function (method) {
-        assert.equal(
-          Reflect.get(router, method).call(router, /^\/\w$/i, function () {}),
-          router
-        );
+        expect(Reflect.get(router, method).call(router, /^\/\w$/i, function () {})).toBe(router);
       });
     });
 
     it('registers route with a given name', () => {
       const router = new Router();
       methods.forEach(function (method) {
-        assert.equal(
-          Reflect.get(router, method).call(router, '/', function () {}),
-          router
-        );
+        expect(Reflect.get(router, method).call(router, '/', function () {})).toBe(router);
       });
     });
 
     it('registers route with with a given name and regexp path', () => {
       const router = new Router();
       methods.forEach(function (method) {
-        assert.equal(
-          Reflect.get(router, method).call(router, /^\/$/i, function () {}),
-          router
-        );
+        expect(Reflect.get(router, method).call(router, /^\/$/i, function () {})).toBe(router);
       });
     });
 
     it('enables route chaining', () => {
       const router = new Router();
       methods.forEach(function (method) {
-        assert(Reflect.get(router, method.toLowerCase()), `${method.toLowerCase()} not exists`);
-        assert.equal(
-          Reflect.get(router, method.toLowerCase()).call(router, '/', function () {}),
-          router
-        );
+        expect(Reflect.get(router, method.toLowerCase())).toBeDefined();
+        expect(Reflect.get(router, method.toLowerCase()).call(router, '/', function () {})).toBe(router);
       });
     });
 
@@ -695,9 +689,9 @@ describe('test/lib/router.test.js', () => {
       router.get(['/one', '/two'], function (_ctx, next) {
         return next();
       });
-      assert.equal(router.stack.length, 2);
-      assert.equal(router.stack[0].path, '/one');
-      assert.equal(router.stack[1].path, '/two');
+      expect(router.stack.length).toBe(2);
+      expect(router.stack[0].path).toBe('/one');
+      expect(router.stack[1].path).toBe('/two');
     });
 
     it('resolves non-parameterized routes without attached parameters', async () => {
@@ -722,9 +716,9 @@ describe('test/lib/router.test.js', () => {
 
       app.use(router.routes());
       const res = await request(app.callback()).get('/notparameter').expect(200);
-      assert.equal(res.body.param, undefined);
-      assert.equal(res.body.routerName, undefined);
-      assert.equal(res.body.routerPath, '/notparameter');
+      expect(res.body.param).toBeUndefined();
+      expect(res.body.routerName).toBeUndefined();
+      expect(res.body.routerPath).toBe('/notparameter');
     });
   });
 
@@ -751,7 +745,7 @@ describe('test/lib/router.test.js', () => {
 
       app.use(router.routes());
       const res = await request(app.callback()).get('/foo/bar').expect(200);
-      assert.equal(res.body.foobar, 'foobar');
+      expect(res.body.foobar).toBe('foobar');
     });
 
     it('uses router middleware at given path', async () => {
@@ -771,7 +765,7 @@ describe('test/lib/router.test.js', () => {
 
       app.use(router.routes());
       const res = await request(app.callback()).get('/foo/bar').expect(200);
-      assert.equal(res.body.foobar, 'foobar');
+      expect(res.body.foobar).toBe('foobar');
     });
 
     it('runs router middleware before subrouter middleware', async () => {
@@ -798,7 +792,7 @@ describe('test/lib/router.test.js', () => {
       router.use('/foo', subrouter.routes());
       app.use(router.routes());
       const res = await request(app.callback()).get('/foo/bar').expect(200);
-      assert.equal(res.body.foobar, 'foobar');
+      expect(res.body.foobar).toBe('foobar');
     });
 
     it('assigns middleware to array of paths', async () => {
@@ -825,9 +819,9 @@ describe('test/lib/router.test.js', () => {
 
       app.use(router.routes());
       let res = await request(app.callback()).get('/foo').expect(200);
-      assert.equal(res.body.foobar, 'foobar');
+      expect(res.body.foobar).toBe('foobar');
       res = await request(app.callback()).get('/bar').expect(200);
-      assert.equal(res.body.foobar, 'foobar');
+      expect(res.body.foobar).toBe('foobar');
     });
 
     it('without path, does not set params.0 to the matched path - gh-247', async () => {
@@ -844,11 +838,11 @@ describe('test/lib/router.test.js', () => {
 
       app.use(router.routes());
       const res = await request(app.callback()).get('/foo/815').expect(200);
-      assert.equal(res.body.id, '815');
-      assert.equal(res.body['0'], undefined);
+      expect(res.body.id).toBe('815');
+      expect(res.body['0']).toBeUndefined();
 
       const res2 = await request(app.callback()).get('/foo/1,2,3,4,5').expect(200);
-      assert.equal(res2.body.id, '1,2,3,4,5');
+      expect(res2.body.id).toBe('1,2,3,4,5');
     });
 
     it('does not add an erroneous (.*) to unprefixed nested routers - gh-369 gh-410', async () => {
@@ -873,7 +867,7 @@ describe('test/lib/router.test.js', () => {
       app.use(router.routes());
 
       await request(app.callback()).get('/test').expect(200).expect('test');
-      assert.equal(called, 1);
+      expect(called).toBe(1);
     });
   });
 
@@ -881,12 +875,12 @@ describe('test/lib/router.test.js', () => {
     it('registers new routes', () => {
       const app = new Koa();
       const router = new Router();
-      assert(typeof router.register === 'function');
+      expect(typeof router.register === 'function').toBe(true);
       const route = router.register('/', ['GET', 'POST'], function () {});
-      assert(route);
+      expect(route).toBeDefined();
       app.use(router.routes());
-      assert.equal(router.stack.length, 1);
-      assert.equal(router.stack[0].path, '/');
+      expect(router.stack.length).toBe(1);
+      expect(router.stack[0].path).toBe('/');
     });
   });
 
@@ -894,11 +888,11 @@ describe('test/lib/router.test.js', () => {
     it('registers redirect routes', () => {
       const app = new Koa();
       const router = new Router();
-      assert(typeof router.redirect === 'function');
+      expect(typeof router.redirect === 'function').toBe(true);
       router.redirect('/source', '/destination', 302);
       app.use(router.routes());
-      assert.equal(router.stack.length, 1);
-      assert.equal(router.stack[0].path, '/source');
+      expect(router.stack.length).toBe(1);
+      expect(router.stack[0].path).toBe('/source');
     });
 
     it('redirects using route names', async () => {
@@ -909,18 +903,18 @@ describe('test/lib/router.test.js', () => {
       router.get('sign-up-form', '/sign-up-form', function () {});
       router.redirect('home', 'sign-up-form');
       const res = await request(app.callback()).post('/').expect(301);
-      assert.equal(res.headers.location, '/sign-up-form');
+      expect(res.headers.location).toBe('/sign-up-form');
     });
 
     it('registers redirect not exists routes', () => {
       const router = new Router();
-      assert(typeof router.redirect === 'function');
-      assert.throws(() => {
+      expect(typeof router.redirect === 'function').toBe(true);
+      expect(() => {
         router.redirect('source-not-exists', '/destination', 302);
-      }, /Error: No route found for name: source-not-exists/);
-      assert.throws(() => {
+      }).toThrow(/No route found for name: source-not-exists/);
+      expect(() => {
         router.redirect('/source', 'destination-not-exists');
-      }, /Error: No route found for name: destination-not-exists/);
+      }).toThrow(/No route found for name: destination-not-exists/);
     });
   });
 
@@ -931,8 +925,8 @@ describe('test/lib/router.test.js', () => {
       });
       const router = new Router().use(subrouter.routes());
       const route = router.route('child');
-      assert(route);
-      assert.equal(route.name, 'child');
+      expect(route).toBeDefined();
+      expect(route && route.name).toBe('child');
     });
   });
 
@@ -945,13 +939,12 @@ describe('test/lib/router.test.js', () => {
         ctx.status = 204;
       });
       let url = router.url('books', { category: 'programming', title: 'how to node' });
-      assert.equal(url, '/programming/how%20to%20node');
+      expect(url).toBe('/programming/how%20to%20node');
       url = router.url('books', 'programming', 'how to node');
-      assert.equal(url, '/programming/how%20to%20node');
+      expect(url).toBe('/programming/how%20to%20node');
 
-      const err = router.url('not-exists', { category: 'programming', title: 'how to node' });
-      assert(err instanceof Error);
-      assert.equal(err.message, 'No route found for name: not-exists');
+      const err = router.url('not-exists', { category: 'programming', title: 'how to node' }) as Error;
+      expect(err.message).toBe('No route found for name: not-exists');
     });
 
     it('generates URL for given route name within embedded routers', () => {
@@ -969,9 +962,9 @@ describe('test/lib/router.test.js', () => {
       router.use(embeddedRouter.routes());
       app.use(router.routes());
       let url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
-      assert.equal(url, '/books/chapters/Learning%20ECMA6/123');
+      expect(url).toBe('/books/chapters/Learning%20ECMA6/123');
       url = router.url('chapters', 'Learning ECMA6', 123);
-      assert.equal(url, '/books/chapters/Learning%20ECMA6/123');
+      expect(url).toBe('/books/chapters/Learning%20ECMA6/123');
     });
 
     it('generates URL for given route name within two embedded routers', () => {
@@ -992,7 +985,7 @@ describe('test/lib/router.test.js', () => {
       router.use(embeddedRouter.routes());
       app.use(router.routes());
       const url = router.url('chapters', { chapterName: 'Learning ECMA6', pageNumber: 123 });
-      assert.equal(url, '/books/chapters/Learning%20ECMA6/pages/123');
+      expect(url).toBe('/books/chapters/Learning%20ECMA6/pages/123');
     });
 
     it('generates URL for given route name with params and query params', () => {
@@ -1003,11 +996,11 @@ describe('test/lib/router.test.js', () => {
       let url = router.url('books', 'programming', 4, {
         query: { page: 3, limit: 10 },
       });
-      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      expect(url).toBe('/books/programming/4?page=3&limit=10');
       url = router.url('books', { category: 'programming', id: 4 }, { query: { page: 3, limit: 10 } });
-      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      expect(url).toBe('/books/programming/4?page=3&limit=10');
       url = router.url('books', { category: 'programming', id: 4 }, { query: 'page=3&limit=10' });
-      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      expect(url).toBe('/books/programming/4?page=3&limit=10');
     });
 
     it('generates URL for given route name without params and query params', () => {
@@ -1018,7 +1011,7 @@ describe('test/lib/router.test.js', () => {
       const url = router.url('category', {
         query: { page: 3, limit: 10 },
       });
-      assert.equal(url, '/category?page=3&limit=10');
+      expect(url).toBe('/category?page=3&limit=10');
     });
   });
 
@@ -1040,7 +1033,7 @@ describe('test/lib/router.test.js', () => {
           ctx.body = ctx.user;
         });
       const res = await request(app.callback()).get('/users/3').expect(200);
-      assert.equal(res.body.name, 'alex');
+      expect(res.body.name).toBe('alex');
     });
 
     it('runs parameter middleware in order of URL appearance', async () => {
@@ -1074,8 +1067,8 @@ describe('test/lib/router.test.js', () => {
         });
 
       const res = await request(app.use(router.routes()).callback()).get('/first/users/3').expect(200);
-      assert.equal(res.body.name, 'alex');
-      assert.equal(res.body.ordered, 'parameters');
+      expect(res.body.name).toBe('alex');
+      expect(res.body.ordered).toBe('parameters');
     });
 
     it('runs parameter middleware in order of URL appearance even when added in random order', async () => {
@@ -1104,7 +1097,7 @@ describe('test/lib/router.test.js', () => {
         });
 
       const res = await request(app.use(router.routes()).callback()).get('/1/2/3/4').expect(200);
-      assert.deepEqual(res.body, ['1', '2', '3', '4']);
+      expect(res.body).toEqual(['1', '2', '3', '4']);
     });
 
     it('runs parent parameter middleware for subrouter', async () => {
@@ -1129,8 +1122,8 @@ describe('test/lib/router.test.js', () => {
         .use('/:id/children', subrouter.routes());
 
       const res = await request(app.use(router.routes()).callback()).get('/did-not-run/children/2').expect(200);
-      assert.deepEqual(res.body.id, 'ran');
-      assert.deepEqual(res.body.cid, '2');
+      expect(res.body.id).toBe('ran');
+      expect(res.body.cid).toBe('2');
     });
   });
 
@@ -1144,7 +1137,7 @@ describe('test/lib/router.test.js', () => {
         ctx.body = 'hello';
       });
       const res = await request(app.use(router.routes()).callback()).get('/info').expect(200);
-      assert.equal(res.text, 'hello');
+      expect(res.text).toBe('hello');
     });
 
     it('should allow setting a prefix', async () => {
@@ -1156,7 +1149,7 @@ describe('test/lib/router.test.js', () => {
       });
 
       const res = await request(app.use(routes.routes()).callback()).get('/things/1/list').expect(200);
-      assert.equal(res.body.thing_id, '1');
+      expect(res.body.thing_id).toBe('1');
     });
 
     it('responds with 404 when has a trailing slash', async () => {
@@ -1181,7 +1174,7 @@ describe('test/lib/router.test.js', () => {
         ctx.body = 'hello';
       });
       const res = await request(app.use(router.routes()).callback()).get('/info').expect(200);
-      assert.equal(res.text, 'hello');
+      expect(res.text).toBe('hello');
     });
 
     it('responds with 404 when has a trailing slash', async () => {
@@ -1212,29 +1205,29 @@ describe('test/lib/router.test.js', () => {
 
       router.use(middlewareA, middlewareB);
       router.get('/users/:id', function (ctx) {
-        assert(ctx.params.id);
+        expect(ctx.params.id).toBeDefined();
         ctx.body = { hello: 'world' };
       });
 
       const routerMiddleware = router.routes();
-      assert(typeof routerMiddleware === 'function');
+      expect(typeof routerMiddleware === 'function').toBe(true);
 
       const res = await request(app.use(routerMiddleware).callback()).get('/users/1').expect(200);
-      assert.equal(res.body.hello, 'world');
-      assert.equal(middlewareCount, 2);
+      expect(res.body.hello).toBe('world');
+      expect(middlewareCount).toBe(2);
     });
 
     it('places a `_matchedRoute` value on context', async () => {
       const app = new Koa();
       const router = new Router();
       const middleware = function (ctx: any, next: Next) {
-        assert.equal(ctx._matchedRoute, '/users/:id');
+        expect(ctx._matchedRoute).toBe('/users/:id');
         return next();
       };
 
       router.get('/users/:id', middleware, function (ctx) {
-        assert.equal(ctx._matchedRoute, '/users/:id');
-        assert(ctx.params.id);
+        expect(ctx._matchedRoute).toBe('/users/:id');
+        expect(ctx.params.id).toBeDefined();
         ctx.body = { hello: 'world' };
       });
 
@@ -1248,7 +1241,7 @@ describe('test/lib/router.test.js', () => {
       const router = new Router();
 
       router.get('users#show', '/users/:id', function (ctx) {
-        assert.equal(ctx._matchedRouteName, 'users#show');
+        expect(ctx._matchedRouteName).toBe('users#show');
         ctx.status = 200;
       });
 
@@ -1260,7 +1253,7 @@ describe('test/lib/router.test.js', () => {
       const router = new Router();
 
       router.get('/users/:id', function (ctx) {
-        assert.equal(ctx._matchedRouteName, undefined);
+        expect(ctx._matchedRouteName).toBeUndefined();
         ctx.status = 200;
       });
 
@@ -1271,17 +1264,17 @@ describe('test/lib/router.test.js', () => {
       const app = new Koa();
       const router = new Router();
       router.get('name1', '/users/1', function (ctx, next) {
-        assert.equal(ctx._matchedRouteName, 'name1');
-        assert.equal(ctx.routerName, 'name1');
-        assert.equal(ctx._matchedRoute, '/users/1');
-        assert.equal(ctx.routerPath, '/users/1');
+        expect(ctx._matchedRouteName).toBe('name1');
+        expect(ctx.routerName).toBe('name1');
+        expect(ctx._matchedRoute).toBe('/users/1');
+        expect(ctx.routerPath).toBe('/users/1');
         return next();
       });
       router.get('name2', '/users/:id', function (ctx) {
-        assert.equal(ctx._matchedRouteName, 'name2');
-        assert.equal(ctx.routerName, 'name2');
-        assert.equal(ctx._matchedRoute, '/users/:id');
-        assert.equal(ctx.routerPath, '/users/:id');
+        expect(ctx._matchedRouteName).toBe('name2');
+        expect(ctx.routerName).toBe('name2');
+        expect(ctx._matchedRoute).toBe('/users/:id');
+        expect(ctx.routerPath).toBe('/users/:id');
         ctx.status = 200;
       });
 
@@ -1295,23 +1288,23 @@ describe('test/lib/router.test.js', () => {
       const router = new Router();
       console.log(router);
       router.get('/users/:id', function (ctx) {
-        assert(ctx.params.id);
+        expect(ctx.params.id).toBeDefined();
         ctx.body = 'hello';
       });
       app.use(router.routes());
       let res = await request(app.callback()).get('/users/1').expect(200);
-      assert.equal(res.text, 'hello');
+      expect(res.text).toBe('hello');
       res = await request(app.callback()).head('/users/1').expect(200);
-      assert.equal(res.text, '');
+      expect(res.text).toBeUndefined();
     });
   });
 
   describe('Router#prefix', () => {
     it('should set opts.prefix', () => {
       const router = new Router();
-      assert.equal(router.opts.prefix, undefined);
+      expect(router.opts.prefix).toBeUndefined();
       router.prefix('/things/:thing_id');
-      assert.equal(router.opts.prefix, '/things/:thing_id');
+      expect(router.opts.prefix).toBe('/things/:thing_id');
     });
 
     it('should prefix existing routes', () => {
@@ -1321,10 +1314,10 @@ describe('test/lib/router.test.js', () => {
       });
       router.prefix('/things/:thing_id');
       const route = router.stack[0];
-      assert.equal(route.path, '/things/:thing_id/users/:id');
-      assert.equal(route.paramNames.length, 2);
-      assert.equal(route.paramNames[0].name, 'thing_id');
-      assert.equal(route.paramNames[1].name, 'id');
+      expect(route.path).toBe('/things/:thing_id/users/:id');
+      expect(route.paramNames.length).toBe(2);
+      expect(route.paramNames[0].name).toBe('thing_id');
+      expect(route.paramNames[1].name).toBe('id');
     });
 
     describe('when used with .use(fn) - gh-247', () => {
@@ -1344,8 +1337,8 @@ describe('test/lib/router.test.js', () => {
 
         app.use(router.routes());
         const res = await request(app.callback()).get('/things/foo/108').expect(200);
-        assert.equal(res.body.id, '108');
-        assert.equal(res.body['0'], undefined);
+        expect(res.body.id).toBe('108');
+        expect(res.body['0']).toBeUndefined();
       });
     });
 
@@ -1357,7 +1350,7 @@ describe('test/lib/router.test.js', () => {
         let server: any;
         let middlewareCount = 0;
 
-        before(function () {
+        beforeAll(function () {
           const app = new Koa();
           const router = new Router();
 
@@ -1382,20 +1375,20 @@ describe('test/lib/router.test.js', () => {
 
         it('should support root level router middleware', async () => {
           const res = await request(server).get(prefix).expect(200);
-          assert.equal(middlewareCount, 2);
-          assert.equal(res.body.name, 'worked');
+          expect(middlewareCount).toBe(2);
+          expect(res.body.name).toBe('worked');
         });
 
         it('should support requests with a trailing path slash', async () => {
           const res = await request(server).get('/admin/').expect(200);
-          assert.equal(middlewareCount, 2);
-          assert.equal(res.body.name, 'worked');
+          expect(middlewareCount).toBe(2);
+          expect(res.body.name).toBe('worked');
         });
 
         it('should support requests without a trailing path slash', async () => {
           const res = await request(server).get('/admin').expect(200);
-          assert.equal(middlewareCount, 2);
-          assert.equal(res.body.name, 'worked');
+          expect(middlewareCount).toBe(2);
+          expect(res.body.name).toBe('worked');
         });
       };
     }
@@ -1404,30 +1397,30 @@ describe('test/lib/router.test.js', () => {
   describe('Static Router#url()', () => {
     it('generates route URL', () => {
       const url = Router.url('/:category/:title', { category: 'programming', title: 'how-to-node' });
-      assert.equal(url, '/programming/how-to-node');
+      expect(url).toBe('/programming/how-to-node');
     });
 
     it('escapes using encodeURIComponent()', () => {
       const url = Router.url('/:category/:title', { category: 'programming', title: 'how to node' });
-      assert.equal(url, '/programming/how%20to%20node');
+      expect(url).toBe('/programming/how%20to%20node');
     });
 
     it('generates route URL with params and query params', () => {
       let url = Router.url('/books/:category/:id', 'programming', 4, {
         query: { page: 3, limit: 10 },
       });
-      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      expect(url).toBe('/books/programming/4?page=3&limit=10');
       url = Router.url('/books/:category/:id', { category: 'programming', id: 4 }, { query: { page: 3, limit: 10 } });
-      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      expect(url).toBe('/books/programming/4?page=3&limit=10');
       url = Router.url('/books/:category/:id', { category: 'programming', id: 4 }, { query: 'page=3&limit=10' });
-      assert.equal(url, '/books/programming/4?page=3&limit=10');
+      expect(url).toBe('/books/programming/4?page=3&limit=10');
     });
 
     it('generates router URL without params and with with query params', () => {
       const url = Router.url('/category', {
         query: { page: 3, limit: 10 },
       });
-      assert.equal(url, '/category?page=3&limit=10');
+      expect(url).toBe('/category?page=3&limit=10');
     });
   });
 });

--- a/packages/router/test/index.test.ts
+++ b/packages/router/test/index.test.ts
@@ -1,0 +1,11 @@
+import { strict as assert } from 'node:assert';
+import Router, { KoaRouter, EggRouter } from '../src/index.js';
+
+describe('test/index.test.ts', () => {
+  it('should expose Router', () => {
+    assert(typeof Router === 'function');
+    assert(typeof KoaRouter === 'function');
+    assert.equal(Router, KoaRouter);
+    assert(typeof EggRouter === 'function');
+  });
+});

--- a/packages/router/test/index.test.ts
+++ b/packages/router/test/index.test.ts
@@ -1,11 +1,13 @@
-import { strict as assert } from 'node:assert';
-import Router, { KoaRouter, EggRouter } from '../src/index.js';
+import { describe, it, expect } from 'vitest';
+
+import Router, { KoaRouter, EggRouter } from '../src/index.ts';
 
 describe('test/index.test.ts', () => {
   it('should expose Router', () => {
-    assert(typeof Router === 'function');
-    assert(typeof KoaRouter === 'function');
-    assert.equal(Router, KoaRouter);
-    assert(typeof EggRouter === 'function');
+    expect(Router).toBeInstanceOf(Function);
+    expect(KoaRouter).toBeInstanceOf(Function);
+    // KoaRouter is alias of Router
+    expect(KoaRouter).toBe(Router);
+    expect(EggRouter).toBeInstanceOf(Function);
   });
 });

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -2,6 +2,5 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": "./"
-  },
-  "include": ["src/**/*.ts"]
+  }
 }

--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: 'src/**/*.ts',
+  unbundle: true,
+  dts: true,
+  exports: {
+    devExports: true,
+  },
+});

--- a/packages/router/vitest.config.ts
+++ b/packages/router/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     '@eggjs/redis':
       specifier: ^3.0.0
       version: 3.1.0
-    '@eggjs/router':
-      specifier: ^3.0.5
-      version: 3.0.6
     '@eggjs/scripts':
       specifier: ^4.0.0
       version: 4.0.0
@@ -740,8 +737,8 @@ importers:
         specifier: workspace:*
         version: link:../koa
       '@eggjs/router':
-        specifier: 'catalog:'
-        version: 3.0.6
+        specifier: workspace:*
+        version: link:../router
       '@eggjs/utils':
         specifier: workspace:*
         version: link:../utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ catalogs:
     '@types/type-is':
       specifier: ^1.6.6
       version: 1.6.7
+    '@types/urijs':
+      specifier: ^1.19.25
+      version: 1.19.25
     '@types/vary':
       specifier: ^1.1.3
       version: 1.1.3
@@ -318,6 +321,9 @@ catalogs:
     husky:
       specifier: ^9.1.7
       version: 9.1.7
+    inflection:
+      specifier: ^3.0.0
+      version: 3.0.2
     ini:
       specifier: ^5.0.0
       version: 5.0.0
@@ -366,6 +372,9 @@ catalogs:
     merge-descriptors:
       specifier: ^2.0.0
       version: 2.0.0
+    methods:
+      specifier: ^1.1.2
+      version: 1.1.2
     mm:
       specifier: ^4.0.2
       version: 4.0.2
@@ -411,6 +420,9 @@ catalogs:
     parseurl:
       specifier: ^1.3.3
       version: 1.3.3
+    path-to-regexp:
+      specifier: ^1.9.0
+      version: 1.9.0
     performance-ms:
       specifier: ^1.1.0
       version: 1.1.0
@@ -483,6 +495,9 @@ catalogs:
     typescript:
       specifier: 5.9.2
       version: 5.9.2
+    urijs:
+      specifier: ^1.19.11
+      version: 1.19.11
     urllib:
       specifier: ^4.8.2
       version: 4.8.2
@@ -1148,6 +1163,64 @@ importers:
       ylru:
         specifier: ^2.0.0
         version: 2.0.0
+
+  packages/router:
+    dependencies:
+      http-errors:
+        specifier: 'catalog:'
+        version: 2.0.0
+      inflection:
+        specifier: 'catalog:'
+        version: 3.0.2
+      is-type-of:
+        specifier: 'catalog:'
+        version: 2.2.0
+      koa-compose:
+        specifier: 'catalog:'
+        version: 4.1.0
+      methods:
+        specifier: 'catalog:'
+        version: 1.1.2
+      path-to-regexp:
+        specifier: 'catalog:'
+        version: 1.9.0
+      urijs:
+        specifier: 'catalog:'
+        version: 1.19.11
+      utility:
+        specifier: 'catalog:'
+        version: 2.5.0
+    devDependencies:
+      '@eggjs/koa':
+        specifier: workspace:*
+        version: link:../koa
+      '@eggjs/supertest':
+        specifier: workspace:*
+        version: link:../supertest
+      '@eggjs/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/http-errors':
+        specifier: 'catalog:'
+        version: 2.0.5
+      '@types/koa-compose':
+        specifier: 'catalog:'
+        version: 3.2.8
+      '@types/methods':
+        specifier: 'catalog:'
+        version: 1.1.4
+      '@types/urijs':
+        specifier: 'catalog:'
+        version: 1.19.25
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.4(oxc-resolver@11.8.3)(typescript@5.9.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.13(@types/debug@4.1.12)(@types/node@24.5.2)(@vitest/ui@4.0.0-beta.13)(esbuild@0.25.10)(jiti@2.6.0)(less@4.4.1)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
 
   packages/supertest:
     dependencies:
@@ -4279,6 +4352,9 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/urijs@1.19.25':
+    resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
 
   '@types/vary@1.1.3':
     resolution: {integrity: sha512-XJT8/ZQCL7NUut9QDLf6l24JfAEl7bnNdgxfj50cHIpEPRJLHHDDFOAq6i+GsEmeFfH7NamhBE4c4Thtb2egWg==}
@@ -13907,6 +13983,8 @@ snapshots:
       '@types/node': 24.5.2
 
   '@types/unist@2.0.11': {}
+
+  '@types/urijs@1.19.25': {}
 
   '@types/vary@1.1.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,7 @@ catalog:
   '@types/statuses': ^2.0.5
   '@types/superagent': ^8.1.9
   '@types/type-is': ^1.6.6
+  '@types/urijs': ^1.19.25
   '@types/vary': ^1.1.3
   '@vitest/coverage-v8': 4.0.0-beta.13
   '@vitest/ui': 4.0.0-beta.13
@@ -116,6 +117,7 @@ catalog:
   http-errors: ^2.0.0
   humanize-ms: ^2.0.0
   husky: ^9.1.7
+  inflection: ^3.0.0
   ini: ^5.0.0
   is-type-of: ^2.2.0
   jest-changed-files: ^30.0.0
@@ -148,6 +150,7 @@ catalog:
   oxlint: ^1.18.0
   oxlint-tsgolint: ^0.2.0
   parseurl: ^1.3.3
+  path-to-regexp: ^1.9.0
   performance-ms: ^1.1.0
   picocolors: ^1.1.1
   prettier: ^3.6.2
@@ -172,6 +175,7 @@ catalog:
   type-fest: ^5.0.1
   type-is: ^2.0.0
   typescript: 5.9.2
+  urijs: ^1.19.11
   urllib: ^4.8.2
   utility: ^2.5.0
   vary: ^1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -134,6 +134,7 @@ catalog:
   lint-staged: ^16.2.0
   matcher: ^4.0.0
   merge-descriptors: ^2.0.0
+  methods: ^1.1.2
   mime-types: ^3.0.0
   mm: ^4.0.2
   mocha: 11.7.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ catalog:
   '@eggjs/compressible': ^3.0.0
   '@eggjs/ip': ^2.1.0
   '@eggjs/redis': ^3.0.0
-  '@eggjs/router': ^3.0.5
   '@eggjs/scripts': ^4.0.0
   '@eggjs/tegg': ^3.2.2
   '@eggjs/tegg-config': ^3.2.2

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
       "path": "./packages/koa-static-cache"
     },
     {
+      "path": "./packages/router"
+    },
+    {
       "path": "./packages/cookies"
     },
     {


### PR DESCRIPTION
Merge @eggjs/router package from https://github.com/eggjs/router into monorepo at packages/router/. Updated to version 4.0.0-beta.15 with standardized build configuration and dependencies.

- Migrate from ESLint to oxlint for linting
- Standardize with tsdown for unbundled builds
- Update tests to use Vitest
- Convert dependencies to workspace:* and catalog:
- Add inflection, path-to-regexp, and urijs to pnpm catalog
- Provides RESTful resource routing for Egg/Koa applications

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new Router package with nested routing, named routes, URL generation, redirects, OPTIONS/405 handling, and an EggRouter with RESTful resource helpers and controller-based routing; full param, prefix, and middleware composition support.

- **Documentation**
  - Added README, CHANGELOG, and MIT license for the new package.

- **Tests**
  - Added extensive test suites for router, layer, EggRouter, and public exports.

- **Chores**
  - Integrated package into workspace, TypeScript/test configs, package metadata, dependencies, and benchmarking utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->