### PR TITLE
feat(path-matching): merge egg-path-matching package into monorepo

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "@eggjs/router": "workspace:*",
     "@eggjs/utils": "workspace:*",
     "egg-logger": "catalog:",
-    "egg-path-matching": "catalog:",
+    "@eggjs/path-matching": "workspace:*",
     "@eggjs/extend2": "workspace:*",
     "get-ready": "catalog:",
     "globby": "catalog:",

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -11,7 +11,7 @@ import { extend } from '@eggjs/extend2';
 import { Request, Response, Application, Context as KoaContext } from '@eggjs/koa';
 import { register as tsconfigPathsRegister } from 'tsconfig-paths';
 import { isESM, isSupportTypeScript } from '@eggjs/utils';
-import { pathMatching, type PathMatchingOptions } from 'egg-path-matching';
+import { pathMatching, type PathMatchingOptions } from '@eggjs/path-matching';
 import { now, diff } from 'performance-ms';
 
 import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';

--- a/packages/path-matching/CHANGELOG.md
+++ b/packages/path-matching/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+> [!IMPORTANT]
+> Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
+
+---
+
+## 3.0.0+
+    
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
+## [2.1.0](https://github.com/eggjs/egg-path-matching/compare/v2.0.0...v2.1.0) (2024-09-18)
+
+
+### Features
+
+* use path-to-regexp@6.3.0 ([#10](https://github.com/eggjs/egg-path-matching/issues/10)) ([b059f04](https://github.com/eggjs/egg-path-matching/commit/b059f04da680010b6cd506a4950bbd120cc78e95))
+
+## [2.0.0](https://github.com/eggjs/egg-path-matching/compare/v1.1.0...v2.0.0) (2024-06-15)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 18.19.0 support
+
+https://github.com/eggjs/egg/issues/5257
+
+### Features
+
+* support cjs and esm both ([#8](https://github.com/eggjs/egg-path-matching/issues/8)) ([a092108](https://github.com/eggjs/egg-path-matching/commit/a092108f1552296ea7ba060300bf580f3a6a5d2e))
+
+## [1.1.0](https://github.com/eggjs/egg-path-matching/compare/v1.0.1...v1.1.0) (2023-12-14)
+
+
+### Features
+
+* use github action and auto release ([#6](https://github.com/eggjs/egg-path-matching/issues/6)) ([1eb34da](https://github.com/eggjs/egg-path-matching/commit/1eb34da16f9676737bbc1fd95fc73ae26e8e5b39))
+
+1.0.1 / 2017-11-15
+==================
+
+**fixes**
+  * [[`6e94f78`](http://github.com/eggjs/egg-path-matching/commit/6e94f78d1229e85a2420274cf3e17c0c7c41c15b)] - fix: reset lastIndex when pattern used the "g" flag (#1) (eric.zhang <<910261782@qq.com>>)
+
+**others**
+  * [[`ca6187d`](http://github.com/eggjs/egg-path-matching/commit/ca6187dd5499f681d5d820541e82210e82019055)] - docs: fix badges (dead-horse <<dead_horse@qq.com>>)
+  * [[`f7d936b`](http://github.com/eggjs/egg-path-matching/commit/f7d936b16d26fb16ea4e5af56f8ced729331f8ae)] - build: add more scripts (dead-horse <<dead_horse@qq.com>>)
+
+1.0.0 / 2016-11-15
+==================
+
+  * feat: add autod config
+  * test: build test on node@4,5,6
+  * feat: first implement

--- a/packages/path-matching/LICENSE
+++ b/packages/path-matching/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-present Alibaba Group Holding Limited and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/path-matching/README.md
+++ b/packages/path-matching/README.md
@@ -1,0 +1,64 @@
+# egg-path-matching
+
+[![NPM version][npm-image]][npm-url]
+[![CI](https://github.com/eggjs/egg-path-matching/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/egg-path-matching/actions/workflows/nodejs.yml)
+[![Test coverage](https://img.shields.io/codecov/c/github/eggjs/egg-path-matching.svg?style=flat-square)](https://codecov.io/gh/eggjs/egg-path-matching)
+[![Known Vulnerabilities][snyk-image]][snyk-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/egg-path-matching.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/egg-path-matching
+[snyk-image]: https://snyk.io/test/npm/egg-path-matching/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/egg-path-matching
+[download-image]: https://img.shields.io/npm/dm/egg-path-matching.svg?style=flat-square
+[download-url]: https://npmjs.org/package/egg-path-matching
+
+## Installation
+
+```bash
+npm install egg-path-matching
+```
+
+## Usage
+
+```ts
+import { pathMatching } from 'egg-path-matching';
+
+const options = {
+  ignore: '/api', // string will use parsed by path-to-regexp
+  // support regexp
+  ignore: /^\/api/,
+  // support function
+  ignore: ctx => ctx.path.startsWith('/api'),
+  // support Array
+  ignore: [ctx => ctx.path.startsWith('/api'), /^\/foo$/, '/bar'],
+  // support match or ignore
+  match: '/api',
+  // custom path-to-regexp module, default is `path-to-regexp@6`
+  // pathToRegexpModule: customPathToRegexp,
+};
+
+const match = pathMatching(options);
+assert.equal(match({ path: '/api' }), true);
+assert.equal(match({ path: '/api/hello' }), true);
+assert.equal(match({ path: '/api' }), true);
+```
+
+### options
+
+- `match` {String | RegExp | Function | Array} - if request path hit `options.match`, will return `true`, otherwise will return `false`.
+- `ignore` {String | RegExp | Function | Array} - if request path hit `options.ignore`, will return `false`, otherwise will return `true`.
+- `pathToRegexpModule` {Object | Function} - custom path-to-regexp module. Default is `path-to-regexp@6`. Supports both `path-to-regexp@6` and `path-to-regexp@8+` formats.
+
+`ignore` and `match` can not both be presented.
+and if neither `ignore` nor `match` presented, the new function will always return `true`.
+
+### License
+
+[MIT](LICENSE)
+
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg-path-matching)](https://github.com/eggjs/egg-path-matching/graphs/contributors)
+
+Made with [contributors-img](https://contrib.rocks).

--- a/packages/path-matching/README.md
+++ b/packages/path-matching/README.md
@@ -1,28 +1,26 @@
-# egg-path-matching
+# @eggjs/path-matching
 
 [![NPM version][npm-image]][npm-url]
-[![CI](https://github.com/eggjs/egg-path-matching/actions/workflows/nodejs.yml/badge.svg)](https://github.com/eggjs/egg-path-matching/actions/workflows/nodejs.yml)
-[![Test coverage](https://img.shields.io/codecov/c/github/eggjs/egg-path-matching.svg?style=flat-square)](https://codecov.io/gh/eggjs/egg-path-matching)
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
 
-[npm-image]: https://img.shields.io/npm/v/egg-path-matching.svg?style=flat-square
-[npm-url]: https://npmjs.org/package/egg-path-matching
-[snyk-image]: https://snyk.io/test/npm/egg-path-matching/badge.svg?style=flat-square
-[snyk-url]: https://snyk.io/test/npm/egg-path-matching
-[download-image]: https://img.shields.io/npm/dm/egg-path-matching.svg?style=flat-square
-[download-url]: https://npmjs.org/package/egg-path-matching
+[npm-image]: https://img.shields.io/npm/v/@eggjs/path-matching.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/@eggjs/path-matching
+[snyk-image]: https://snyk.io/test/npm/@eggjs/path-matching/badge.svg?style=flat-square
+[snyk-url]: https://snyk.io/test/npm/@eggjs/path-matching/badge.svg?style=flat-square
+[download-image]: https://img.shields.io/npm/dm/@eggjs/path-matching.svg?style=flat-square
+[download-url]: https://npmjs.org/package/@eggjs/path-matching
 
 ## Installation
 
 ```bash
-npm install egg-path-matching
+npm install @eggjs/path-matching
 ```
 
 ## Usage
 
 ```ts
-import { pathMatching } from 'egg-path-matching';
+import { pathMatching } from '@eggjs/path-matching';
 
 const options = {
   ignore: '/api', // string will use parsed by path-to-regexp
@@ -59,6 +57,6 @@ and if neither `ignore` nor `match` presented, the new function will always retu
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=eggjs/egg-path-matching)](https://github.com/eggjs/egg-path-matching/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg)](https://github.com/eggjs/egg/graphs/contributors)
 
 Made with [contributors-img](https://contrib.rocks).

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -38,7 +38,7 @@
     "url": "http://deadhorse.me"
   },
   "engines": {
-    "node": ">= 22.18.0"
+    "node": ">=22.18.0"
   },
   "scripts": {
     "build": "tsdown",

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@eggjs/path-matching",
+  "version": "3.0.0-beta.27",
+  "description": "match or ignore url path",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/index.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "url",
+    "match",
+    "ignore"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/eggjs/egg/tree/next/packages/path-matching",
+  "bugs": {
+    "url": "https://github.com/eggjs/egg/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eggjs/egg.git",
+    "directory": "packages/path-matching"
+  },
+  "author": {
+    "name": "dead-horse",
+    "email": "dead_horse@qq.com",
+    "url": "http://deadhorse.me"
+  },
+  "engines": {
+    "node": ">= 22.18.0"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "rimraf dist",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint --type-aware",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "npm run lint:fix && vitest",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "path-to-regexp": "^6.3.0"
+  },
+  "devDependencies": {
+    "@eggjs/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "oxlint": "catalog:",
+    "path-to-regexp-v8": "npm:path-to-regexp@^8.3.0",
+    "rimraf": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts"
+}

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -48,7 +48,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "path-to-regexp": "^6.3.0"
+    "path-to-regexp": "catalog:"
   },
   "devDependencies": {
     "@eggjs/tsconfig": "workspace:*",

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -42,11 +42,9 @@
   },
   "scripts": {
     "build": "tsdown",
-    "clean": "rimraf dist",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --type-aware",
-    "lint:fix": "npm run lint -- --fix",
-    "test": "npm run lint:fix && vitest",
+    "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/path-matching/src/index.ts
+++ b/packages/path-matching/src/index.ts
@@ -1,0 +1,59 @@
+import { pathToRegexp } from 'path-to-regexp';
+
+export type PathMatchingFun = (ctx: any) => boolean;
+
+export type PathMatchingPattern = string | RegExp | PathMatchingFun | (string | RegExp | PathMatchingFun)[];
+
+export interface PathMatchingOptions {
+  ignore?: PathMatchingPattern;
+  match?: PathMatchingPattern;
+  pathToRegexpModule?: any;
+}
+
+export function pathMatching(options: PathMatchingOptions): PathMatchingFun {
+  options = options || {};
+  if (options.match && options.ignore) {
+    throw new Error('options.match and options.ignore can not both present');
+  }
+  if (!options.match && !options.ignore) {
+    return () => true;
+  }
+
+  const pathToRegexpModule = options.pathToRegexpModule || { pathToRegexp };
+  const pathToRegexpFn = pathToRegexpModule.pathToRegexp || pathToRegexpModule;
+  const matchFn = options.match
+    ? toPathMatch(options.match, pathToRegexpFn)
+    : toPathMatch(options.ignore!, pathToRegexpFn);
+
+  return function pathMatch(ctx: any) {
+    const matched = matchFn(ctx);
+    return options.match ? matched : !matched;
+  };
+}
+
+function toPathMatch(pattern: PathMatchingPattern, pathToRegexpFn: any): PathMatchingFun {
+  if (typeof pattern === 'string') {
+    let reg = pathToRegexpFn(pattern, [], { end: false });
+    if (reg.regexp) {
+      // support path-to-regexp@8
+      // => const { regexp, keys } = pathToRegexp("/foo/:bar");
+      reg = reg.regexp;
+    }
+    if (reg.global) reg.lastIndex = 0;
+    return ctx => reg.test(ctx.path);
+  }
+  if (pattern instanceof RegExp) {
+    return ctx => {
+      if (pattern.global) {
+        pattern.lastIndex = 0;
+      }
+      return pattern.test(ctx.path);
+    };
+  }
+  if (typeof pattern === 'function') return pattern;
+  if (Array.isArray(pattern)) {
+    const matchFns = pattern.map(item => toPathMatch(item, pathToRegexpFn));
+    return ctx => matchFns.some(matchFn => matchFn(ctx));
+  }
+  throw new Error(`match/ignore pattern must be RegExp, Array or String, but got ${pattern}`);
+}

--- a/packages/path-matching/test/index.test.ts
+++ b/packages/path-matching/test/index.test.ts
@@ -1,145 +1,140 @@
-import { strict as assert } from 'node:assert';
-
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import { pathMatching as match } from '../src/index.ts';
 
 describe('index.test.ts', () => {
   it('options.match and options.ignore both present should throw', () => {
-    try {
+    expect(() => {
       match({ ignore: '/api', match: '/dashboard' });
-      throw new Error('should not exec');
-    } catch (e: any) {
-      assert.equal(e.message, 'options.match and options.ignore can not both present');
-    }
+    }).toThrow('options.match and options.ignore can not both present');
   });
 
   it('options.match and options.ignore both not present should always return true', () => {
     const fn = match({});
-    assert(fn({}) === true);
+    expect(fn({})).toBe(true);
   });
 
   describe('match', () => {
     it('support string', () => {
       const fn = match({ match: '/api' });
-      assert(fn({ path: '/api/hello' }) === true);
-      assert(fn({ path: '/api/' }) === true);
-      assert(fn({ path: '/api' }) === true);
-      assert(fn({ path: '/api1/hello' }) === false);
-      assert(fn({ path: '/api1' }) === false);
+      expect(fn({ path: '/api/hello' })).toBe(true);
+      expect(fn({ path: '/api/' })).toBe(true);
+      expect(fn({ path: '/api' })).toBe(true);
+      expect(fn({ path: '/api1/hello' })).toBe(false);
+      expect(fn({ path: '/api1' })).toBe(false);
     });
 
     it('support custom pathToRegexpModule', async () => {
       const pathToRegexpV8 = await import('path-to-regexp-v8');
       const fn = match({ match: '/api{/*path}', pathToRegexpModule: pathToRegexpV8 });
-      assert(fn({ path: '/api/hello' }) === true);
-      assert(fn({ path: '/api/' }) === true);
-      assert(fn({ path: '/api' }) === true);
-      assert(fn({ path: '/api1/hello' }) === false);
-      assert(fn({ path: '/api1' }) === false);
+      expect(fn({ path: '/api/hello' })).toBe(true);
+      expect(fn({ path: '/api/' })).toBe(true);
+      expect(fn({ path: '/api' })).toBe(true);
+      expect(fn({ path: '/api1/hello' })).toBe(false);
+      expect(fn({ path: '/api1' })).toBe(false);
     });
 
     it('support regexp', () => {
       const fn = match({ match: /^\/api/ });
-      assert(fn({ path: '/api/hello' }) === true);
-      assert(fn({ path: '/api/' }) === true);
-      assert(fn({ path: '/api' }) === true);
-      assert(fn({ path: '/api1/hello' }) === true);
-      assert(fn({ path: '/api1' }) === true);
-      assert(fn({ path: '/v1/api1' }) === false);
+      expect(fn({ path: '/api/hello' })).toBe(true);
+      expect(fn({ path: '/api/' })).toBe(true);
+      expect(fn({ path: '/api' })).toBe(true);
+      expect(fn({ path: '/api1/hello' })).toBe(true);
+      expect(fn({ path: '/api1' })).toBe(true);
+      expect(fn({ path: '/v1/api1' })).toBe(false);
     });
 
     it('support global regexp', () => {
       const fn = match({ match: /^\/api/g });
-      assert(fn({ path: '/api/hello' }) === true);
-      assert(fn({ path: '/api/' }) === true);
-      assert(fn({ path: '/api' }) === true);
-      assert(fn({ path: '/api1/hello' }) === true);
-      assert(fn({ path: '/api1' }) === true);
-      assert(fn({ path: '/v1/api1' }) === false);
+      expect(fn({ path: '/api/hello' })).toBe(true);
+      expect(fn({ path: '/api/' })).toBe(true);
+      expect(fn({ path: '/api' })).toBe(true);
+      expect(fn({ path: '/api1/hello' })).toBe(true);
+      expect(fn({ path: '/api1' })).toBe(true);
+      expect(fn({ path: '/v1/api1' })).toBe(false);
     });
 
     it('support function', () => {
       const fn = match({
         match: ctx => ctx.path.startsWith('/api'),
       });
-      assert(fn({ path: '/api/hello' }) === true);
-      assert(fn({ path: '/api/' }) === true);
-      assert(fn({ path: '/api' }) === true);
-      assert(fn({ path: '/api1/hello' }) === true);
-      assert(fn({ path: '/api1' }) === true);
-      assert(fn({ path: '/v1/api1' }) === false);
+      expect(fn({ path: '/api/hello' })).toBe(true);
+      expect(fn({ path: '/api/' })).toBe(true);
+      expect(fn({ path: '/api' })).toBe(true);
+      expect(fn({ path: '/api1/hello' })).toBe(true);
+      expect(fn({ path: '/api1' })).toBe(true);
+      expect(fn({ path: '/v1/api1' })).toBe(false);
     });
 
     it('support array', () => {
       const fn = match({
         match: [ctx => ctx.path.startsWith('/api'), '/ajax', /^\/foo$/],
       });
-      assert(fn({ path: '/api/hello' }) === true);
-      assert(fn({ path: '/api/' }) === true);
-      assert(fn({ path: '/api' }) === true);
-      assert(fn({ path: '/api1/hello' }) === true);
-      assert(fn({ path: '/api1' }) === true);
-      assert(fn({ path: '/v1/api1' }) === false);
-      assert(fn({ path: '/ajax/hello' }) === true);
-      assert(fn({ path: '/foo' }) === true);
+      expect(fn({ path: '/api/hello' })).toBe(true);
+      expect(fn({ path: '/api/' })).toBe(true);
+      expect(fn({ path: '/api' })).toBe(true);
+      expect(fn({ path: '/api1/hello' })).toBe(true);
+      expect(fn({ path: '/api1' })).toBe(true);
+      expect(fn({ path: '/v1/api1' })).toBe(false);
+      expect(fn({ path: '/ajax/hello' })).toBe(true);
+      expect(fn({ path: '/foo' })).toBe(true);
     });
   });
 
   describe('ignore', () => {
     it('support string', () => {
       const fn = match({ ignore: '/api' });
-      assert(fn({ path: '/api/hello' }) === false);
-      assert(fn({ path: '/api/' }) === false);
-      assert(fn({ path: '/api' }) === false);
-      assert(fn({ path: '/api1/hello' }) === true);
-      assert(fn({ path: '/api1' }) === true);
+      expect(fn({ path: '/api/hello' })).toBe(false);
+      expect(fn({ path: '/api/' })).toBe(false);
+      expect(fn({ path: '/api' })).toBe(false);
+      expect(fn({ path: '/api1/hello' })).toBe(true);
+      expect(fn({ path: '/api1' })).toBe(true);
     });
 
     it('support regexp', () => {
       const fn = match({ ignore: /^\/api/ });
-      assert(fn({ path: '/api/hello' }) === false);
-      assert(fn({ path: '/api/' }) === false);
-      assert(fn({ path: '/api' }) === false);
-      assert(fn({ path: '/api1/hello' }) === false);
-      assert(fn({ path: '/api1' }) === false);
-      assert(fn({ path: '/v1/api1' }) === true);
+      expect(fn({ path: '/api/hello' })).toBe(false);
+      expect(fn({ path: '/api/' })).toBe(false);
+      expect(fn({ path: '/api' })).toBe(false);
+      expect(fn({ path: '/api1/hello' })).toBe(false);
+      expect(fn({ path: '/api1' })).toBe(false);
+      expect(fn({ path: '/v1/api1' })).toBe(true);
     });
 
     it('support global regexp', () => {
       const fn = match({ ignore: /^\/api/g });
-      assert(fn({ path: '/api/hello' }) === false);
-      assert(fn({ path: '/api/' }) === false);
-      assert(fn({ path: '/api' }) === false);
-      assert(fn({ path: '/api1/hello' }) === false);
-      assert(fn({ path: '/api1' }) === false);
-      assert(fn({ path: '/v1/api1' }) === true);
+      expect(fn({ path: '/api/hello' })).toBe(false);
+      expect(fn({ path: '/api/' })).toBe(false);
+      expect(fn({ path: '/api' })).toBe(false);
+      expect(fn({ path: '/api1/hello' })).toBe(false);
+      expect(fn({ path: '/api1' })).toBe(false);
+      expect(fn({ path: '/v1/api1' })).toBe(true);
     });
 
     it('support function', () => {
       const fn = match({
         ignore: ctx => ctx.path.startsWith('/api'),
       });
-      assert(fn({ path: '/api/hello' }) === false);
-      assert(fn({ path: '/api/' }) === false);
-      assert(fn({ path: '/api' }) === false);
-      assert(fn({ path: '/api1/hello' }) === false);
-      assert(fn({ path: '/api1' }) === false);
-      assert(fn({ path: '/v1/api1' }) === true);
+      expect(fn({ path: '/api/hello' })).toBe(false);
+      expect(fn({ path: '/api/' })).toBe(false);
+      expect(fn({ path: '/api' })).toBe(false);
+      expect(fn({ path: '/api1/hello' })).toBe(false);
+      expect(fn({ path: '/api1' })).toBe(false);
+      expect(fn({ path: '/v1/api1' })).toBe(true);
     });
 
     it('support array', () => {
       const fn = match({
         ignore: [ctx => ctx.path.startsWith('/api'), '/ajax', /^\/foo$/],
       });
-      assert(fn({ path: '/api/hello' }) === false);
-      assert(fn({ path: '/api/' }) === false);
-      assert(fn({ path: '/api' }) === false);
-      assert(fn({ path: '/api1/hello' }) === false);
-      assert(fn({ path: '/api1' }) === false);
-      assert(fn({ path: '/v1/api1' }) === true);
-      assert(fn({ path: '/ajax/hello' }) === false);
-      assert(fn({ path: '/foo' }) === false);
+      expect(fn({ path: '/api/hello' })).toBe(false);
+      expect(fn({ path: '/api/' })).toBe(false);
+      expect(fn({ path: '/api' })).toBe(false);
+      expect(fn({ path: '/api1/hello' })).toBe(false);
+      expect(fn({ path: '/api1' })).toBe(false);
+      expect(fn({ path: '/v1/api1' })).toBe(true);
+      expect(fn({ path: '/ajax/hello' })).toBe(false);
+      expect(fn({ path: '/foo' })).toBe(false);
     });
   });
 });

--- a/packages/path-matching/test/index.test.ts
+++ b/packages/path-matching/test/index.test.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'vitest';
+import { pathMatching as match } from '../src/index.ts';
+
+describe('egg-path-matching', () => {
+  it('options.match and options.ignore both present should throw', () => {
+    try {
+      match({ ignore: '/api', match: '/dashboard' });
+      throw new Error('should not exec');
+    } catch (e: any) {
+      assert.equal(e.message, 'options.match and options.ignore can not both present');
+    }
+  });
+
+  it('options.match and options.ignore both not present should always return true', () => {
+    const fn = match({});
+    assert(fn({}) === true);
+  });
+
+  describe('match', () => {
+    it('support string', () => {
+      const fn = match({ match: '/api' });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+    });
+
+    it('support custom pathToRegexpModule', async () => {
+      const pathToRegexpV8 = await import('path-to-regexp-v8');
+      const fn = match({ match: '/api{/*path}', pathToRegexpModule: pathToRegexpV8 });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+    });
+
+    it('support regexp', () => {
+      const fn = match({ match: /^\/api/ });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === true);
+      assert(fn({ path: '/api1' }) === true);
+      assert(fn({ path: '/v1/api1' }) === false);
+    });
+
+    it('support global regexp', () => {
+      const fn = match({ match: /^\/api/g });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === true);
+      assert(fn({ path: '/api1' }) === true);
+      assert(fn({ path: '/v1/api1' }) === false);
+    });
+
+    it('support function', () => {
+      const fn = match({
+        match: ctx => ctx.path.startsWith('/api'),
+      });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === true);
+      assert(fn({ path: '/api1' }) === true);
+      assert(fn({ path: '/v1/api1' }) === false);
+    });
+
+    it('support array', () => {
+      const fn = match({
+        match: [ctx => ctx.path.startsWith('/api'), '/ajax', /^\/foo$/],
+      });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === true);
+      assert(fn({ path: '/api1' }) === true);
+      assert(fn({ path: '/v1/api1' }) === false);
+      assert(fn({ path: '/ajax/hello' }) === true);
+      assert(fn({ path: '/foo' }) === true);
+    });
+  });
+
+  describe('ignore', () => {
+    it('support string', () => {
+      const fn = match({ ignore: '/api' });
+      assert(fn({ path: '/api/hello' }) === false);
+      assert(fn({ path: '/api/' }) === false);
+      assert(fn({ path: '/api' }) === false);
+      assert(fn({ path: '/api1/hello' }) === true);
+      assert(fn({ path: '/api1' }) === true);
+    });
+
+    it('support regexp', () => {
+      const fn = match({ ignore: /^\/api/ });
+      assert(fn({ path: '/api/hello' }) === false);
+      assert(fn({ path: '/api/' }) === false);
+      assert(fn({ path: '/api' }) === false);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+      assert(fn({ path: '/v1/api1' }) === true);
+    });
+
+    it('support global regexp', () => {
+      const fn = match({ ignore: /^\/api/g });
+      assert(fn({ path: '/api/hello' }) === false);
+      assert(fn({ path: '/api/' }) === false);
+      assert(fn({ path: '/api' }) === false);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+      assert(fn({ path: '/v1/api1' }) === true);
+    });
+
+    it('support function', () => {
+      const fn = match({
+        ignore: ctx => ctx.path.startsWith('/api'),
+      });
+      assert(fn({ path: '/api/hello' }) === false);
+      assert(fn({ path: '/api/' }) === false);
+      assert(fn({ path: '/api' }) === false);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+      assert(fn({ path: '/v1/api1' }) === true);
+    });
+
+    it('support array', () => {
+      const fn = match({
+        ignore: [ctx => ctx.path.startsWith('/api'), '/ajax', /^\/foo$/],
+      });
+      assert(fn({ path: '/api/hello' }) === false);
+      assert(fn({ path: '/api/' }) === false);
+      assert(fn({ path: '/api' }) === false);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+      assert(fn({ path: '/v1/api1' }) === true);
+      assert(fn({ path: '/ajax/hello' }) === false);
+      assert(fn({ path: '/foo' }) === false);
+    });
+  });
+});

--- a/packages/path-matching/test/index.test.ts
+++ b/packages/path-matching/test/index.test.ts
@@ -1,8 +1,10 @@
 import { strict as assert } from 'node:assert';
+
 import { describe, it } from 'vitest';
+
 import { pathMatching as match } from '../src/index.ts';
 
-describe('egg-path-matching', () => {
+describe('index.test.ts', () => {
   it('options.match and options.ignore both present should throw', () => {
     try {
       match({ ignore: '/api', match: '/dashboard' });

--- a/packages/path-matching/tsconfig.json
+++ b/packages/path-matching/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  }
+}

--- a/packages/path-matching/tsdown.config.ts
+++ b/packages/path-matching/tsdown.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: 'src/**/*.ts',
-  // unbundle: true,
+  entry: ['src/index.ts'],
+  unbundle: true,
   unused: {
     level: 'error',
   },

--- a/packages/path-matching/tsdown.config.ts
+++ b/packages/path-matching/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: 'src/**/*.ts',
+  // unbundle: true,
+  unused: {
+    level: 'error',
+  },
+  dts: true,
+  exports: {
+    devExports: true,
+  },
+});

--- a/packages/path-matching/vitest.config.ts
+++ b/packages/path-matching/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -27,7 +27,7 @@
     "is-type-of": "catalog:",
     "koa-compose": "catalog:",
     "methods": "catalog:",
-    "path-to-regexp": "catalog:",
+    "path-to-regexp": "^1.9.0",
     "urijs": "catalog:",
     "utility": "catalog:"
   },

--- a/packages/utils/test/fixtures/egg-app/package.json
+++ b/packages/utils/test/fixtures/egg-app/package.json
@@ -2,7 +2,7 @@
   "name": "egg-app",
   "dependencies": {
     "egg": "beta",
-    "@eggjs/core": "6",
+    "@eggjs/core": "beta",
     "framework-demo": "^1.0.1"
   }
 }

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -59,10 +59,10 @@
     }
   },
   "dependencies": {
+    "@eggjs/path-matching": "workspace:*",
     "bytes": "catalog:",
     "co-busboy": "catalog:",
-    "dayjs": "catalog:",
-    "egg-path-matching": "catalog:"
+    "dayjs": "catalog:"
   },
   "peerDependencies": {
     "egg": "workspace:*"

--- a/plugins/multipart/src/app/middleware/multipart.ts
+++ b/plugins/multipart/src/app/middleware/multipart.ts
@@ -1,4 +1,4 @@
-import { pathMatching } from 'egg-path-matching';
+import { pathMatching } from '@eggjs/path-matching';
 import type { Application, MiddlewareFunc } from 'egg';
 
 import type { MultipartConfig } from '../../config/config.default.ts';

--- a/plugins/multipart/src/config/config.default.ts
+++ b/plugins/multipart/src/config/config.default.ts
@@ -2,7 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type { Context, EggAppInfo } from 'egg';
-import type { PathMatchingPattern } from 'egg-path-matching';
+import type { PathMatchingPattern } from '@eggjs/path-matching';
 
 export type MatchItem = string | RegExp | ((ctx: Context) => boolean);
 

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -110,8 +110,8 @@
   },
   "dependencies": {
     "@eggjs/ip": "catalog:",
+    "@eggjs/path-matching": "workspace:*",
     "csrf": "catalog:",
-    "egg-path-matching": "catalog:",
     "escape-html": "catalog:",
     "extend": "catalog:",
     "koa-compose": "catalog:",

--- a/plugins/security/src/app/middleware/securities.ts
+++ b/plugins/security/src/app/middleware/securities.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 
 import compose from 'koa-compose';
-import { pathMatching } from 'egg-path-matching';
+import { pathMatching } from '@eggjs/path-matching';
 import type { Application, MiddlewareFunc } from 'egg';
 
 import securityMiddlewares from '../../lib/middlewares/index.ts';

--- a/plugins/security/src/lib/utils.ts
+++ b/plugins/security/src/lib/utils.ts
@@ -3,7 +3,7 @@ import { normalize } from 'node:path';
 import matcher from 'matcher';
 import IP from '@eggjs/ip';
 import type { Context } from 'egg';
-import type { PathMatchingFun } from 'egg-path-matching';
+import type { PathMatchingFun } from '@eggjs/path-matching';
 
 import type { SecurityConfig } from '../config/config.default.ts';
 

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@eggjs/mock": "workspace:*",
-    "@eggjs/redis": "catalog:",
+    "@eggjs/redis": "workspace:*",
     "@eggjs/supertest": "workspace:*",
     "@eggjs/tsconfig": "workspace:*",
     "@types/node": "catalog:",

--- a/plugins/typebox-validate/CHANGELOG.md
+++ b/plugins/typebox-validate/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+> [!IMPORTANT]
+> Moving forwards we are using the GitHub releases page at <https://github.com/eggjs/egg/releases> in combination with [release.yml](https://github.com/eggjs/egg/actions/workflows/release.yml) for publishing releases and their changelogs.
+
+---
+
+## 4.0.0+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 22.18.0 support
+* only support egg@4
+
+part of https://github.com/eggjs/egg/issues/5434
+
+---
+
+## [3.0.0](https://github.com/eggjs-community/egg-typebox-validate/compare/v2.3.1...v3.0.0) (2025-03-05)
+
+
+### ⚠ BREAKING CHANGES
+
+* drop Node.js < 18.19.0 support
+
+part of https://github.com/eggjs/egg/issues/3644
+
+https://github.com/eggjs/egg/issues/5257
+
+### Features
+
+* support egg >= 4.0 ([ea1bf7e](https://github.com/eggjs-community/egg-typebox-validate/commit/ea1bf7ef8363728f95c5367d70654e8445981bd9))
+
+
+### Bug Fixes
+
+* export Ajv ([62157b7](https://github.com/eggjs-community/egg-typebox-validate/commit/62157b7ac5b3b13d03ebd93ed6409dcedae91c34))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1237,8 +1237,8 @@ importers:
         specifier: 'catalog:'
         version: 1.1.2
       path-to-regexp:
-        specifier: 'catalog:'
-        version: 6.3.0
+        specifier: ^1.9.0
+        version: 1.9.0
       urijs:
         specifier: 'catalog:'
         version: 1.19.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,8 +424,8 @@ catalogs:
       specifier: ^1.3.3
       version: 1.3.3
     path-to-regexp:
-      specifier: ^1.9.0
-      version: 1.9.0
+      specifier: ^6.3.0
+      version: 6.3.0
     performance-ms:
       specifier: ^1.1.0
       version: 1.1.0
@@ -1191,7 +1191,7 @@ importers:
   packages/path-matching:
     dependencies:
       path-to-regexp:
-        specifier: ^6.3.0
+        specifier: 'catalog:'
         version: 6.3.0
     devDependencies:
       '@eggjs/tsconfig':
@@ -1238,7 +1238,7 @@ importers:
         version: 1.1.2
       path-to-regexp:
         specifier: 'catalog:'
-        version: 1.9.0
+        version: 6.3.0
       urijs:
         specifier: 'catalog:'
         version: 1.19.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@eggjs/ip':
       specifier: ^2.1.0
       version: 2.1.0
-    '@eggjs/redis':
-      specifier: ^3.0.0
-      version: 3.1.0
     '@eggjs/scripts':
       specifier: ^4.0.0
       version: 4.0.0
@@ -264,9 +261,6 @@ catalogs:
     egg-logger:
       specifier: ^3.5.0
       version: 3.6.1
-    egg-path-matching:
-      specifier: ^2.0.0
-      version: 2.1.0
     egg-plugin-puml:
       specifier: ^2.4.0
       version: 2.4.0
@@ -751,6 +745,9 @@ importers:
       '@eggjs/koa':
         specifier: workspace:*
         version: link:../koa
+      '@eggjs/path-matching':
+        specifier: workspace:*
+        version: link:../path-matching
       '@eggjs/router':
         specifier: workspace:*
         version: link:../router
@@ -760,9 +757,6 @@ importers:
       egg-logger:
         specifier: 'catalog:'
         version: 3.6.1
-      egg-path-matching:
-        specifier: 'catalog:'
-        version: 2.1.0
       get-ready:
         specifier: 'catalog:'
         version: 3.4.0
@@ -1570,6 +1564,9 @@ importers:
 
   plugins/multipart:
     dependencies:
+      '@eggjs/path-matching':
+        specifier: workspace:*
+        version: link:../../packages/path-matching
       bytes:
         specifier: 'catalog:'
         version: 3.1.2
@@ -1582,9 +1579,6 @@ importers:
       egg:
         specifier: workspace:*
         version: link:../../packages/egg
-      egg-path-matching:
-        specifier: 'catalog:'
-        version: 2.1.0
     devDependencies:
       '@eggjs/mock':
         specifier: workspace:*
@@ -1751,15 +1745,15 @@ importers:
       '@eggjs/ip':
         specifier: 'catalog:'
         version: 2.1.0
+      '@eggjs/path-matching':
+        specifier: workspace:*
+        version: link:../../packages/path-matching
       csrf:
         specifier: 'catalog:'
         version: 3.1.0
       egg:
         specifier: workspace:*
         version: link:../../packages/egg
-      egg-path-matching:
-        specifier: 'catalog:'
-        version: 2.1.0
       escape-html:
         specifier: 'catalog:'
         version: 1.0.3
@@ -1850,8 +1844,8 @@ importers:
         specifier: workspace:*
         version: link:../mock
       '@eggjs/redis':
-        specifier: 'catalog:'
-        version: 3.1.0
+        specifier: workspace:*
+        version: link:../redis
       '@eggjs/supertest':
         specifier: workspace:*
         version: link:../../packages/supertest
@@ -2556,10 +2550,6 @@ packages:
     resolution: {integrity: sha512-WLnBmOTJPjahU9XpNkAacsCB47OWYwuSplVVCxFajsoK4aXEL//BSAKL5MvqpF857FXtBqCdSMRnslbt4y+0gg==}
     engines: {node: '>=22.18.0'}
 
-  '@eggjs/core@6.5.0':
-    resolution: {integrity: sha512-JwiHVoRihNtt1XekIp9rfs/+M/w7tHiZW5OMUzZV3IpAVh60tiMC+pbWXcDWxTseTDp0HLItrYFXUPLrptMYRQ==}
-    engines: {node: '>= 18.19.0'}
-
   '@eggjs/dal-decorator@4.0.0-beta.11':
     resolution: {integrity: sha512-tNf50wuqTqmHHXBzrLahrx7TZiYKIjXZ1mj7GM5ylsG1+EvDLcGkFALHaML3xJ0+UDqFWlnoHlbc9QR2aWeQoQ==}
     engines: {node: '>=22.18.0'}
@@ -2576,21 +2566,9 @@ packages:
     resolution: {integrity: sha512-jOsufOpySKBld+N1GG8IAW9EEQNmQ6bDaBnrRlYFk6AspoxG8gAzXSW93ZFfEPwscS5rL7UbDUKyIHUkmkTPyw==}
     engines: {node: '>= 14.0.0'}
 
-  '@eggjs/koa@2.22.2':
-    resolution: {integrity: sha512-cqubIqo5SCDPVN2qJ/ZiIPsfWl0xvNRvdLc9h1h8s5zdUk33RyNmCP83Ur9WS3GWbew+rDpVkNReJUCPbvrxkg==}
-    engines: {node: '>= 18.19.0'}
-
   '@eggjs/rds@1.3.0':
     resolution: {integrity: sha512-MshrDFuP18G30Zt1U0NcxHFmFEfi6LDXOUDAJ5Qvf4rn6PDzZ8U0kvp/C8tHeWA2RK3rIDGRqWlqvAzwwdGpFA==}
     engines: {node: '>= 16.17.0'}
-
-  '@eggjs/redis@3.1.0':
-    resolution: {integrity: sha512-YqqPE/QOHpDPM+NsUu/dn2OZ7yZCHb02JMFc0nEnIYtVF4o73nhOC13BNn3u0lgNGUJCDYWF+sxtNa87kO00xQ==}
-    engines: {node: '>= 18.19.0'}
-
-  '@eggjs/router@3.0.6':
-    resolution: {integrity: sha512-mqOFkq79x3wGHYoI/lWMwSZ4wqmET9okJ0WU+qeuEgwA7PNMt8HyUmZ9Edz8+o3TjCSl85uMhpC0K4WWfPh7yA==}
-    engines: {node: '>= 18.19.0'}
 
   '@eggjs/router@4.0.0-beta.27':
     resolution: {integrity: sha512-Ie1dZYIeAbS9TskRbOuJF2EN0hVbPqoD8TUJG/YVNjtm6zVWHW4XQd8aF46ZBs0o78pdAh0hszVVUdHEZNHfag==}
@@ -6442,9 +6420,6 @@ packages:
   egg-logger@3.6.1:
     resolution: {integrity: sha512-lGiEumARJAT7NiwMm577NFiOEBMX9FlZzfuBsLLS6eu14R9udcTI1IzXLGJ63SrCmFIXB+zsWLQv5U11e8fq0Q==}
     engines: {node: '>=14.17.0'}
-
-  egg-path-matching@2.1.0:
-    resolution: {integrity: sha512-g2V2ohTSf/WN1UNtUdeUAhu/xbA97uAJHgqRpRInR2KT77MRxrG4XtcsjbZudQmB5XRPvYSbnny/1m/57+UadA==}
 
   egg-plugin-puml@2.4.0:
     resolution: {integrity: sha512-M6ALp4iGFEGP25OWOQ1EGDSUb/GgxOtC/EOpC28oQtiP/7GqWkTzPw/3CY22vW6UoJ6jL+pHELR1z04ul/r1ig==}
@@ -12096,23 +12071,6 @@ snapshots:
     transitivePeerDependencies:
       - egg
 
-  '@eggjs/core@6.5.0':
-    dependencies:
-      '@eggjs/koa': 2.22.2
-      '@eggjs/router': 3.0.6
-      '@eggjs/utils': 4.4.1
-      egg-logger: 3.6.1
-      egg-path-matching: 2.1.0
-      extend2: 4.0.0
-      get-ready: 3.4.0
-      globby: 11.1.0
-      is-type-of: 2.2.0
-      node-homedir: 2.0.0
-      performance-ms: 1.1.0
-      ready-callback: 4.0.0
-      tsconfig-paths: 4.2.0
-      utility: 2.5.0
-
   '@eggjs/dal-decorator@4.0.0-beta.11(egg@packages+egg)':
     dependencies:
       '@eggjs/core-decorator': 4.0.0-beta.11(egg@packages+egg)
@@ -12136,50 +12094,10 @@ snapshots:
 
   '@eggjs/ip@2.1.0': {}
 
-  '@eggjs/koa@2.22.2':
-    dependencies:
-      '@types/content-disposition': 0.5.9
-      accepts: 1.3.8
-      cache-content-type: 2.1.0
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookies: 0.9.1
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      fresh: 0.5.2
-      gals: 1.0.2
-      http-errors: 2.0.0
-      is-type-of: 2.2.0
-      koa-compose: 4.1.0
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-      type-is: 1.6.18
-      vary: 1.1.2
-
   '@eggjs/rds@1.3.0':
     dependencies:
       mysql2: 3.15.1
       sqlstring: 2.3.3
-
-  '@eggjs/redis@3.1.0':
-    dependencies:
-      '@eggjs/core': 6.5.0
-      ioredis: 5.8.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@eggjs/router@3.0.6':
-    dependencies:
-      http-errors: 2.0.0
-      inflection: 3.0.2
-      is-type-of: 2.2.0
-      koa-compose: 4.1.0
-      methods: 1.1.2
-      path-to-regexp: 1.9.0
-      urijs: 1.19.11
-      utility: 2.5.0
 
   '@eggjs/router@4.0.0-beta.27':
     dependencies:
@@ -16425,10 +16343,6 @@ snapshots:
       egg-errors: 2.3.2
       iconv-lite: 0.6.3
       utility: 2.5.0
-
-  egg-path-matching@2.1.0:
-    dependencies:
-      path-to-regexp: 6.3.0
 
   egg-plugin-puml@2.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1194,6 +1194,37 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
 
+  packages/path-matching:
+    dependencies:
+      path-to-regexp:
+        specifier: ^6.3.0
+        version: 6.3.0
+    devDependencies:
+      '@eggjs/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.6.2
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.19.0(oxlint-tsgolint@0.2.0)
+      path-to-regexp-v8:
+        specifier: npm:path-to-regexp@^8.3.0
+        version: path-to-regexp@8.3.0
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.0.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.4(oxc-resolver@11.8.3)(typescript@5.9.3)(unplugin-unused@0.5.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.0-beta.17(@types/debug@4.1.12)(@types/node@24.6.2)(@vitest/ui@4.0.0-beta.17)(esbuild@0.25.10)(jiti@2.6.0)(less@4.4.1)(sass@1.93.2)(terser@5.44.0)(yaml@2.8.1)
+
   packages/router:
     dependencies:
       http-errors:
@@ -9231,6 +9262,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -19987,6 +20021,8 @@ snapshots:
       isarray: 0.0.1
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,7 +154,7 @@ catalog:
   oxlint: ^1.19.0
   oxlint-tsgolint: ^0.2.0
   parseurl: ^1.3.3
-  path-to-regexp: ^1.9.0
+  path-to-regexp: ^6.3.0
   performance-ms: ^1.1.0
   picocolors: ^1.1.1
   prettier: ^3.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,7 +96,6 @@ catalog:
   detect-port: ^2.1.0
   dumi: ^2.4.17
   egg-logger: ^3.5.0
-  egg-path-matching: ^2.0.0
   egg-plugin-puml: ^2.4.0
   egg-ts-helper: ^3.0.0
   egg-view-nunjucks: ^2.3.0

--- a/site/docs/basics/middleware.md
+++ b/site/docs/basics/middleware.md
@@ -248,4 +248,4 @@ module.exports = {
 };
 ```
 
-For more configs about `match` and `ignore`, please refer to [egg-path-matching](https://github.com/eggjs/egg-path-matching).
+For more configs about `match` and `ignore`, please refer to [@eggjs/path-matching](https://github.com/eggjs/egg/tree/next/packages/path-matching).

--- a/site/docs/basics/middleware.zh-CN.md
+++ b/site/docs/basics/middleware.zh-CN.md
@@ -249,4 +249,4 @@ module.exports = {
 };
 ```
 
-有关更多的 `match` 和 `ignore` 配置情况，详见 [egg-path-matching](https://github.com/eggjs/egg-path-matching)。
+有关更多的 `match` 和 `ignore` 配置情况，详见 [@eggjs/path-matching](https://github.com/eggjs/egg/tree/next/packages/path-matching)。

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
       "path": "./packages/errors"
     },
     {
+      "path": "./packages/path-matching"
+    },
+    {
       "path": "./packages/utils"
     },
     {


### PR DESCRIPTION
- Merge package from https://github.com/eggjs/egg-path-matching
- Rename package to @eggjs/path-matching v3.0.0-beta.27
- Migrate to monorepo structure following CLAUDE.md standards
- Use path-to-regexp v6.3.0 as dependency
- Migrate tests from Mocha to Vitest (13 tests passing)
- Create standard tsdown.config.ts with unplugin-unused
- Update imports to use .ts extensions
- Add package reference to root tsconfig.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added @eggjs/path-matching package for flexible route filtering with match/ignore options; supports strings, RegExp (including global), functions, arrays, and pluggable path-to-regexp; defaults to allow when no criteria provided.

- **Documentation**
  - Added README and CHANGELOG; updated site docs to reference the new package.

- **Tests**
  - Added unit tests covering match/ignore behaviors and edge cases.

- **Chores**
  - Added package metadata, build/test configs, TS project reference; updated workspace dependency references across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->