### PR TITLE
fix: normalize referer before redirect

### DIFF
--- a/packages/koa/src/response.ts
+++ b/packages/koa/src/response.ts
@@ -223,11 +223,6 @@ export class Response {
   protected _getBackReferrer(): string | undefined {
     const referrer = this.ctx.get<string>('Referrer');
     if (referrer) {
-      // referrer is a relative path
-      if (referrer.startsWith('/')) {
-        return referrer;
-      }
-
       // referrer is an absolute URL, check if it's the same origin
       const url = new URL(referrer, this.ctx.href);
       if (url.host === this.ctx.host) {

--- a/packages/koa/test/response/redirect.test.ts
+++ b/packages/koa/test/response/redirect.test.ts
@@ -44,7 +44,7 @@ describe('ctx.redirect(url)', () => {
       assert.equal(ctx.response.header.location, '/login');
     });
 
-    it('should redirect to Referer to a relative path', () => {
+    it('should redirect to Referer with a relative path', () => {
       const ctx = context({ url: '/', headers: { host: 'example.com' } });
       ctx.req.headers.referer = '/login';
       ctx.redirect('back');

--- a/packages/koa/test/response/redirect.test.ts
+++ b/packages/koa/test/response/redirect.test.ts
@@ -51,7 +51,7 @@ describe('ctx.redirect(url)', () => {
       assert.equal(ctx.response.header.location, '/login');
     });
 
-    it('should redirect to Referer to a same origin url', () => {
+    it('should redirect to Referer with a same origin url', () => {
       const ctx = context({ url: '/', headers: { host: 'example.com', referer: 'https://example.com/login' } });
       ctx.redirect('back');
       assert.equal(ctx.response.header.location, 'https://example.com/login');

--- a/packages/koa/test/response/redirect.test.ts
+++ b/packages/koa/test/response/redirect.test.ts
@@ -38,17 +38,23 @@ describe('ctx.redirect(url)', () => {
 
   describe('with "back"', () => {
     it('should redirect to Referrer', () => {
-      const ctx = context();
+      const ctx = context({ url: '/', headers: { host: 'example.com' } });
       ctx.req.headers.referrer = '/login';
       ctx.redirect('back');
       assert.equal(ctx.response.header.location, '/login');
     });
 
-    it('should redirect to Referer', () => {
-      const ctx = context();
+    it('should redirect to Referer to a relative path', () => {
+      const ctx = context({ url: '/', headers: { host: 'example.com' } });
       ctx.req.headers.referer = '/login';
       ctx.redirect('back');
       assert.equal(ctx.response.header.location, '/login');
+    });
+
+    it('should redirect to Referer to a same origin url', () => {
+      const ctx = context({ url: '/', headers: { host: 'example.com', referer: 'https://example.com/login' } });
+      ctx.redirect('back');
+      assert.equal(ctx.response.header.location, 'https://example.com/login');
     });
 
     it('should default to alt', () => {
@@ -77,6 +83,16 @@ describe('ctx.redirect(url)', () => {
       ctx.req.headers.referrer = 'https://other.com/login';
       ctx.redirect('back');
       assert.strictEqual(ctx.response.header.location, '/');
+    });
+
+    it('should fix Trailing Double-Slash security issue', () => {
+      const ctx = context({ url: '/', headers: { host: 'example.com' } });
+      ctx.req.headers.referrer = '//evil.com/login/';
+      ctx.redirect('back');
+      assert.equal(ctx.response.header.location, '/');
+
+      ctx.redirect('back', '/home');
+      assert.equal(ctx.response.header.location, '/home');
     });
   });
 

--- a/plugins/schedule/test/dynamic.test.ts
+++ b/plugins/schedule/test/dynamic.test.ts
@@ -5,7 +5,8 @@ import { describe, it, afterAll, beforeAll, expect } from 'vitest';
 
 import { contains, getFixtures, getLogContent } from './utils.ts';
 
-describe('cluster', () => {
+// TODO: flaky test on windows, Hook timed out in 20000ms
+describe.skipIf(process.platform === 'win32')('cluster', () => {
   let app: MockApplication;
   beforeAll(async () => {
     app = mm.cluster({ baseDir: getFixtures('dynamic-cluster'), workers: 2 });


### PR DESCRIPTION
pick from https://github.com/koajs/koa/pull/1908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redirect "back" now only honors same-origin absolute referrers and falls back safely for protocol-relative or unsafe referrers.

* **Tests**
  * Expanded redirect-back test coverage (origin validation, referer variations, host-context cases).
  * Marked flaky cluster tests to skip on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->