### PR TITLE
chore: add typecheck for templates

### DIFF
--- a/tools/create-egg/src/templates/simple-ts/config/config.default.ts
+++ b/tools/create-egg/src/templates/simple-ts/config/config.default.ts
@@ -1,6 +1,6 @@
-import { defineConfig, type PartialEggConfig } from 'egg';
+import { defineConfigFactory, type PartialEggConfig } from 'egg';
 
-export default defineConfig(appInfo => {
+export default defineConfigFactory(appInfo => {
   const config = {
     // use for cookie sign key, should change to your own and keep security
     keys: appInfo.name + '_{{keys}}',

--- a/tools/create-egg/src/templates/simple-ts/package.json
+++ b/tools/create-egg/src/templates/simple-ts/package.json
@@ -17,6 +17,7 @@
     "ci": "vitest run --coverage",
     "postci": "npm run prepublishOnly && npm start && sleep 10 && npm stop && npm run clean",
     "lint": "oxlint --type-aware",
+    "typecheck": "tsc --noEmit",
     "tsc": "tsc",
     "clean": "tsc -b --clean",
     "prepublishOnly": "npm run clean && npm run tsc"

--- a/tools/create-egg/src/templates/tegg/config/config.default.ts
+++ b/tools/create-egg/src/templates/tegg/config/config.default.ts
@@ -1,6 +1,6 @@
-import { defineConfig, type PartialEggConfig } from 'egg';
+import { defineConfigFactory, type PartialEggConfig } from 'egg';
 
-export default defineConfig(appInfo => {
+export default defineConfigFactory(appInfo => {
   const config = {
     // use for cookie sign key, should change to your own and keep security
     keys: appInfo.name + '_{{keys}}',

--- a/tools/create-egg/src/templates/tegg/package.json
+++ b/tools/create-egg/src/templates/tegg/package.json
@@ -17,6 +17,7 @@
     "ci": "npm run test:local -- --coverage",
     "postci": "npm run prepublishOnly && npm start && sleep 10 && npm stop && npm run clean",
     "lint": "oxlint --type-aware",
+    "typecheck": "tsc --noEmit",
     "tsc": "tsc",
     "clean": "tsc -b --clean",
     "prepublishOnly": "npm run clean && npm run tsc"

--- a/tools/create-egg/test/cli.test.ts
+++ b/tools/create-egg/test/cli.test.ts
@@ -129,6 +129,8 @@ test.skipIf(process.platform === 'win32')(
     execaCommandSync(`pnpm link ${mockDir} ${eggDir} ${binDir} ${tracerDir}`, { cwd: projectDir });
     const { stdout: testStdout } = execaCommandSync('pnpm test:local', { cwd: projectDir });
     expect(testStdout).toContain('2 passed');
+    // run typecheck
+    execaCommandSync('pnpm typecheck', { cwd: projectDir });
   }
 );
 
@@ -155,6 +157,8 @@ test.skipIf(process.platform === 'win32')('successfully scaffolds a project base
   execaCommandSync(`pnpm link ${mockDir} ${eggDir} ${binDir} ${tracerDir}`, { cwd: projectDir });
   const { stdout: testStdout } = execaCommandSync('pnpm test:local', { cwd: projectDir });
   expect(testStdout).toContain('2 passed');
+  // run typecheck
+  execaCommandSync('pnpm typecheck', { cwd: projectDir });
 });
 
 test('works with the -t alias', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a TypeScript type-check script to the simple-ts and tegg templates (tsc --noEmit) for quick static validation.

* Refactor
  * Updated template configuration to use the latest framework config factory for improved compatibility, with no behavioral changes.

* Tests
  * Extended test flow to run type checks on generated projects, enhancing reliability.

* Chores
  * General template maintenance to align with current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->