### PR TITLE
fix: tsdown unbundle will cause types missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,9 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   entry: 'src/**/*.ts',
   // unbundle: true,
+  unused: {
+    level: 'error',
+  },
   dts: true,
   exports: {
     devExports: true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,7 +290,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   exports: {
     devExports: true,

--- a/examples/helloworld-typescript/tsdown.config.ts
+++ b/examples/helloworld-typescript/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['app.ts', 'config/**/*.ts', 'app/**/*.ts'],
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   exports: {
     devExports: true,

--- a/packages/cluster/tsdown.config.ts
+++ b/packages/cluster/tsdown.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     agent_worker: 'src/agent_worker.ts',
     app_worker: 'src/app_worker.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/cookies/tsdown.config.ts
+++ b/packages/cookies/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/egg/tsdown.config.ts
+++ b/packages/egg/tsdown.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   entry: 'src/**/*.ts',
   dts: true,
-  unbundle: true,
+  // FIXME: unbundle will missing types https://github.com/fengmk2/tsdown-vs-tsc/blob/main/README.md#tsdown-build-output-missing-types
+  // unbundle: true,
   unused: {
     level: 'error',
   },

--- a/packages/extend2/tsdown.config.ts
+++ b/packages/extend2/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/koa-static-cache/tsdown.config.ts
+++ b/packages/koa-static-cache/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/koa/tsdown.config.ts
+++ b/packages/koa/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   unused: {
     level: 'error',
     ignore: ['@types/content-disposition'],

--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/supertest/tsdown.config.ts
+++ b/packages/supertest/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/packages/utils/tsdown.config.ts
+++ b/packages/utils/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/development/tsdown.config.ts
+++ b/plugins/development/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/i18n/tsdown.config.ts
+++ b/plugins/i18n/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/jsonp/tsdown.config.ts
+++ b/plugins/jsonp/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/logrotator/tsdown.config.ts
+++ b/plugins/logrotator/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/mock/tsdown.config.ts
+++ b/plugins/mock/tsdown.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   //   register: 'src/register.ts',
   // },
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/multipart/tsdown.config.ts
+++ b/plugins/multipart/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/onerror/tsdown.config.ts
+++ b/plugins/onerror/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/schedule/tsdown.config.ts
+++ b/plugins/schedule/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/security/tsdown.config.ts
+++ b/plugins/security/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/session/tsdown.config.ts
+++ b/plugins/session/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/static/tsdown.config.ts
+++ b/plugins/static/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/tracer/tsdown.config.ts
+++ b/plugins/tracer/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/view/tsdown.config.ts
+++ b/plugins/view/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/plugins/watcher/tsdown.config.ts
+++ b/plugins/watcher/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: 'src/**/*.ts',
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/tools/create-egg/tsdown.config.ts
+++ b/tools/create-egg/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/cli.ts'],
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/tools/egg-bin/tsdown.config.ts
+++ b/tools/egg-bin/tsdown.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  // unbundle: true,
+  // MEMO: @oclif/core only work on unbundle mode
+  unbundle: true,
   dts: true,
   unused: {
     level: 'error',

--- a/tools/egg-bin/tsdown.config.ts
+++ b/tools/egg-bin/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
-  unbundle: true,
+  // unbundle: true,
   dts: true,
   unused: {
     level: 'error',


### PR DESCRIPTION
https://github.com/fengmk2/tsdown-vs-tsc/blob/main/README.md#tsdown-build-output-missing-types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Documentation
  - Updated build/config notes to reflect current defaults and linting expectations.

- Chores
  - Disabled unbundled build output across examples, packages, plugins, and tooling to align with defaults.
  - Enabled stricter unused-variable reporting to improve code quality.
  - No changes to public APIs or runtime behavior expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->