### PR TITLE
refactor(bin): remove mochawesome reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "js-yaml": "catalog:",
     "lint-staged": "catalog:",
     "mocha": "catalog:",
-    "mochawesome-with-mocha": "catalog:",
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
     "prettier": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ catalogs:
       specifier: ^3.1.2
       version: 3.1.2
     c8:
-      specifier: 10.1.3
+      specifier: ^10.1.3
       version: 10.1.3
     cache-content-type:
       specifier: ^2.0.0
@@ -373,11 +373,8 @@ catalogs:
       specifier: ^4.0.2
       version: 4.0.2
     mocha:
-      specifier: 11.7.2
+      specifier: ^11.7.2
       version: 11.7.2
-    mochawesome-with-mocha:
-      specifier: 8.0.0
-      version: 8.0.0
     moment:
       specifier: ^2.30.1
       version: 2.30.1
@@ -487,7 +484,7 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.1
     typescript:
-      specifier: 5.9.2
+      specifier: ^5.9.2
       version: 5.9.2
     urijs:
       specifier: ^1.19.11
@@ -552,9 +549,6 @@ importers:
       mocha:
         specifier: 'catalog:'
         version: 11.7.2
-      mochawesome-with-mocha:
-        specifier: 'catalog:'
-        version: 8.0.0
       oxlint:
         specifier: 'catalog:'
         version: 1.19.0(oxlint-tsgolint@0.2.0)
@@ -1970,9 +1964,6 @@ importers:
       mocha:
         specifier: 'catalog:'
         version: 11.7.2
-      mochawesome-with-mocha:
-        specifier: 'catalog:'
-        version: 8.0.0
       runscript:
         specifier: 'catalog:'
         version: 2.0.1
@@ -5897,9 +5888,6 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  dateformat@4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
-
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
 
@@ -6796,9 +6784,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  fsu@1.1.1:
-    resolution: {integrity: sha512-xQVsnjJ/5pQtcKh+KjUoZGzVWn4uNkchxTF6Lwjr4Gf7nQr8fmUfhKJ62zE77+xQg9xnxi5KUps7XGs+VC986A==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -8124,20 +8109,8 @@ packages:
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
-  lodash.isempty@4.4.0:
-    resolution: {integrity: sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==}
-
-  lodash.isfunction@3.0.9:
-    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
-
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
-
-  lodash.isobject@3.0.2:
-    resolution: {integrity: sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==}
-
-  lodash.isstring@4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -8602,14 +8575,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
-  mochawesome-report-generator@6.3.0:
-    resolution: {integrity: sha512-t9IOqFOymbk39YPYSPU6Z4hIhlpSdB+sI283jO+5YAEqqU79df57UrmS8ByOwrc+EVZ7fuL4e0dMWP5RofWeyg==}
-    hasBin: true
-
-  mochawesome-with-mocha@8.0.0:
-    resolution: {integrity: sha512-JY9bXUqbEK3ad4UtsvCXtyzxo9UED7c7YdNWshfWuSkSBM9TxVgJUPI7Vcd4P3XWc3RoASe/6zRXNGITxEE03g==}
-    engines: {node: '>=18.19.0'}
-
   moment-timezone@0.5.48:
     resolution: {integrity: sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==}
 
@@ -8959,10 +8924,6 @@ packages:
   open@9.1.0:
     resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
     engines: {node: '>=14.16'}
-
-  opener@1.5.2:
-    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
-    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -10836,12 +10797,6 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-
-  tcomb-validation@3.4.1:
-    resolution: {integrity: sha512-urVVMQOma4RXwiVCa2nM2eqrAomHROHvWPuj6UkDGz/eb5kcy0x6P0dVt6kzpUZtYMNoAqJLWmz1BPtxrtjtrA==}
-
-  tcomb@3.2.29:
-    resolution: {integrity: sha512-di2Hd1DB2Zfw6StGv861JoAF5h/uQVu/QJp2g8KVbtfKnoHdBQl5M32YWq6mnSYBQ1vFFrns5B1haWJL7rKaOQ==}
 
   tcp-base@3.2.0:
     resolution: {integrity: sha512-fFAqH8QTbheuEbXLdbxTSe31Gkw6Lg3nq4loyrxIXM6+ILGdbYXEblgyuu7UltOkOHbP/q2iqaC+gIXXu0C5bg==}
@@ -16049,8 +16004,6 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  dateformat@4.6.3: {}
-
   dayjs@1.11.18: {}
 
   debounce@2.2.0: {}
@@ -17336,8 +17289,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  fsu@1.1.1: {}
 
   function-bind@1.1.2: {}
 
@@ -18765,15 +18716,7 @@ snapshots:
 
   lodash.isarguments@3.1.0: {}
 
-  lodash.isempty@4.4.0: {}
-
-  lodash.isfunction@3.0.9: {}
-
   lodash.ismatch@4.4.0: {}
-
-  lodash.isobject@3.0.2: {}
-
-  lodash.isstring@4.0.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -19477,35 +19420,6 @@ snapshots:
       yargs-parser: 21.1.1
       yargs-unparser: 2.0.0
 
-  mochawesome-report-generator@6.3.0:
-    dependencies:
-      chalk: 4.1.2
-      dateformat: 4.6.3
-      escape-html: 1.0.3
-      fs-extra: 10.1.0
-      fsu: 1.1.1
-      lodash.isfunction: 3.0.9
-      opener: 1.5.2
-      prop-types: 15.8.1
-      tcomb: 3.2.29
-      tcomb-validation: 3.4.1
-      validator: 13.15.15
-      yargs: 17.7.2
-
-  mochawesome-with-mocha@8.0.0:
-    dependencies:
-      chalk: 4.1.2
-      diff: 5.2.0
-      json-stringify-safe: 5.0.1
-      lodash.isempty: 4.4.0
-      lodash.isfunction: 3.0.9
-      lodash.isobject: 3.0.2
-      lodash.isstring: 4.0.1
-      mocha: 11.7.2
-      mochawesome-report-generator: 6.3.0
-      strip-ansi: 6.0.1
-      uuid: 8.3.2
-
   moment-timezone@0.5.48:
     dependencies:
       moment: 2.30.1
@@ -19967,8 +19881,6 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 2.2.0
-
-  opener@1.5.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -22105,12 +22017,6 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
-
-  tcomb-validation@3.4.1:
-    dependencies:
-      tcomb: 3.2.29
-
-  tcomb@3.2.29: {}
 
   tcp-base@3.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ catalog:
   benchmark: ^2.1.4
   body-parser: ^2.0.0
   bytes: ^3.1.2
-  c8: 10.1.3
+  c8: ^10.1.3
   cache-content-type: ^2.0.0
   camelcase: ^8.0.0
   cfork: ^2.0.0
@@ -135,8 +135,7 @@ catalog:
   methods: ^1.1.2
   mime-types: ^3.0.0
   mm: ^4.0.2
-  mocha: 11.7.2
-  mochawesome-with-mocha: 8.0.0
+  mocha: ^11.7.2
   moment: ^2.30.1
   mri: ^1.2.0
   multimatch: ^7.0.0
@@ -173,7 +172,7 @@ catalog:
   tsdown: ^0.15.4
   type-fest: ^5.0.1
   type-is: ^2.0.0
-  typescript: 5.9.2
+  typescript: ^5.9.2
   urijs: ^1.19.11
   urllib: ^4.8.2
   utility: ^2.5.0

--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -136,7 +136,6 @@ You can pass any mocha argv.
 - `--parallel` enable mocha parallel mode, default to `false`.
 - `--auto-agent` auto start agent in mocha master agent.
 - `--jobs` number of jobs to run in parallel, default to `os.cpus().length - 1`.
-- `--mochawesome` enable [mochawesome](https://github.com/adamgruber/mochawesome) reporter, default to `true`.
 
 #### test environment
 

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -34,7 +34,6 @@
     "globby": "catalog:",
     "jest-changed-files": "catalog:",
     "mocha": "catalog:",
-    "mochawesome-with-mocha": "catalog:",
     "runscript": "catalog:",
     "ts-node": "catalog:",
     "tsconfig-paths": "catalog:",

--- a/tools/egg-bin/src/commands/test.ts
+++ b/tools/egg-bin/src/commands/test.ts
@@ -53,11 +53,6 @@ export default class Test<T extends typeof Test> extends BaseCommand<T> {
       description: 'only test with changed files and match test/**/*.test.(js|ts)',
       char: 'c',
     }),
-    mochawesome: Flags.boolean({
-      description: '[default: true] enable mochawesome reporter',
-      default: true,
-      allowNo: true,
-    }),
     parallel: Flags.boolean({
       description: 'mocha parallel mode',
       default: false,
@@ -135,21 +130,6 @@ export default class Test<T extends typeof Test> extends BaseCommand<T> {
       }
     }
 
-    // handle mochawesome enable
-    let reporter = this.env.TEST_REPORTER;
-    let reporterOptions = '';
-    if (!reporter && flags.mochawesome) {
-      // use https://github.com/node-modules/mochawesome/pull/1 instead
-      reporter = importResolve('mochawesome-with-mocha', {
-        paths: [flags.base],
-      });
-      reporterOptions = 'reportDir=node_modules/.mochawesome-reports';
-      if (flags.parallel) {
-        // https://github.com/adamgruber/mochawesome#parallel-mode
-        requires.push(path.join(reporter, '../register.js'));
-      }
-    }
-
     const ext = flags.typescript ? 'ts' : 'js';
     let pattern = args.file ? args.file.split(',') : [];
     // changed
@@ -221,8 +201,7 @@ export default class Test<T extends typeof Test> extends BaseCommand<T> {
       flags.timeout ? `--timeout=${flags.timeout}` : '--no-timeout',
       flags.parallel ? '--parallel' : '',
       flags.parallel && flags.jobs ? `--jobs=${flags.jobs}` : '',
-      reporter ? `--reporter=${reporter}` : '',
-      reporterOptions ? `--reporter-options=${reporterOptions}` : '',
+      this.env.TEST_REPORTER ? `--reporter=${this.env.TEST_REPORTER}` : '',
       ...requires.map(r => `--require=${r}`),
       ...files,
       flags['dry-run'] ? '--dry-run' : '',

--- a/tools/egg-bin/test/commands/test.test.ts
+++ b/tools/egg-bin/test/commands/test.test.ts
@@ -120,20 +120,6 @@ describe('test/commands/test.test.ts', () => {
         .end();
     });
 
-    it('should success with --mochawesome', async () => {
-      await coffee
-        .fork(eggBin, ['test', '--mochawesome'], { cwd })
-        // .debug()
-        .expect('stdout', /should success/)
-        .expect('stdout', /a\.test\.js/)
-        .expect('stdout', /b\/b\.test\.js/)
-        .expect('stdout', /\[mochawesome] Report JSON saved to/)
-        .expect('stdout', /mochawesome\.json/)
-        .notExpect('stdout', /\ba\.js/)
-        .expect('code', 0)
-        .end();
-    });
-
     it('should success with --bail', async () => {
       await coffee
         .fork(eggBin, ['test', '--bail'], { cwd })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - Removed support for the mochawesome reporter; the --mochawesome CLI flag is no longer available. Reporter selection now relies on the TEST_REPORTER environment variable.

- Documentation
  - Updated README to remove the mochawesome reporter option.

- Chores
  - Removed mochawesome-with-mocha dependency.
  - Relaxed dependency versions to caret ranges for c8, mocha, and typescript.

- Tests
  - Removed tests related to the --mochawesome flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->