### PR TITLE
fix: use tsc build

### DIFF
--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -22,7 +22,7 @@
   "types": "./dist/index.d.ts",
   "description": "cluster manager for egg",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "lint": "oxlint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/cluster/tsconfig.json
+++ b/packages/cluster/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -35,7 +35,7 @@
   "author": "fengmk2 <fengmk2@gmail.com> (https://github.com/fengmk2)",
   "license": "MIT",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/cookies/tsconfig.json
+++ b/packages/cookies/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
   },
   "description": "A core plugin framework based on @eggjs/koa",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "lint": "oxlint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "exclude": ["test/fixtures/**/*.ts", "example/**/*.ts"]
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts", "example/**/*.ts"]
 }

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -172,7 +172,7 @@
   "scripts": {
     "lint": "oxlint",
     "typecheck": "tsc --noEmit",
-    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc && cp src/config/favicon.png dist/config/favicon.png",
     "test": "vitest run",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -172,7 +172,7 @@
   "scripts": {
     "lint": "oxlint",
     "typecheck": "tsc --noEmit",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "test": "vitest run",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/egg/tsconfig.json
+++ b/packages/egg/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "exclude": ["test/fixtures/**/*.ts"]
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/egg/tsdown.config.ts
+++ b/packages/egg/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: 'src/**/*.ts',
   dts: true,
   // FIXME: unbundle will missing types https://github.com/fengmk2/tsdown-vs-tsc/blob/main/README.md#tsdown-build-output-missing-types
-  // unbundle: true,
+  unbundle: true,
   unused: {
     level: 'error',
   },

--- a/packages/extend2/package.json
+++ b/packages/extend2/package.json
@@ -14,7 +14,7 @@
   },
   "description": "Port of jQuery.extend for Node.js",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint",
     "test": "vitest run",

--- a/packages/extend2/tsconfig.json
+++ b/packages/extend2/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/koa-static-cache/package.json
+++ b/packages/koa-static-cache/package.json
@@ -47,7 +47,7 @@
     "ylru": "^2.0.0"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/packages/koa-static-cache/tsconfig.json
+++ b/packages/koa-static-cache/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -24,7 +24,7 @@
   "module": "./dist/index.js",
   "description": "Koa web app framework for https://eggjs.org",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "test": "vitest run",

--- a/packages/koa/tsconfig.json
+++ b/packages/koa/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "example", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -47,7 +47,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "prepublishOnly": "npm run build",
     "prebench": "npm run build",
     "bench": "cd bench && make"

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/supertest/package.json
+++ b/packages/supertest/package.json
@@ -55,7 +55,7 @@
     "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",

--- a/packages/supertest/tsconfig.json
+++ b/packages/supertest/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,7 +24,7 @@
   },
   "description": "Utils for all egg projects",
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "exclude": ["test/fixtures/ts-module/**"]
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/development/package.json
+++ b/plugins/development/package.json
@@ -69,7 +69,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "prepublishOnly": "pnpm run build"
   },
   "repository": {

--- a/plugins/development/tsconfig.json
+++ b/plugins/development/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/i18n/package.json
+++ b/plugins/i18n/package.json
@@ -73,7 +73,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/i18n/tsconfig.json
+++ b/plugins/i18n/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -70,7 +70,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/jsonp/tsconfig.json
+++ b/plugins/jsonp/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/logrotator/package.json
+++ b/plugins/logrotator/package.json
@@ -92,7 +92,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "test": "vitest run",

--- a/plugins/logrotator/tsconfig.json
+++ b/plugins/logrotator/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/mock/package.json
+++ b/plugins/mock/package.json
@@ -128,7 +128,7 @@
     "typescript": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "lint": "oxlint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/plugins/mock/tsconfig.json
+++ b/plugins/mock/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "exclude": ["test/fixtures/**/app/**/*.ts", "test/fixtures/**/test/**/*.ts"]
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -82,7 +82,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/multipart/tsconfig.json
+++ b/plugins/multipart/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -57,7 +57,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "prepublishOnly": "pnpm run build"
   },
   "type": "module",

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -57,7 +57,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc && cp src/lib/onerror_page.mustache.html dist/lib/onerror_page.mustache.html",
     "prepublishOnly": "pnpm run build"
   },
   "type": "module",

--- a/plugins/onerror/tsconfig.json
+++ b/plugins/onerror/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
   },
-  "exclude": ["test/fixtures/**/*.ts", "dist/**/*"]
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -68,7 +68,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/schedule/src/types.ts
+++ b/plugins/schedule/src/types.ts
@@ -8,10 +8,11 @@ declare module 'egg' {
      */
     schedule: EggScheduleConfig;
   }
-}
 
-declare module '@eggjs/mock' {
-  interface MockApplication {
+  interface Application {
+    /**
+     * Run a schedule, only for unit test
+     */
     runSchedule(schedulePath: string, ...args: any[]): Promise<any>;
   }
 }

--- a/plugins/schedule/tsconfig.json
+++ b/plugins/schedule/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -143,7 +143,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/security/tsconfig.json
+++ b/plugins/security/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -65,7 +65,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/session/tsconfig.json
+++ b/plugins/session/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/static/package.json
+++ b/plugins/static/package.json
@@ -57,7 +57,7 @@
     "vitest": "catalog:"
   },
   "scripts": {
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
     "lint:fix": "npm run lint -- --fix",

--- a/plugins/static/tsconfig.json
+++ b/plugins/static/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/tracer/package.json
+++ b/plugins/tracer/package.json
@@ -59,7 +59,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "prepublishOnly": "npm run build"
   },
   "type": "module",

--- a/plugins/tracer/tsconfig.json
+++ b/plugins/tracer/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/view/package.json
+++ b/plugins/view/package.json
@@ -76,7 +76,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "prepublishOnly": "npm run build"
   }
 }

--- a/plugins/view/tsconfig.json
+++ b/plugins/view/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -29,7 +29,7 @@
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "build": "tsdown",
+    "build": "tsdown && rimraf dist && tsc -b --clean && tsc",
     "prepublishOnly": "pnpm run build"
   },
   "homepage": "https://github.com/eggjs/egg/tree/next/plugins/watcher",

--- a/plugins/watcher/tsconfig.json
+++ b/plugins/watcher/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "./"
-  }
+    "baseUrl": "./",
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "exclude": ["test", "dist", "tsdown.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Schedule plugin: added Application.runSchedule API to trigger schedules programmatically.

- **Chores**
  - Standardized build pipeline across packages to clean outputs and run a full TypeScript rebuild for more reliable releases.
  - Unified TypeScript project layout by setting source/output directories and excluding tests/build artifacts across packages.
  - Enabled unbundled build mode for the Egg-related package.
  - Added prepublishOnly hooks to select packages (e.g., extend2, supertest, logrotator).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->