### PR TITLE
refactor(koa): use @eggjs/cookies instead of cookies

### DIFF
--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -40,12 +40,12 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "@eggjs/cookies": "workspace:*",
     "@types/content-disposition": "catalog:",
     "accepts": "catalog:",
     "cache-content-type": "catalog:",
     "content-disposition": "catalog:",
     "content-type": "catalog:",
-    "cookies": "catalog:",
     "destroy": "catalog:",
     "encodeurl": "catalog:",
     "escape-html": "catalog:",
@@ -64,7 +64,6 @@
     "@eggjs/supertest": "workspace:*",
     "@types/accepts": "catalog:",
     "@types/content-type": "catalog:",
-    "@types/cookies": "catalog:",
     "@types/destroy": "catalog:",
     "@types/encodeurl": "catalog:",
     "@types/escape-html": "catalog:",

--- a/packages/koa/src/context.ts
+++ b/packages/koa/src/context.ts
@@ -2,8 +2,8 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ParsedUrlQuery } from 'node:querystring';
 import util from 'node:util';
 
+import { Cookies } from '@eggjs/cookies';
 import type { Accepts } from 'accepts';
-import Cookies from 'cookies';
 import createError from 'http-errors';
 import statuses from 'statuses';
 
@@ -223,8 +223,8 @@ export class Context {
 
   get cookies() {
     if (!this._cookies) {
-      this._cookies = new Cookies(this.req, this.res, {
-        keys: this.app.keys,
+      // FIXME: keys is required for encrypt/sign cookies
+      this._cookies = new Cookies(this, this.app.keys ?? [], {
         secure: this.request.secure,
       });
     }

--- a/packages/koa/test/context/cookies.test.ts
+++ b/packages/koa/test/context/cookies.test.ts
@@ -8,7 +8,9 @@ import Koa, { type Context } from '../../src/index.ts';
 describe('ctx.cookies', () => {
   describe('ctx.cookies.set()', () => {
     it('should set an unsigned cookie', async () => {
-      const app = new Koa();
+      const app = new Koa({
+        keys: ['a', 'b'],
+      });
 
       app.use((ctx: Context) => {
         ctx.cookies.set('name', 'jon');
@@ -40,7 +42,7 @@ describe('ctx.cookies', () => {
           }
         });
 
-        return request(app.callback()).get('/').expect('.keys required for signed cookies');
+        return request(app.callback()).get('/').expect('keys must be provided and should be an array');
       });
 
       it('should send a signed cookie', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ catalogs:
     '@types/cookie-parser':
       specifier: ^1.4.8
       version: 1.4.9
-    '@types/cookies':
-      specifier: ^0.9.0
-      version: 0.9.1
     '@types/cross-spawn':
       specifier: ^6.0.6
       version: 6.0.6
@@ -1123,6 +1120,9 @@ importers:
 
   packages/koa:
     dependencies:
+      '@eggjs/cookies':
+        specifier: workspace:*
+        version: link:../cookies
       '@types/content-disposition':
         specifier: 'catalog:'
         version: 0.5.9
@@ -1138,9 +1138,6 @@ importers:
       content-type:
         specifier: 'catalog:'
         version: 1.0.5
-      cookies:
-        specifier: 'catalog:'
-        version: 0.9.1
       destroy:
         specifier: 'catalog:'
         version: 1.2.0
@@ -1190,9 +1187,6 @@ importers:
       '@types/content-type':
         specifier: 'catalog:'
         version: 1.1.9
-      '@types/cookies':
-        specifier: 'catalog:'
-        version: 0.9.1
       '@types/destroy':
         specifier: 'catalog:'
         version: 1.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
 catalog:
   '@clack/prompts': ^0.11.0
   '@eggjs/compressible': ^3.0.0
+  '@eggjs/cookies': ^3.1.0
   '@eggjs/ip': ^2.1.0
   '@eggjs/rds': ^1.3.0
   '@eggjs/redis': ^3.0.0


### PR DESCRIPTION
close https://github.com/eggjs/egg/issues/5735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Koa constructor now accepts an optional options object to configure cookie signing keys: `new Koa({ keys: [...] })`
  * Koa instances now expose a public `keys` property for accessing signing key configuration

* **Changes**
  * Updated error message validation for cookie signing configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->