### PR TITLE
refactor: use definePluginFactory to export plugin config

### DIFF
--- a/packages/egg/src/config/plugin.ts
+++ b/packages/egg/src/config/plugin.ts
@@ -1,4 +1,15 @@
 import developmentPlugin from '@eggjs/development';
+import i18nPlugin from '@eggjs/i18n';
+import jsonpPlugin from '@eggjs/jsonp';
+import logrotatorPlugin from '@eggjs/logrotator';
+import multipartPlugin from '@eggjs/multipart';
+import onerrorPlugin from '@eggjs/onerror';
+import schedulePlugin from '@eggjs/schedule';
+import securityPlugin from '@eggjs/security';
+import sessionPlugin from '@eggjs/session';
+import staticPlugin from '@eggjs/static';
+import viewPlugin from '@eggjs/view';
+import watcherPlugin from '@eggjs/watcher';
 
 import type { EggPluginItem } from '../index.ts';
 
@@ -10,10 +21,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @member {Object} Plugin#onerror
    * @property {Boolean} enable - `true` by default
    */
-  onerror: {
-    enable: true,
-    package: '@eggjs/onerror',
-  },
+  ...onerrorPlugin(),
 
   /**
    * session
@@ -21,10 +29,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  session: {
-    enable: true,
-    package: '@eggjs/session',
-  },
+  ...sessionPlugin(),
 
   /**
    * i18n
@@ -32,10 +37,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  i18n: {
-    enable: true,
-    package: '@eggjs/i18n',
-  },
+  ...i18nPlugin(),
 
   /**
    * file and dir watcher
@@ -43,10 +45,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  watcher: {
-    enable: true,
-    package: '@eggjs/watcher',
-  },
+  ...watcherPlugin(),
 
   /**
    * multipart
@@ -54,10 +53,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  multipart: {
-    enable: true,
-    package: '@eggjs/multipart',
-  },
+  ...multipartPlugin(),
 
   /**
    * security middlewares and extends
@@ -65,10 +61,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  security: {
-    enable: true,
-    package: '@eggjs/security',
-  },
+  ...securityPlugin(),
 
   ...developmentPlugin(),
 
@@ -78,10 +71,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  logrotator: {
-    enable: true,
-    package: '@eggjs/logrotator',
-  },
+  ...logrotatorPlugin(),
 
   /**
    * schedule tasks
@@ -89,10 +79,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 2.7.0
    */
-  schedule: {
-    enable: true,
-    package: '@eggjs/schedule',
-  },
+  ...schedulePlugin(),
 
   /**
    * `app/public` dir static serve
@@ -100,10 +87,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  static: {
-    enable: true,
-    package: '@eggjs/static',
-  },
+  ...staticPlugin(),
 
   /**
    * jsonp support for egg
@@ -111,10 +95,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  jsonp: {
-    enable: true,
-    package: '@eggjs/jsonp',
-  },
+  ...jsonpPlugin(),
 
   /**
    * view plugin
@@ -122,10 +103,7 @@ const plugins: Record<string, EggPluginItem> = {
    * @property {Boolean} enable - `true` by default
    * @since 1.0.0
    */
-  view: {
-    enable: true,
-    package: '@eggjs/view',
-  },
+  ...viewPlugin(),
 
   // tegg plugins
   teggConfig: {

--- a/packages/egg/src/lib/types.plugin.ts
+++ b/packages/egg/src/lib/types.plugin.ts
@@ -1,18 +1,3 @@
-// import plugin types only, avoid circular dependency
-
-// import '@eggjs/development/types';
-import '@eggjs/i18n/types';
-import '@eggjs/jsonp/types';
-import '@eggjs/logrotator/types';
-import '@eggjs/multipart/types';
-import '@eggjs/onerror/types';
-import '@eggjs/schedule/types';
-import '@eggjs/security/types';
-import '@eggjs/session/types';
-import '@eggjs/static/types';
-import '@eggjs/view/types';
-import '@eggjs/watcher/types';
-
 // enable tegg plugin types
 import '@eggjs/ajv-plugin/types';
 import '@eggjs/aop-plugin/types';

--- a/packages/egg/src/lib/types.plugin.ts
+++ b/packages/egg/src/lib/types.plugin.ts
@@ -1,3 +1,18 @@
+// enable built-in plugin types, let type check pass, e.g.: `agent.watcher`
+
+import '@eggjs/development/types';
+import '@eggjs/i18n/types';
+import '@eggjs/jsonp/types';
+import '@eggjs/logrotator/types';
+import '@eggjs/multipart/types';
+import '@eggjs/onerror/types';
+import '@eggjs/schedule/types';
+import '@eggjs/security/types';
+import '@eggjs/session/types';
+import '@eggjs/static/types';
+import '@eggjs/view/types';
+import '@eggjs/watcher/types';
+
 // enable tegg plugin types
 import '@eggjs/ajv-plugin/types';
 import '@eggjs/aop-plugin/types';

--- a/packages/egg/test/lib/core/loader/load_plugin.test.ts
+++ b/packages/egg/test/lib/core/loader/load_plugin.test.ts
@@ -59,8 +59,10 @@ describe('test/lib/core/loader/load_plugin.test.ts', () => {
     if (process.platform !== 'win32') {
       assert.match(appLoader.plugins.onerror.path!, /\/onerror\//);
     }
-    assert.equal(appLoader.plugins.onerror.package, '@eggjs/onerror');
-    assert.match(appLoader.plugins.onerror.version!, /\d+\.\d+\.\d+/);
+    assert.equal(appLoader.plugins.onerror.package, undefined);
+    assert.equal(appLoader.plugins.onerror.version, undefined);
+    // assert.equal(appLoader.plugins.onerror.package, '@eggjs/onerror');
+    // assert.match(appLoader.plugins.onerror.version!, /\d+\.\d+\.\d+/);
     assert(Array.isArray(appLoader.orderPlugins));
   });
 

--- a/packages/egg/test/lib/core/loader/load_plugin.test.ts
+++ b/packages/egg/test/lib/core/loader/load_plugin.test.ts
@@ -61,6 +61,7 @@ describe('test/lib/core/loader/load_plugin.test.ts', () => {
     }
     assert.equal(appLoader.plugins.onerror.package, undefined);
     assert.equal(appLoader.plugins.onerror.version, undefined);
+    assert.equal(appLoader.plugins.onerror.skipMerge, true);
     // assert.equal(appLoader.plugins.onerror.package, '@eggjs/onerror');
     // assert.match(appLoader.plugins.onerror.version!, /\d+\.\d+\.\d+/);
     assert(Array.isArray(appLoader.orderPlugins));

--- a/plugins/development/README.md
+++ b/plugins/development/README.md
@@ -17,10 +17,6 @@ This is an egg plugin for local development, under development environment enabl
 
 `@eggjs/development` has been built-in for egg. It is enabled by default.
 
-## Requirements
-
-- egg >= 4.x
-
 ## Configuration
 
 see [config/config.default.ts](https://github.com/eggjs/egg/blob/master/plugins/development/src/config/config.default.ts) for more detail.

--- a/plugins/development/src/index.ts
+++ b/plugins/development/src/index.ts
@@ -1,6 +1,6 @@
-import { definePluginFactory, type EggPluginFactory } from 'egg';
-
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
 
 /**
  * Local development plugin, only enabled in `local` environment.

--- a/plugins/i18n/README.md
+++ b/plugins/i18n/README.md
@@ -23,17 +23,7 @@
 
 ## 配置
 
-默认处于关闭状态，你需要在 `config/plugin.ts` 开启它：
-
-```ts
-// config/plugin.ts
-export default {
-  i18n: {
-    enable: true,
-    package: '@eggjs/i18n',
-  },
-};
-```
+egg 内置插件 `i18n` 默认开启。
 
 你可以修改 `config/config.default.ts` 来设定 i18n 的配置项：
 
@@ -42,7 +32,7 @@ export default {
 export default {
   i18n: {
     // 默认语言，默认 "en_US"
-    defaultLocale: 'zh-CN',
+    defaultLocale: 'zh_CN',
     // URL 参数，默认 "locale"
     queryField: 'locale',
     // Cookie 记录的 key, 默认："locale"
@@ -114,6 +104,20 @@ export default ctx => {
     user: ctx.user,
   };
 };
+```
+
+### HttpController 下的使用示例
+
+```ts
+import { HTTPController, HTTPMethod, HTTPMethodEnum, HTTPContext, Context } from 'egg';
+
+@HTTPController()
+export default class I18nController {
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/i18n' })
+  async getI18n(@HTTPContext() ctx: Context) {
+    return { message: ctx.__('Welcome back, %s!', ctx.user.name) };
+  }
+}
 ```
 
 ### View 文件下的使用示例

--- a/plugins/i18n/package.json
+++ b/plugins/i18n/package.json
@@ -2,9 +2,6 @@
   "name": "@eggjs/i18n",
   "version": "4.0.0-beta.33",
   "description": "i18n plugin for egg",
-  "eggPlugin": {
-    "name": "i18n"
-  },
   "keywords": [
     "egg",
     "egg-plugin",

--- a/plugins/i18n/src/index.ts
+++ b/plugins/i18n/src/index.ts
@@ -1,4 +1,23 @@
-import './config/config.default.ts';
-import './app/extend/context.ts';
-import './app/extend/application.ts';
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * I18n plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import i18nPlugin from '@eggjs/i18n';
+ *
+ * export default {
+ *   ...i18nPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'i18n',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;

--- a/plugins/jsonp/README.md
+++ b/plugins/jsonp/README.md
@@ -15,17 +15,9 @@
 
 An egg plugin for jsonp support.
 
-## Requirements
-
-- egg >= 4.x
-
-## Install
-
-```bash
-npm i @eggjs/jsonp
-```
-
 ## Usage
+
+egg built-in plugin `jsonp` is enabled by default.
 
 ```ts
 // {app_root}/config/plugin.ts
@@ -33,7 +25,6 @@ npm i @eggjs/jsonp
 export default {
   jsonp: {
     enable: true,
-    package: '@eggjs/jsonp',
   },
 };
 ```
@@ -109,6 +100,8 @@ see [config/config.default.ts](https://github.com/eggjs/egg/blob/master/plugins/
 
 ## Example
 
+### Standard Application Usage
+
 In `app/router.ts`
 
 ```ts
@@ -121,6 +114,10 @@ app.get('/another', jsonp, 'jsonp.another');
 // Customize by create another jsonp middleware with specific configurations.
 app.get('/customize', app.jsonp({ callback: 'fn' }), 'jsonp.customize');
 ```
+
+### tegg HttpController Usage
+
+TODO: TBD
 
 ## Questions & Suggestions
 

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -29,12 +29,6 @@
     "dist"
   ],
   "description": "jsonp support for egg",
-  "eggPlugin": {
-    "name": "jsonp",
-    "optionalDependencies": [
-      "security"
-    ]
-  },
   "keywords": [
     "egg",
     "egg-plugin",

--- a/plugins/jsonp/src/index.ts
+++ b/plugins/jsonp/src/index.ts
@@ -1,1 +1,24 @@
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * JSONP plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import jsonpPlugin from '@eggjs/jsonp';
+ *
+ * export default {
+ *   ...jsonpPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'jsonp',
+  enable: true,
+  path: import.meta.dirname,
+  optionalDependencies: ['security'],
+}) as EggPluginFactory;

--- a/plugins/logrotator/README.md
+++ b/plugins/logrotator/README.md
@@ -13,36 +13,25 @@
 
 LogRotator for egg. Rotate all file of `app.loggers` by default
 
-## Install
-
-```bash
-npm i @eggjs/logrotator
-```
+egg built-in plugin `logrotator` is enabled by default.
 
 ## Usage
 
-- `plugin.js`
+- `config/config.default.ts`
 
-```js
-exports.logrotator = {
-  enable: true,
-  package: '@eggjs/logrotator',
-};
-```
-
-- `config.default.js`
-
-```js
+```ts
 // if any files need rotate by file size, config here
-exports.logrotator = {
-  filesRotateByHour: [], // list of files that will be rotated by hour
-  hourDelimiter: '-', // rotate the file by hour use specified delimiter
-  filesRotateBySize: [], // list of files that will be rotated by size
-  maxFileSize: 50 * 1024 * 1024, // Max file size to judge if any file need rotate
-  maxFiles: 10, // pieces rotate by size
-  rotateDuration: 60000, // time interval to judge if any file need rotate
-  maxDays: 31, // keep max days log files, default is `31`. Set `0` to keep all logs
-  gzip: false, // use gzip compress logger on rotate file, default is `false`. Set `true` to enable
+export default {
+  logrotator: {
+    filesRotateByHour: [], // list of files that will be rotated by hour
+    hourDelimiter: '-', // rotate the file by hour use specified delimiter
+    filesRotateBySize: [], // list of files that will be rotated by size
+    maxFileSize: 50 * 1024 * 1024, // Max file size to judge if any file need rotate
+    maxFiles: 10, // pieces rotate by size
+    rotateDuration: 60000, // time interval to judge if any file need rotate
+    maxDays: 31, // keep max days log files, default is `31`. Set `0` to keep all logs
+    gzip: false, // use gzip compress logger on rotate file, default is `false`. Set `true` to enable
+  },
 };
 ```
 
@@ -72,9 +61,9 @@ If `file` is relative path, then will normalize to `path.join(this.app.config.lo
 
 You can use `app.LogRotator` to customize.
 
-```js
-// app/schedule/custom.js
-module.exports = app => {
+```ts
+// app/schedule/custom.ts
+export default (app: Application) => {
   const rotator = getRotator(app);
   return {
     // https://github.com/eggjs/egg-schedule
@@ -88,7 +77,7 @@ module.exports = app => {
   };
 };
 
-function getRotator(app) {
+function getRotator(app: Application) {
   class CustomRotator extends app.LogRotator {
     // return map that contains a pair of srcPath and targetPath
     // LogRotator will rename ksrcPath to targetPath

--- a/plugins/logrotator/README.zh-CN.md
+++ b/plugins/logrotator/README.zh-CN.md
@@ -15,12 +15,6 @@ egg 的日志切割插件，默认会按照时间切割所有的 app.loggers。
 
 ## 配置
 
-- `plugin.js`
-
-```js
-exports.logrotator = true;
-```
-
 - `config.default.js`
 
 ```js

--- a/plugins/logrotator/package.json
+++ b/plugins/logrotator/package.json
@@ -2,12 +2,6 @@
   "name": "@eggjs/logrotator",
   "version": "5.0.0-beta.33",
   "description": "logrotator for egg",
-  "eggPlugin": {
-    "name": "logrotator",
-    "dependencies": [
-      "schedule"
-    ]
-  },
   "keywords": [
     "egg",
     "eggPlugin",

--- a/plugins/logrotator/src/index.ts
+++ b/plugins/logrotator/src/index.ts
@@ -1,5 +1,26 @@
-import './config/config.default.ts';
-import './app/extend/application.ts';
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * LogRotator plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import logrotatorPlugin from '@eggjs/logrotator';
+ *
+ * export default {
+ *   ...logrotatorPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'logrotator',
+  enable: true,
+  path: import.meta.dirname,
+  dependencies: ['schedule'],
+}) as EggPluginFactory;
 
 export * from './lib/rotator.ts';

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -1,13 +1,7 @@
 {
   "name": "@eggjs/multipart",
   "version": "5.0.0-beta.33",
-  "description": "multipart plugin for egg",
-  "eggPlugin": {
-    "name": "multipart",
-    "optionalDependencies": [
-      "schedule"
-    ]
-  },
+  "description": "Multipart plugin for egg",
   "keywords": [
     "egg",
     "egg-plugin",

--- a/plugins/multipart/src/index.ts
+++ b/plugins/multipart/src/index.ts
@@ -1,3 +1,24 @@
-import './config/config.default.ts';
-import './app/extend/context.ts';
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * Multipart plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import multipartPlugin from '@eggjs/multipart';
+ *
+ * export default {
+ *   ...multipartPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'multipart',
+  enable: true,
+  path: import.meta.dirname,
+  optionalDependencies: ['schedule'],
+}) as EggPluginFactory;

--- a/plugins/onerror/README.md
+++ b/plugins/onerror/README.md
@@ -16,15 +16,9 @@
 
 Default error handling plugin for egg.
 
-## Install
-
-```bash
-npm i @eggjs/onerror
-```
-
 ## Usage
 
-`egg-onerror` is on by default in egg. But you still can configure its properties to fits your scenarios.
+`onerror` plugin is enabled by default in egg. But you still can configure its properties to fits your scenarios.
 
 - `errorPageUrl: String or Function` - If user request html pages in production environment and unexpected error happened, it will redirect user to `errorPageUrl`.
 - `accepts: Function` - detect user's request accept `json` or `html`.
@@ -34,12 +28,16 @@ npm i @eggjs/onerror
 - `json: Function` - customize json error handler.
 - `jsonp: Function` - customize jsonp error handler.
 
-```js
-// config.default.js
-// errorPageUrl support function
-exports.onerror = {
-  errorPageUrl: (err, ctx) => ctx.errorPageUrl || '/500',
-};
+```ts
+// config/config.default.ts
+import { defineConfig } from 'egg';
+
+export default defineConfig({
+  onerror: {
+    // errorPageUrl support function
+    errorPageUrl: (err, ctx) => ctx.errorPageUrl || '/500',
+  },
+});
 
 // an accept detect function that mark all request with `x-requested-with=XMLHttpRequest` header accepts json.
 function accepts(ctx) {

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -15,12 +15,6 @@
     }
   },
   "description": "error handler for egg",
-  "eggPlugin": {
-    "name": "onerror",
-    "optionalDependencies": [
-      "jsonp"
-    ]
-  },
   "homepage": "https://github.com/eggjs/egg/tree/next/plugins/onerror",
   "repository": {
     "type": "git",

--- a/plugins/onerror/src/index.ts
+++ b/plugins/onerror/src/index.ts
@@ -1,1 +1,24 @@
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * Onerror plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import onerrorPlugin from '@eggjs/onerror';
+ *
+ * export default {
+ *   ...onerrorPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'onerror',
+  enable: true,
+  path: import.meta.dirname,
+  optionalDependencies: ['jsonp'],
+}) as EggPluginFactory;

--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -36,12 +36,11 @@ If you want to know specific usage, you should refer to the document of [ioredis
 Change `${app_root}/config/plugin.ts` to enable redis plugin:
 
 ```ts
+import redisPlugin from '@eggjs/redis';
+
 export default {
-  redis: {
-    enable: true,
-    package: '@eggjs/redis',
-  },
-};
+  ...redisPlugin(),
+});
 ```
 
 Configure redis information in `${app_root}/config/config.default.ts`:

--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -40,7 +40,7 @@ import redisPlugin from '@eggjs/redis';
 
 export default {
   ...redisPlugin(),
-});
+};
 ```
 
 Configure redis information in `${app_root}/config/config.default.ts`:

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -3,9 +3,6 @@
   "version": "4.0.0-beta.33",
   "description": "Valkey / Redis plugin for egg",
   "type": "module",
-  "eggPlugin": {
-    "name": "redis"
-  },
   "exports": {
     ".": "./src/index.ts",
     "./agent": "./src/agent.ts",

--- a/plugins/redis/src/index.ts
+++ b/plugins/redis/src/index.ts
@@ -1,1 +1,23 @@
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * Redis plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import redisPlugin from '@eggjs/redis';
+ *
+ * export default {
+ *   ...redisPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'redis',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -27,9 +27,6 @@
     "node": ">=22.18.0"
   },
   "description": "schedule plugin for egg, support corn job.",
-  "eggPlugin": {
-    "name": "schedule"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/eggjs/egg.git",

--- a/plugins/schedule/src/index.ts
+++ b/plugins/schedule/src/index.ts
@@ -1,5 +1,7 @@
 import './types.ts';
 
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
 import Agent from './app/extend/agent.ts';
 import Application from './app/extend/application.ts';
 import ApplicationUnittest from './app/extend/application.unittest.ts';
@@ -9,3 +11,9 @@ export { ScheduleWorker } from './lib/schedule_worker.ts';
 export { Scheduler } from './lib/schedule.ts';
 
 export * from './lib/types.ts';
+
+export default definePluginFactory({
+  name: 'schedule',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;

--- a/plugins/schedule/src/types.ts
+++ b/plugins/schedule/src/types.ts
@@ -8,7 +8,7 @@ declare module 'egg' {
   interface EggAppConfig {
     /**
      * Schedule Config
-     * @see https://www.eggjs.org/zh-CN/basics/schedule
+     * @see https://eggjs.org/basics/schedule
      */
     schedule: EggScheduleConfig;
   }

--- a/plugins/security/README.md
+++ b/plugins/security/README.md
@@ -16,12 +16,6 @@
 
 Egg's default security plugin, generally no need to configure.
 
-## Install
-
-```bash
-npm i @eggjs/security
-```
-
 ## Usage & configuration
 
 - `config.default.js`

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -44,12 +44,6 @@
     }
   },
   "description": "security plugin in egg framework",
-  "eggPlugin": {
-    "name": "security",
-    "optionalDependencies": [
-      "session"
-    ]
-  },
   "keywords": [
     "egg",
     "eggPlugin",

--- a/plugins/security/src/index.ts
+++ b/plugins/security/src/index.ts
@@ -1,4 +1,24 @@
-import './app/extend/application.ts';
-import './app/extend/context.ts';
-import './app/extend/response.ts';
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * Security plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import securityPlugin from '@eggjs/security';
+ *
+ * export default {
+ *   ...securityPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'security',
+  enable: true,
+  path: import.meta.dirname,
+  optionalDependencies: ['session'],
+}) as EggPluginFactory;

--- a/plugins/security/vitest.config.ts
+++ b/plugins/security/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, type UserWorkspaceConfig } from 'vitest/config';
 const config: UserWorkspaceConfig = defineConfig({
   test: {
     hookTimeout: 20000,
+    testTimeout: 20000,
     include: ['test/**/*.test.ts'],
   },
 });

--- a/plugins/session/README.md
+++ b/plugins/session/README.md
@@ -16,15 +16,9 @@
 
 Session plugin for egg, based on [koa-session](https://github.com/koajs/session).
 
-## Install
-
-```bash
-npm i @eggjs/session
-```
-
 ## Usage
 
-egg-session is a built-in plugin in egg and enabled by default.
+`session` is a built-in plugin in egg and enabled by default.
 
 ```js
 // {app_root}/config/plugin.js

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -2,9 +2,6 @@
   "name": "@eggjs/session",
   "version": "5.0.0-beta.33",
   "description": "session plugin for egg",
-  "eggPlugin": {
-    "name": "session"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/eggjs/egg.git",

--- a/plugins/session/src/index.ts
+++ b/plugins/session/src/index.ts
@@ -1,5 +1,11 @@
-import './config/config.default.ts';
-import './app/extend/application.ts';
 import './types.ts';
 
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
 export * from './config/config.default.ts';
+
+export default definePluginFactory({
+  name: 'session',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;

--- a/plugins/static/package.json
+++ b/plugins/static/package.json
@@ -14,9 +14,6 @@
     }
   },
   "description": "static server plugin for egg",
-  "eggPlugin": {
-    "name": "static"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/eggjs/egg.git",

--- a/plugins/static/src/index.ts
+++ b/plugins/static/src/index.ts
@@ -1,1 +1,23 @@
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * Static file serve plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import staticPlugin from '@eggjs/static';
+ *
+ * export default {
+ *   ...staticPlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'static',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;

--- a/plugins/typebox-validate/README.md
+++ b/plugins/typebox-validate/README.md
@@ -105,27 +105,20 @@ export default HomeController;
 
 1. 安装
 
-针对 `egg@4.x` 及以上版本，使用
-
 ```js
-npm i @eggjs/typebox-validate -S
+npm i @eggjs/typebox-validate
 ```
 
-针对 `egg@3.x` 版本，使用
-
-```js
-npm i egg-typebox-validate@3 -S
-```
+> 针对 `egg@3.x` 版本，请移步 https://github.com/eggjs-community/egg-typebox-validate
 
 1. 在项目中配置
 
 ```js
 // config/plugin.ts
-const plugin: EggPlugin = {
-  typeboxValidate: {
-    enable: true,
-    package: '@eggjs/typebox-validate',
-  },
+import typeboxValidatePlugin from '@eggjs/typebox-validate';
+
+export default {
+  ...typeboxValidatePlugin(),
 };
 ```
 

--- a/plugins/typebox-validate/package.json
+++ b/plugins/typebox-validate/package.json
@@ -3,9 +3,6 @@
   "version": "4.0.0-beta.33",
   "description": "another validate for typescript egg projects",
   "type": "module",
-  "eggPlugin": {
-    "name": "typeboxValidate"
-  },
   "exports": {
     ".": "./src/index.ts",
     "./app": "./src/app.ts",

--- a/plugins/typebox-validate/src/index.ts
+++ b/plugins/typebox-validate/src/index.ts
@@ -1,3 +1,24 @@
 import './types.ts';
 
 export { Ajv2019 as Ajv } from 'ajv/dist/2019.js';
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * Typebox validate plugin
+ *
+ * @since 4.1.0
+ * Usage:
+ * ```ts
+ * // config/plugin.ts
+ * import typeboxValidatePlugin from '@eggjs/typebox-validate';
+ *
+ * export default {
+ *   ...typeboxValidatePlugin(),
+ * };
+ * ```
+ */
+export default definePluginFactory({
+  name: 'typeboxValidate',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;

--- a/plugins/view-nunjucks/README.md
+++ b/plugins/view-nunjucks/README.md
@@ -17,8 +17,6 @@
 
 ```bash
 npm install @eggjs/view-nunjucks
-pnpm add @eggjs/view-nunjucks
-yarn add @eggjs/view-nunjucks
 ```
 
 ## Usage
@@ -26,11 +24,10 @@ yarn add @eggjs/view-nunjucks
 Enable plugin in `config/plugin.ts`
 
 ```ts
+import nunjucksPlugin from '@eggjs/view-nunjucks';
+
 export default {
-  nunjucks: {
-    enable: true,
-    package: '@eggjs/view-nunjucks',
-  },
+  ...nunjucksPlugin(),
 };
 ```
 

--- a/plugins/view-nunjucks/package.json
+++ b/plugins/view-nunjucks/package.json
@@ -44,13 +44,6 @@
     "test": "vitest run",
     "prepublishOnly": "pnpm run build"
   },
-  "eggPlugin": {
-    "name": "nunjucks",
-    "dep": [
-      "security",
-      "view"
-    ]
-  },
   "keywords": [
     "egg",
     "eggPlugin",

--- a/plugins/view-nunjucks/src/index.ts
+++ b/plugins/view-nunjucks/src/index.ts
@@ -1,5 +1,14 @@
 import './types.ts';
 
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+export default definePluginFactory({
+  name: 'nunjucks',
+  enable: true,
+  path: import.meta.dirname,
+  dependencies: ['security', 'view'],
+}) as EggPluginFactory;
+
 export { NunjucksEnvironment } from './lib/environment.ts';
 export { NunjucksFileLoader } from './lib/file_loader.ts';
 export { createHelper } from './lib/helper.ts';

--- a/plugins/view-nunjucks/test/__snapshots__/index.test.ts.snap
+++ b/plugins/view-nunjucks/test/__snapshots__/index.test.ts.snap
@@ -7,5 +7,6 @@ exports[`should exports keep stable 1`] = `
   "NunjucksView": [Function],
   "createEngine": [Function],
   "createHelper": [Function],
+  "default": [Function],
 }
 `;

--- a/plugins/view/package.json
+++ b/plugins/view/package.json
@@ -36,9 +36,6 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
-  "eggPlugin": {
-    "name": "view"
-  },
   "keywords": [
     "egg",
     "eggPlugin",

--- a/plugins/view/src/index.ts
+++ b/plugins/view/src/index.ts
@@ -1,6 +1,11 @@
-import './config/config.default.ts';
-import './app/extend/application.ts';
-import './app/extend/context.ts';
 import './types.ts';
+
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+export default definePluginFactory({
+  name: 'view',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;
 
 export * from './lib/index.ts';

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -22,9 +22,6 @@
     }
   },
   "description": "file watcher plugin for egg",
-  "eggPlugin": {
-    "name": "watcher"
-  },
   "scripts": {
     "lint": "oxlint --type-aware",
     "typecheck": "tsc --noEmit",

--- a/plugins/watcher/src/index.ts
+++ b/plugins/watcher/src/index.ts
@@ -1,4 +1,12 @@
 import './types.ts';
 
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+export default definePluginFactory({
+  name: 'watcher',
+  enable: true,
+  path: import.meta.dirname,
+}) as EggPluginFactory;
+
 export * from './lib/watcher.ts';
 export * from './lib/event-sources/index.ts';

--- a/plugins/watcher/test/__snapshots__/index.test.ts.snap
+++ b/plugins/watcher/test/__snapshots__/index.test.ts.snap
@@ -6,5 +6,6 @@ exports[`should exports work 1`] = `
   "DefaultEventSource",
   "DevelopmentEventSource",
   "Watcher",
+  "default",
 ]
 `;

--- a/site/docs/core/error-handling.md
+++ b/site/docs/core/error-handling.md
@@ -61,7 +61,7 @@ For convenience of locating problems, exceptions must be guaranteed to be Error 
 
 ## Egg Takes Charge of Exceptions
 
-[@eggjs/onerror](https://github.com/eggjs/onerror), one of Egg's plugin, handles all exceptions thrown in Middleware, Controller and Service, and returns the error as response based on "Accept" in request header field.
+[@eggjs/onerror](https://github.com/eggjs/egg/tree/next/plugins/onerror), one of Egg's plugin, handles all exceptions thrown in Middleware, Controller and Service, and returns the error as response based on "Accept" in request header field.
 
 | Accept       | ENV              | errorPageUrl | response                                             |
 | ------------ | ---------------- | ------------ | ---------------------------------------------------- |

--- a/site/docs/core/logger.md
+++ b/site/docs/core/logger.md
@@ -369,4 +369,4 @@ Generally, requests are frequent events to Web services, so writing logs into di
 
 > Logs will be firstly transferred into memory, and then Egg will asynchronously write them into files by second.
 
-More about [egg-logger](https://github.com/eggjs/egg-logger) and [@eggjs/logrotator](https://github.com/eggjs/logrotator)。
+More about [egg-logger](https://github.com/eggjs/egg-logger) and [@eggjs/logrotator](https://github.com/eggjs/egg/tree/next/plugins/logrotator)。

--- a/site/docs/zh-CN/core/error-handling.md
+++ b/site/docs/zh-CN/core/error-handling.md
@@ -58,7 +58,7 @@ class HomeController extends Controller {
 
 ## 框架层统一异常处理
 
-框架通过 [@eggjs/onerror](https://github.com/eggjs/onerror) 插件提供统一的错误处理机制。此机制将捕获所有处理方法（Middleware、Controller、Service）中抛出的任何异常，并根据请求预期的响应类型返回不同的错误内容。
+框架通过 [@eggjs/onerror](https://github.com/eggjs/egg/tree/next/plugins/onerror) 插件提供统一的错误处理机制。此机制将捕获所有处理方法（Middleware、Controller、Service）中抛出的任何异常，并根据请求预期的响应类型返回不同的错误内容。
 
 | 请求格式需求 | 环境             | `errorPageUrl` 配置 | 返回内容                              |
 | ------------ | ---------------- | ------------------- | ------------------------------------- |

--- a/site/docs/zh-CN/core/logger.md
+++ b/site/docs/zh-CN/core/logger.md
@@ -372,4 +372,4 @@ module.exports = (appInfo) => {
 
 > 日志同步写入内存，异步每隔一段时间（默认 1 秒）进行刷盘。
 
-更多细节，请参考 [egg-logger](https://github.com/eggjs/egg-logger) 和 [@eggjs/logrotator](https://github.com/eggjs/logrotator)。
+更多细节，请参考 [egg-logger](https://github.com/eggjs/egg-logger) 和 [@eggjs/logrotator](https://github.com/eggjs/egg/tree/next/plugins/logrotator)。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched many built-in plugins to a factory-based registration and added an environment flag to toggle a group of related plugins.

* **Documentation**
  * Updated READMEs and docs to reflect new plugin usage patterns, examples, and TypeScript configuration.

* **Tests**
  * Updated plugin tests to match changed plugin metadata/shape.

* **Chores**
  * Cleaned plugin manifests and standardized public plugin exports across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->