### PR TITLE
feat(skills): add eval framework for skill routing and quality assess…

### DIFF
--- a/packages/skills/PLAN.md
+++ b/packages/skills/PLAN.md
@@ -1,0 +1,396 @@
+# Skills 评测方案设计
+
+## 目标
+
+为 `packages/skills/` 设计一套评测体系，覆盖两个层面：
+
+1. **静态校验** — 验证 Skill 文件的结构正确性、引用完整性
+2. **动态评测** — 用 LLM-as-Judge 评估 AI 基于 Skill 生成回答的质量
+
+全部手动触发运行，不集成 CI。
+
+---
+
+## 目录结构
+
+```
+packages/skills/
+├── egg/
+├── controller/
+├── tegg-core/
+├── eval/                          # 新增：评测目录
+│   ├── static/
+│   │   └── validate.test.ts       # 静态校验测试
+│   ├── dynamic/
+│   │   ├── routing.eval.ts        # 入口路由评测
+│   │   └── quality.eval.ts        # 内容质量评测
+│   ├── fixtures/
+│   │   ├── routing-cases.ts       # 路由测试用例
+│   │   └── quality-cases.ts       # 质量测试用例
+│   └── lib/
+│       ├── skill-loader.ts        # Skill 文件加载器
+│       ├── judge.ts               # LLM-as-Judge 核心逻辑
+│       └── types.ts               # 共享类型定义
+├── vitest.config.ts
+├── package.json
+└── tsconfig.json
+```
+
+---
+
+## 第一部分：静态校验
+
+### 校验项
+
+| 校验项               | 说明                                                          |
+| -------------------- | ------------------------------------------------------------- |
+| **Frontmatter 格式** | 每个 SKILL.md 必须包含 `name`、`description`、`allowed-tools` |
+| **引用文件存在性**   | SKILL.md 中提到的 `references/*.md` 文件必须存在              |
+| **交叉引用一致性**   | 入口 skill 提到的子 skill 目录必须存在且包含 SKILL.md         |
+| **Markdown 结构**    | 标题层级合理（以 `# ` 开头，不跳级）                          |
+| **决策表完整性**     | 入口 skill 的路由表中每个 skill 都有对应目录                  |
+
+### 实现方式
+
+使用 vitest + node:assert 编写测试，通过 Node.js fs API 读取文件并解析：
+
+```typescript
+// eval/static/validate.test.ts
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import { loadAllSkills } from '../lib/skill-loader.ts';
+
+describe('Skill 静态校验', () => {
+  describe('Frontmatter', () => {
+    it('每个 SKILL.md 包含必填字段: name, description, allowed-tools', ...);
+  });
+
+  describe('引用完整性', () => {
+    it('SKILL.md 中引用的 references/ 文件均存在', ...);
+    it('入口 skill 引用的子 skill 目录均存在', ...);
+  });
+
+  describe('Markdown 结构', () => {
+    it('标题层级不跳级', ...);
+  });
+});
+```
+
+---
+
+## 第二部分：动态评测（LLM-as-Judge）
+
+### 评测维度
+
+动态评测分为两个子场景：
+
+#### 2.1 路由评测 — 入口 Skill 是否正确路由
+
+测试 `egg/SKILL.md` 的决策逻辑：给定用户查询，判断 AI 是否路由到正确的子 skill。
+
+**测试用例结构：**
+
+```typescript
+// eval/fixtures/routing-cases.ts
+export const routingCases: RoutingCase[] = [
+  {
+    query: '如何创建 HTTP controller？',
+    expectedSkill: 'controller',
+    reason: '明确提到 controller，属于协议实现',
+  },
+  {
+    query: '@SingletonProto 和 @ContextProto 有什么区别？',
+    expectedSkill: 'tegg-core',
+    reason: '关于对象生命周期，属于核心概念',
+  },
+  {
+    query: '我需要创建一个可以被 HTTP 控制器使用的服务',
+    expectedSkill: 'tegg-core',
+    reason: '模糊意图，按规则 1（基础优先）应路由到 core',
+  },
+  // ... 更多用例
+];
+```
+
+**测试实现：**
+
+```typescript
+// eval/dynamic/routing.eval.ts
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import Anthropic from '@anthropic-ai/sdk';
+import { loadSkillContent } from '../lib/skill-loader.ts';
+import { routingCases } from '../fixtures/routing-cases.ts';
+
+const client = new Anthropic();
+const AVAILABLE_SKILLS = ['controller', 'tegg-core'];
+
+describe('路由评测', () => {
+  // 加载入口 skill 作为 system prompt
+  const entrySkillContent = loadSkillContent('egg');
+
+  for (const { query, expectedSkill, reason } of routingCases) {
+    it(`"${query}" → ${expectedSkill}`, async () => {
+      // 1. 将 SKILL.md 作为 system prompt，发送用户查询
+      const response = await client.messages.create({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 1024,
+        system: [
+          entrySkillContent,
+          // 约束输出格式，让 AI 只做路由决策
+          `你是 EGG 框架技能路由器。根据上面的决策指南，分析用户查询并选择应该加载的技能。`,
+          `可选技能: ${AVAILABLE_SKILLS.join(', ')}`,
+          `只输出 JSON: {"skill": "<技能名>", "reason": "<简要理由>"}`,
+        ].join('\n\n'),
+        messages: [{ role: 'user', content: query }],
+      });
+
+      // 2. 解析 AI 回答中的路由选择
+      const text = response.content[0].type === 'text' ? response.content[0].text : '';
+      const parsed = JSON.parse(text);
+
+      // 3. 断言路由正确性
+      assert.equal(parsed.skill, expectedSkill,
+        `路由错误: 期望 "${expectedSkill}" 但得到 "${parsed.skill}"` +
+        `\n  用例理由: ${reason}` +
+        `\n  AI 理由: ${parsed.reason}`
+      );
+    });
+  }
+});
+```
+
+#### 2.2 内容质量评测 — 子 Skill 回答质量
+
+测试各子 skill 对领域问题的回答质量。
+
+**测试用例结构：**
+
+```typescript
+// eval/fixtures/quality-cases.ts
+export const qualityCases: QualityCase[] = [
+  {
+    skill: 'controller',
+    query: '如何创建一个 POST 接口接收 JSON body？',
+    criteria: [
+      '使用 @HTTPController 装饰器',
+      '使用 @HTTPMethod 且 method 为 POST',
+      '使用 @HTTPBody() 获取请求体',
+      '包含完整可运行的代码示例',
+    ],
+    references: ['references/http-controller.md'],  // 需要加载的参考文档
+  },
+  {
+    skill: 'tegg-core',
+    query: '如何让一个服务可以被其他模块访问？',
+    criteria: [
+      '提到 AccessLevel.PUBLIC',
+      '使用 @SingletonProto 装饰器',
+      '解释跨模块访问机制',
+    ],
+    references: [],
+  },
+  // ... 更多用例
+];
+```
+
+**测试实现：**
+
+```typescript
+// eval/dynamic/quality.eval.ts
+import { describe, it } from 'vitest';
+import assert from 'node:assert/strict';
+import Anthropic from '@anthropic-ai/sdk';
+import { loadSkillContent, loadReference } from '../lib/skill-loader.ts';
+import { qualityCases } from '../fixtures/quality-cases.ts';
+import { judge } from '../lib/judge.ts';
+
+const client = new Anthropic();
+
+describe('内容质量评测', () => {
+  for (const testCase of qualityCases) {
+    describe(`[${testCase.skill}] ${testCase.query}`, () => {
+      let aiResponse: string;
+
+      // Step 1: 加载 skill 内容作为 system prompt，向被测 LLM 提问
+      it('生成回答', async () => {
+        const skillContent = loadSkillContent(testCase.skill);
+        const refContents = testCase.references
+          .map(ref => loadReference(testCase.skill, ref));
+
+        const systemPrompt = [skillContent, ...refContents].join('\n\n---\n\n');
+
+        const response = await client.messages.create({
+          model: 'claude-sonnet-4-20250514',
+          max_tokens: 2048,
+          system: systemPrompt,
+          messages: [{ role: 'user', content: testCase.query }],
+        });
+
+        aiResponse = response.content[0].type === 'text' ? response.content[0].text : '';
+        assert.ok(aiResponse.length > 0, 'AI 应该返回非空回答');
+      });
+
+      // Step 2: 用 Judge LLM 对回答逐项评分
+      it('通过质量评审', async () => {
+        const result = await judge(client, {
+          query: testCase.query,
+          response: aiResponse,
+          criteria: testCase.criteria,
+        });
+
+        // 输出详细评分到 console 供人工查看
+        console.log(`    得分: ${result.totalScore} (${result.passed}/${result.total})`);
+        for (const item of result.details) {
+          const icon = item.score === 1 ? '✓' : '✗';
+          console.log(`      ${icon} ${item.criterion}: ${item.reason}`);
+        }
+
+        // 断言：所有 criteria 都应满足
+        assert.ok(result.totalScore >= 0.8,
+          `质量不达标: ${result.totalScore} < 0.8\n` +
+          result.details
+            .filter(d => d.score === 0)
+            .map(d => `  ✗ ${d.criterion}: ${d.reason}`)
+            .join('\n')
+        );
+      });
+    });
+  }
+});
+```
+
+### LLM-as-Judge 实现
+
+```typescript
+// eval/lib/judge.ts
+import type Anthropic from '@anthropic-ai/sdk';
+import type { JudgeInput, JudgeResult, JudgeDetail } from './types.ts';
+
+export async function judge(
+  client: Anthropic,
+  input: JudgeInput,
+): Promise<JudgeResult> {
+  const criteriaList = input.criteria
+    .map((c, i) => `${i + 1}. ${c}`)
+    .join('\n');
+
+  const response = await client.messages.create({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 1024,
+    system: '你是 AI 回答质量评估专家。严格按照 JSON 格式输出评分结果。',
+    messages: [{
+      role: 'user',
+      content: `请根据评分标准，对以下 AI 回答逐项评分。
+
+## 评分标准
+${criteriaList}
+
+## 用户问题
+${input.query}
+
+## AI 回答
+${input.response}
+
+## 输出格式（严格 JSON）
+{
+  "details": [
+    { "criterion": "标准内容", "score": 0 或 1, "reason": "简要理由" }
+  ]
+}`,
+    }],
+  });
+
+  const text = response.content[0].type === 'text' ? response.content[0].text : '';
+  const parsed = JSON.parse(text);
+  const details: JudgeDetail[] = parsed.details;
+  const passed = details.filter(d => d.score === 1).length;
+
+  return {
+    details,
+    passed,
+    total: details.length,
+    totalScore: passed / details.length,
+  };
+}
+```
+
+### 评测报告
+
+运行评测后生成 JSON 报告：
+
+```json
+{
+  "timestamp": "2026-02-05T10:00:00Z",
+  "routing": {
+    "total": 10,
+    "correct": 9,
+    "accuracy": 0.9,
+    "failures": [
+      {
+        "query": "...",
+        "expected": "tegg-core",
+        "actual": "controller",
+        "reason": "..."
+      }
+    ]
+  },
+  "quality": {
+    "controller": {
+      "cases": 5,
+      "avg_score": 0.85,
+      "details": [...]
+    },
+    "tegg-core": {
+      "cases": 5,
+      "avg_score": 0.90,
+      "details": [...]
+    }
+  }
+}
+```
+
+---
+
+## 第三部分：技术选型与依赖
+
+| 组件                  | 选型               | 理由                           |
+| --------------------- | ------------------ | ------------------------------ |
+| 测试框架              | vitest             | 遵循 monorepo 标准             |
+| 断言库                | node:assert/strict | Node.js 内置，零依赖           |
+| YAML frontmatter 解析 | gray-matter        | 成熟的 frontmatter 解析库      |
+| LLM 调用              | @anthropic-ai/sdk  | 使用 Claude API 做评测和 Judge |
+| 报告输出              | JSON 文件          | 简单可读，方便后续扩展为可视化 |
+
+### package.json scripts
+
+```json
+{
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts eval/static/",
+    "eval": "vitest run --config vitest.config.ts eval/dynamic/",
+    "eval:routing": "vitest run --config vitest.config.ts eval/dynamic/routing.eval.ts",
+    "eval:quality": "vitest run --config vitest.config.ts eval/dynamic/quality.eval.ts"
+  }
+}
+```
+
+- `test` — 运行静态校验（快速，无 API 调用）
+- `eval` — 运行全部动态评测
+- `eval:routing` — 仅运行路由评测
+- `eval:quality` — 仅运行内容质量评测
+
+动态评测需设置 `ANTHROPIC_API_KEY` 环境变量。
+
+---
+
+## 实施步骤
+
+1. 在 worktree (`egg-skills-eval`) 中添加依赖：vitest、gray-matter、@anthropic-ai/sdk
+2. 添加 `vitest.config.ts` 和更新 `package.json` scripts
+3. 创建 `eval/lib/` 基础工具：skill-loader、types、judge
+4. 实现 `eval/static/validate.test.ts` 静态校验
+5. 编写路由测试用例 `eval/fixtures/routing-cases.ts`
+6. 实现 `eval/dynamic/routing.eval.ts` 路由评测
+7. 编写质量测试用例 `eval/fixtures/quality-cases.ts`
+8. 实现 `eval/dynamic/quality.eval.ts` 内容质量评测

--- a/packages/skills/eval/.gitignore
+++ b/packages/skills/eval/.gitignore
@@ -1,0 +1,1 @@
+workspace/

--- a/packages/skills/eval/dynamic/quality.eval.ts
+++ b/packages/skills/eval/dynamic/quality.eval.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+
+import { describe, it, beforeAll, afterAll } from 'vitest';
+
+import { qualityCases } from '../fixtures/quality-cases.ts';
+import { claudeChat } from '../lib/claude-cli.ts';
+import { judge } from '../lib/judge.ts';
+import { setupWorkspace, cleanWorkspace } from '../lib/setup.ts';
+
+describe('内容质量评测', () => {
+  beforeAll(() => {
+    setupWorkspace();
+  });
+
+  afterAll(() => {
+    cleanWorkspace();
+  });
+
+  for (const testCase of qualityCases) {
+    describe(`[${testCase.skill}] ${testCase.query}`, () => {
+      let aiResponse: string;
+
+      it('生成回答', async () => {
+        // 直接发送用户查询，skills 自然加载
+        aiResponse = await claudeChat(testCase.query);
+        assert.ok(aiResponse.length > 0, 'AI 应该返回非空回答');
+      });
+
+      it('通过质量评审', async () => {
+        const result = await judge({
+          query: testCase.query,
+          response: aiResponse,
+          criteria: testCase.criteria,
+        });
+
+        // 输出详细评分供人工查看
+        console.log(`    得分: ${result.totalScore} (${result.passed}/${result.total})`);
+        for (const item of result.details) {
+          const icon = item.score === 1 ? '  ✓' : '  ✗';
+          console.log(`    ${icon} ${item.criterion}: ${item.reason}`);
+        }
+
+        assert.ok(
+          result.totalScore >= 0.8,
+          `质量不达标: ${result.totalScore} < 0.8\n` +
+            result.details
+              .filter((d) => d.score === 0)
+              .map((d) => `  ✗ ${d.criterion}: ${d.reason}`)
+              .join('\n'),
+        );
+      });
+    });
+  }
+});

--- a/packages/skills/eval/dynamic/routing.eval.ts
+++ b/packages/skills/eval/dynamic/routing.eval.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+
+import { describe, it, beforeAll, afterAll } from 'vitest';
+
+import { routingCases } from '../fixtures/routing-cases.ts';
+import { claudeChat } from '../lib/claude-cli.ts';
+import { setupWorkspace, cleanWorkspace } from '../lib/setup.ts';
+
+const AVAILABLE_SKILLS = ['controller', 'tegg-core'];
+
+describe('路由评测', () => {
+  beforeAll(() => {
+    setupWorkspace();
+  });
+
+  afterAll(() => {
+    cleanWorkspace();
+  });
+
+  for (const { query, expectedSkill, reason } of routingCases) {
+    it(`"${query}" → ${expectedSkill}`, async () => {
+      // 通过 append-system-prompt 要求输出路由决策 JSON
+      // skills 会被 claude 自然发现和加载
+      const text = await claudeChat(query, {
+        appendSystemPrompt: [
+          '你需要根据已安装的 skills 决定使用哪个 skill 来回答用户问题。',
+          `可选技能: ${AVAILABLE_SKILLS.join(', ')}`,
+          '只输出 JSON: {"skill": "<技能名>", "reason": "<简要理由>"}，不要输出其他内容。',
+        ].join('\n'),
+      });
+
+      // 从 LLM 输出中提取第一个 JSON 对象，兼容裸 JSON、markdown 代码块、夹杂解释文字等情况
+      const match = text.match(/\{[\s\S]*\}/);
+      assert.ok(match, `未能从输出中提取 JSON:\n${text}`);
+
+      const parsed = JSON.parse(match[0]) as { skill: string; reason: string };
+
+      assert.equal(
+        parsed.skill,
+        expectedSkill,
+        `路由错误: 期望 "${expectedSkill}" 但得到 "${parsed.skill}"` +
+          `\n  用例理由: ${reason}` +
+          `\n  AI 理由: ${parsed.reason}`,
+      );
+    });
+  }
+});

--- a/packages/skills/eval/fixtures/quality-cases.ts
+++ b/packages/skills/eval/fixtures/quality-cases.ts
@@ -1,0 +1,57 @@
+import type { QualityCase } from '../lib/types.ts';
+
+export const qualityCases: QualityCase[] = [
+  // === controller skill ===
+  {
+    skill: 'controller',
+    query: '如何创建一个 POST 接口接收 JSON body？',
+    criteria: [
+      '使用 @HTTPController 装饰器',
+      '使用 @HTTPMethod 且 method 为 POST',
+      '使用 @HTTPBody() 获取请求体',
+      '包含完整可运行的代码示例',
+    ],
+    references: ['references/http-controller.md'],
+  },
+  {
+    skill: 'controller',
+    query: '如何从 URL 路径中获取参数？',
+    criteria: ['使用 @HTTPParam 装饰器', '展示路径中的参数定义（如 :id）', '包含代码示例'],
+    references: ['references/http-controller.md'],
+  },
+  {
+    skill: 'controller',
+    query: '如何实现 SSE 流式响应？',
+    criteria: [
+      '使用 HTTPController',
+      '涉及 Readable stream 或 async generator',
+      '设置正确的 content-type',
+      '包含代码示例',
+    ],
+    references: ['references/http-controller.md'],
+  },
+
+  // === tegg-core skill ===
+  {
+    skill: 'tegg-core',
+    query: '如何让一个服务可以被其他模块访问？',
+    criteria: ['提到 AccessLevel.PUBLIC', '使用 @SingletonProto 装饰器', '解释跨模块访问机制', '包含代码示例'],
+    references: [],
+  },
+  {
+    skill: 'tegg-core',
+    query: 'SingletonProto 和 ContextProto 应该怎么选？',
+    criteria: [
+      '解释 SingletonProto 是全局单例',
+      '解释 ContextProto 是每请求创建',
+      '给出选择建议（默认用 Singleton，需要请求隔离用 Context）',
+    ],
+    references: [],
+  },
+  {
+    skill: 'tegg-core',
+    query: '如何在 EGG 中定义一个模块？',
+    criteria: ['提到 package.json 中的 eggModule.name 字段', '说明模块名不能包含特殊字符', '包含 package.json 示例'],
+    references: [],
+  },
+];

--- a/packages/skills/eval/fixtures/routing-cases.ts
+++ b/packages/skills/eval/fixtures/routing-cases.ts
@@ -1,0 +1,69 @@
+import type { RoutingCase } from '../lib/types.ts';
+
+export const routingCases: RoutingCase[] = [
+  // === 明确的 controller 意图 ===
+  {
+    query: '如何创建 HTTP controller？',
+    expectedSkill: 'controller',
+    reason: '明确提到 controller，属于协议实现',
+  },
+  {
+    query: '如何创建返回 JSON 的 HTTP controller？',
+    expectedSkill: 'controller',
+    reason: '明确的 HTTP 协议实现',
+  },
+  {
+    query: '如何创建定时任务？',
+    expectedSkill: 'controller',
+    reason: 'schedule 属于控制器类型',
+  },
+  {
+    query: '如何实现 MCP tool？',
+    expectedSkill: 'controller',
+    reason: 'MCP 属于控制器类型',
+  },
+  {
+    query: 'How to create an API endpoint that accepts POST requests?',
+    expectedSkill: 'controller',
+    reason: '英文查询，API endpoint 属于 HTTP controller',
+  },
+
+  // === 明确的 core 意图 ===
+  {
+    query: '@SingletonProto 和 @ContextProto 有什么区别？',
+    expectedSkill: 'tegg-core',
+    reason: '关于对象生命周期，属于核心概念',
+  },
+  {
+    query: '如何在 EGG 中创建模块？',
+    expectedSkill: 'tegg-core',
+    reason: '模块架构是核心概念',
+  },
+  {
+    query: '如何注入服务？',
+    expectedSkill: 'tegg-core',
+    reason: '依赖注入是核心概念',
+  },
+  {
+    query: '如何访问其他模块的对象？',
+    expectedSkill: 'tegg-core',
+    reason: '跨模块访问（AccessLevel）是核心概念',
+  },
+  {
+    query: 'What is AccessLevel in TEGG?',
+    expectedSkill: 'tegg-core',
+    reason: '英文查询，AccessLevel 是核心概念',
+  },
+
+  // === 模糊意图（按规则应路由到 core） ===
+  {
+    query: '我需要创建一个可以被 HTTP 控制器使用的服务',
+    expectedSkill: 'tegg-core',
+    reason: '模糊意图，按规则 1（基础优先）应路由到 core',
+  },
+  {
+    query: '如何实现一个需要跨模块访问的服务？',
+    expectedSkill: 'tegg-core',
+    reason: '跨模块访问是核心概念，基础优先',
+  },
+];

--- a/packages/skills/eval/lib/claude-cli.ts
+++ b/packages/skills/eval/lib/claude-cli.ts
@@ -1,0 +1,117 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { EVAL_WORKSPACE } from './setup.ts';
+
+export interface ClaudeOptions {
+  /** 工作目录，默认使用评测工作区（有 skills 安装） */
+  cwd?: string;
+  /** 追加 system prompt（不覆盖默认 + skills） */
+  appendSystemPrompt?: string;
+  /** 指定模型 */
+  model?: string;
+  /** 最大输出 tokens */
+  maxTokens?: number;
+}
+
+function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+function spawnClaude(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'claude-eval-'));
+    const cleanup = (): void => {
+      try {
+        rmSync(tempDir, { recursive: true });
+      } catch {
+        /* ignore */
+      }
+    };
+
+    // 写一个 wrapper 脚本，避免 script 命令的 shell 转义问题
+    const cmdFile = join(tempDir, 'cmd.sh');
+    const escapedArgs = args.map(shellQuote).join(' ');
+    writeFileSync(cmdFile, `#!/bin/sh\nexec claude ${escapedArgs}\n`, { mode: 0o755 });
+
+    // 用 macOS `script -q` 分配真正的 PTY，让 claude 看到 isTTY=true
+    // 不能直接传 /dev/tty FD 给 stdio（Bun kqueue EINVAL），也不能纯 pipe（claude 需要 TTY）
+    const child = spawn('script', ['-q', '/dev/null', cmdFile], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let buffer = '';
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      // console.log(chunk.toString());
+      buffer += chunk.toString('utf-8');
+    });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      cleanup();
+      reject(new Error('claude process timed out after 300s'));
+    }, 300_000);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      cleanup();
+      reject(err);
+    });
+
+    child.on('close', () => {
+      clearTimeout(timer);
+      cleanup();
+      // script 退出时 PTY 会回显 ^D（EOF），过滤掉控制字符
+      // eslint-disable-next-line no-control-regex -- 需要过滤 PTY EOF 控制字符
+      const result = buffer.replace(/\x04/g, '').replace(/\^D/g, '').trim();
+      if (result) {
+        resolve(result);
+      } else {
+        reject(new Error('No result received from claude'));
+      }
+    });
+  });
+}
+
+/**
+ * 在评测工作区中调用 claude -p
+ * skills 通过 .claude/skills/ 目录自然发现和加载
+ */
+export async function claudeChat(userMessage: string, options: ClaudeOptions = {}): Promise<string> {
+  const args = ['-p'];
+
+  if (options.model) {
+    args.push('--model', options.model);
+  }
+
+  if (options.maxTokens) {
+    args.push('--max-tokens', String(options.maxTokens));
+  }
+
+  if (options.appendSystemPrompt) {
+    args.push('--append-system-prompt', options.appendSystemPrompt);
+  }
+
+  args.push(userMessage);
+
+  return spawnClaude(args, options.cwd ?? EVAL_WORKSPACE);
+}
+
+/**
+ * 纯净模式调用 claude -p（禁用 skills，用于 Judge 评分）
+ */
+export async function claudePlain(userMessage: string, systemPrompt?: string): Promise<string> {
+  const args = ['-p', '--disable-slash-commands'];
+
+  if (systemPrompt) {
+    args.push('--system-prompt', systemPrompt);
+  }
+
+  args.push(userMessage);
+
+  return spawnClaude(args, EVAL_WORKSPACE);
+}

--- a/packages/skills/eval/lib/judge.ts
+++ b/packages/skills/eval/lib/judge.ts
@@ -1,0 +1,47 @@
+import { claudePlain } from './claude-cli.ts';
+import type { JudgeInput, JudgeResult, JudgeDetail } from './types.ts';
+
+/**
+ * 使用 LLM-as-Judge 对 AI 回答进行逐项评分
+ * 通过 claudePlain（禁用 skills）调用，避免 skill 干扰评分
+ */
+export async function judge(input: JudgeInput): Promise<JudgeResult> {
+  const criteriaList = input.criteria.map((c, i) => `${i + 1}. ${c}`).join('\n');
+
+  const text = await claudePlain(
+    `请根据评分标准，对以下 AI 回答逐项评分。
+
+## 评分标准
+${criteriaList}
+
+## 用户问题
+${input.query}
+
+## AI 回答
+${input.response}
+
+## 输出格式（严格 JSON，不要包含 markdown 代码块标记）
+{
+  "details": [
+    { "criterion": "标准内容", "score": 0, "reason": "简要理由" }
+  ]
+}`,
+    '你是 AI 回答质量评估专家。严格按照 JSON 格式输出评分结果，不要输出其他内容。',
+  );
+
+  // 从 LLM 输出中提取第一个 JSON 对象，兼容裸 JSON、markdown 代码块、夹杂解释文字等情况
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) {
+    throw new Error(`未能从 Judge 输出中提取 JSON:\n${text}`);
+  }
+  const parsed = JSON.parse(match[0]) as { details: JudgeDetail[] };
+  const details = parsed.details;
+  const passed = details.filter((d) => d.score === 1).length;
+
+  return {
+    details,
+    passed,
+    total: details.length,
+    totalScore: details.length > 0 ? passed / details.length : 0,
+  };
+}

--- a/packages/skills/eval/lib/setup.ts
+++ b/packages/skills/eval/lib/setup.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** skills 源目录（packages/skills/） */
+const SKILLS_SRC = path.resolve(import.meta.dirname, '..', '..');
+
+/** 评测工作区目录 */
+export const EVAL_WORKSPACE = path.resolve(import.meta.dirname, '..', 'workspace');
+
+/** 工作区内的 skills 安装目录 */
+const SKILLS_INSTALL_DIR = path.join(EVAL_WORKSPACE, '.claude', 'skills');
+
+/** 需要排除的非 skill 目录 */
+const EXCLUDE_DIRS = new Set(['eval', 'node_modules']);
+
+/**
+ * 发现 packages/skills/ 下的所有 skill 目录
+ */
+function discoverSkillSrcDirs(): string[] {
+  const entries = fs.readdirSync(SKILLS_SRC, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && !EXCLUDE_DIRS.has(e.name))
+    .filter((e) => fs.existsSync(path.join(SKILLS_SRC, e.name, 'SKILL.md')))
+    .map((e) => e.name);
+}
+
+/**
+ * 初始化评测工作区：将 skills 通过 symlink 安装到 .claude/skills/ 下
+ *
+ * 结构：
+ * eval/workspace/
+ * └── .claude/
+ *     └── skills/
+ *         ├── egg/          → symlink → packages/skills/egg/
+ *         ├── controller/   → symlink → packages/skills/controller/
+ *         └── tegg-core/    → symlink → packages/skills/tegg-core/
+ */
+export function setupWorkspace(): void {
+  // 清理旧的安装目录
+  if (fs.existsSync(SKILLS_INSTALL_DIR)) {
+    fs.rmSync(SKILLS_INSTALL_DIR, { recursive: true });
+  }
+  fs.mkdirSync(SKILLS_INSTALL_DIR, { recursive: true });
+
+  const skillDirs = discoverSkillSrcDirs();
+  for (const dir of skillDirs) {
+    const src = path.join(SKILLS_SRC, dir);
+    const dest = path.join(SKILLS_INSTALL_DIR, dir);
+    fs.symlinkSync(src, dest, 'dir');
+  }
+}
+
+/**
+ * 安装指定的 skills 到工作区（用于单独测试特定 skill）
+ */
+export function setupWorkspaceWith(skillNames: string[]): void {
+  if (fs.existsSync(SKILLS_INSTALL_DIR)) {
+    fs.rmSync(SKILLS_INSTALL_DIR, { recursive: true });
+  }
+  fs.mkdirSync(SKILLS_INSTALL_DIR, { recursive: true });
+
+  for (const dir of skillNames) {
+    const src = path.join(SKILLS_SRC, dir);
+    const dest = path.join(SKILLS_INSTALL_DIR, dir);
+    if (fs.existsSync(src)) {
+      fs.symlinkSync(src, dest, 'dir');
+    }
+  }
+}
+
+/**
+ * 清理评测工作区
+ */
+export function cleanWorkspace(): void {
+  if (fs.existsSync(EVAL_WORKSPACE)) {
+    fs.rmSync(EVAL_WORKSPACE, { recursive: true });
+  }
+}

--- a/packages/skills/eval/lib/skill-loader.ts
+++ b/packages/skills/eval/lib/skill-loader.ts
@@ -1,0 +1,87 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import matter from 'gray-matter';
+
+import type { LoadedSkill, SkillMeta } from './types.ts';
+
+/** skills 根目录 */
+const SKILLS_ROOT = path.resolve(import.meta.dirname, '..', '..');
+
+/** 需要排除的非 skill 目录 */
+const EXCLUDE_DIRS = new Set(['eval', 'node_modules']);
+
+/**
+ * 获取所有 skill 目录名（包含 SKILL.md 的子目录）
+ */
+export function discoverSkillDirs(): string[] {
+  const entries = fs.readdirSync(SKILLS_ROOT, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && !EXCLUDE_DIRS.has(e.name))
+    .filter((e) => fs.existsSync(path.join(SKILLS_ROOT, e.name, 'SKILL.md')))
+    .map((e) => e.name);
+}
+
+/**
+ * 加载单个 skill 的 SKILL.md 内容
+ */
+export function loadSkill(skillDir: string): LoadedSkill {
+  const skillPath = path.join(SKILLS_ROOT, skillDir);
+  const skillMdPath = path.join(skillPath, 'SKILL.md');
+  const raw = fs.readFileSync(skillMdPath, 'utf-8');
+  const { data, content } = matter(raw);
+
+  return {
+    dir: skillDir,
+    meta: data as SkillMeta,
+    content: content.trim(),
+    path: skillPath,
+  };
+}
+
+/**
+ * 加载所有 skills
+ */
+export function loadAllSkills(): LoadedSkill[] {
+  return discoverSkillDirs().map((dir) => loadSkill(dir));
+}
+
+/**
+ * 加载 skill 的 SKILL.md 内容（纯文本，含 frontmatter）用作 system prompt
+ */
+export function loadSkillContent(skillDir: string): string {
+  const skillMdPath = path.join(SKILLS_ROOT, skillDir, 'SKILL.md');
+  return fs.readFileSync(skillMdPath, 'utf-8');
+}
+
+/**
+ * 加载 skill 下的 reference 文件内容
+ */
+export function loadReference(skillDir: string, refPath: string): string {
+  const fullPath = path.join(SKILLS_ROOT, skillDir, refPath);
+  return fs.readFileSync(fullPath, 'utf-8');
+}
+
+/**
+ * 列出 skill 目录下 references/ 中的所有 .md 文件
+ */
+export function listReferences(skillDir: string): string[] {
+  const refsDir = path.join(SKILLS_ROOT, skillDir, 'references');
+  if (!fs.existsSync(refsDir)) return [];
+
+  return fs.readdirSync(refsDir).filter((f) => f.endsWith('.md'));
+}
+
+/**
+ * 从 SKILL.md 内容中提取引用的 references 路径
+ * 匹配 `references/*.md` 模式
+ */
+export function extractReferencePaths(content: string): string[] {
+  const regex = /`references\/([^`]+\.md)`/g;
+  const paths: string[] = [];
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    paths.push(match[1]);
+  }
+  return [...new Set(paths)];
+}

--- a/packages/skills/eval/lib/types.ts
+++ b/packages/skills/eval/lib/types.ts
@@ -1,0 +1,63 @@
+/** 路由评测用例 */
+export interface RoutingCase {
+  /** 用户查询 */
+  query: string;
+  /** 期望路由到的 skill 名称 */
+  expectedSkill: string;
+  /** 用例理由说明 */
+  reason: string;
+}
+
+/** 质量评测用例 */
+export interface QualityCase {
+  /** 目标 skill 名称 */
+  skill: string;
+  /** 用户查询 */
+  query: string;
+  /** 评分标准列表 */
+  criteria: string[];
+  /** 需要额外加载的 reference 文件路径（相对于 skill 目录） */
+  references: string[];
+}
+
+/** Judge 输入 */
+export interface JudgeInput {
+  query: string;
+  response: string;
+  criteria: string[];
+}
+
+/** Judge 单项评分 */
+export interface JudgeDetail {
+  criterion: string;
+  score: 0 | 1;
+  reason: string;
+}
+
+/** Judge 评分结果 */
+export interface JudgeResult {
+  details: JudgeDetail[];
+  passed: number;
+  total: number;
+  totalScore: number;
+}
+
+/** Skill 元数据（SKILL.md frontmatter） */
+export interface SkillMeta {
+  name: string;
+  description: string;
+  'allowed-tools': string;
+  [key: string]: unknown;
+}
+
+/** 加载后的 Skill */
+export interface LoadedSkill {
+  /** skill 目录名 */
+  dir: string;
+  /** frontmatter 元数据 */
+  meta: SkillMeta;
+  /** SKILL.md body 内容（去除 frontmatter） */
+  content: string;
+  /** skill 目录的绝对路径 */
+  path: string;
+}

--- a/packages/skills/eval/static/validate.test.ts
+++ b/packages/skills/eval/static/validate.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it } from 'vitest';
+
+import {
+  loadAllSkills,
+  loadSkill,
+  discoverSkillDirs,
+  extractReferencePaths,
+  listReferences,
+} from '../lib/skill-loader.ts';
+
+const skills = loadAllSkills();
+const skillDirs = discoverSkillDirs();
+
+describe('Skill 静态校验', () => {
+  describe('Frontmatter 格式', () => {
+    for (const skill of skills) {
+      describe(`[${skill.dir}]`, () => {
+        it('包含 name 字段', () => {
+          assert.ok(skill.meta.name, `SKILL.md 缺少 name 字段`);
+          assert.equal(typeof skill.meta.name, 'string');
+        });
+
+        it('包含 description 字段', () => {
+          assert.ok(skill.meta.description, `SKILL.md 缺少 description 字段`);
+          assert.equal(typeof skill.meta.description, 'string');
+        });
+
+        it('包含 allowed-tools 字段', () => {
+          assert.ok(skill.meta['allowed-tools'], `SKILL.md 缺少 allowed-tools 字段`);
+          assert.equal(typeof skill.meta['allowed-tools'], 'string');
+        });
+      });
+    }
+  });
+
+  describe('引用文件存在性', () => {
+    for (const skill of skills) {
+      const referencedPaths = extractReferencePaths(skill.content);
+      if (referencedPaths.length === 0) continue;
+
+      describe(`[${skill.dir}]`, () => {
+        for (const refFile of referencedPaths) {
+          it(`references/${refFile} 文件存在`, () => {
+            const fullPath = path.join(skill.path, 'references', refFile);
+            assert.ok(fs.existsSync(fullPath), `引用的文件不存在: references/${refFile}`);
+          });
+        }
+      });
+    }
+  });
+
+  describe('交叉引用一致性', () => {
+    // 入口 skill（egg/）引用的子 skill 必须存在
+    const entrySkill = loadSkill('egg');
+
+    it('入口 skill 存在', () => {
+      assert.ok(entrySkill, 'egg/SKILL.md 不存在');
+    });
+
+    // 从入口 skill 中提取提到的 skills-xxx 引用
+    const skillRefRegex = /@eggjs\/skills-(\w+)/g;
+    const referencedSkills: string[] = [];
+    let match;
+    while ((match = skillRefRegex.exec(entrySkill.content)) !== null) {
+      referencedSkills.push(match[1]);
+    }
+
+    for (const refSkill of new Set(referencedSkills)) {
+      it(`入口 skill 引用的 @eggjs/skills-${refSkill} 有对应的 skill 目录`, () => {
+        // skills-core → tegg-core, skills-controller → controller
+        const possibleDirs = [refSkill, `tegg-${refSkill}`, refSkill.replace(/^tegg-/, '')];
+        const found = possibleDirs.some((d) => skillDirs.includes(d));
+        assert.ok(
+          found,
+          `入口 skill 引用了 @eggjs/skills-${refSkill}，但未找到对应目录。` +
+            `\n  已有的 skill 目录: ${skillDirs.join(', ')}`,
+        );
+      });
+    }
+  });
+
+  describe('Markdown 结构', () => {
+    for (const skill of skills) {
+      describe(`[${skill.dir}]`, () => {
+        it('以一级标题开头', () => {
+          const firstHeading = skill.content.match(/^(#{1,6})\s/m);
+          assert.ok(firstHeading, 'SKILL.md 内容中没有标题');
+          assert.equal(firstHeading[1], '#', '第一个标题应为一级标题');
+        });
+
+        it('标题层级不跳级', () => {
+          const headings = [...skill.content.matchAll(/^(#{1,6})\s+(.+)$/gm)];
+          let lastLevel = 0;
+
+          for (const heading of headings) {
+            const level = heading[1].length;
+            if (lastLevel > 0 && level > lastLevel + 1) {
+              assert.fail(
+                `标题跳级: "${heading[2]}" 是 h${level}，但上一个标题是 h${lastLevel}` +
+                  `（最多应为 h${lastLevel + 1}）`,
+              );
+            }
+            lastLevel = level;
+          }
+        });
+      });
+    }
+
+    // 同样校验 references/ 下的 md 文件
+    for (const skillDir of skillDirs) {
+      const refs = listReferences(skillDir);
+      for (const ref of refs) {
+        describe(`[${skillDir}/references/${ref}]`, () => {
+          it('标题层级不跳级', () => {
+            const content = fs.readFileSync(
+              path.join(skills.find((s) => s.dir === skillDir)!.path, 'references', ref),
+              'utf-8',
+            );
+            const headings = [...content.matchAll(/^(#{1,6})\s+(.+)$/gm)];
+            let lastLevel = 0;
+
+            for (const heading of headings) {
+              const level = heading[1].length;
+              if (lastLevel > 0 && level > lastLevel + 1) {
+                assert.fail(`标题跳级: "${heading[2]}" 是 h${level}，但上一个标题是 h${lastLevel}`);
+              }
+              lastLevel = level;
+            }
+          });
+        });
+      }
+    }
+  });
+
+  describe('决策表完整性', () => {
+    const entrySkill = loadSkill('egg');
+
+    it('入口 skill 包含快速参考表', () => {
+      assert.ok(
+        entrySkill.content.includes('快速参考表') || entrySkill.content.includes('快速决策'),
+        '入口 skill 应包含快速参考/决策表',
+      );
+    });
+
+    it('入口 skill 包含决策框架', () => {
+      assert.ok(
+        entrySkill.content.includes('决策框架') || entrySkill.content.includes('决策树'),
+        '入口 skill 应包含决策框架或决策树',
+      );
+    });
+  });
+});

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -35,9 +35,17 @@
       "./package.json": "./package.json"
     }
   },
-  "scripts": {},
+  "scripts": {
+    "test": "vitest run eval/static/",
+    "eval": "vitest run eval/dynamic/",
+    "eval:routing": "vitest run eval/dynamic/routing.eval.ts",
+    "eval:quality": "vitest run eval/dynamic/quality.eval.ts"
+  },
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "gray-matter": "^4.0.3",
+    "vitest": "catalog:"
+  },
   "engines": {
     "node": ">=22.18.0"
   }

--- a/packages/skills/tsconfig.json
+++ b/packages/skills/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/skills/vitest.config.ts
+++ b/packages/skills/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    include: ['eval/**/*.{test,eval}.ts'],
+    testTimeout: 300_000,
+    // 用 child_process.fork 代替 worker_threads, cc 会用到 tty
+    pool: 'forks',
+  },
+});
+
+export default config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,6 +1341,18 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/skills:
+    devDependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.39.0
+        version: 0.39.0(encoding@0.1.13)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.15(@types/node@24.10.2)(@vitest/ui@4.0.15)(esbuild@0.27.0)(jiti@2.6.1)(less@4.4.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.2)
+
   packages/supertest:
     dependencies:
       '@types/superagent':
@@ -3373,6 +3385,9 @@ importers:
 
 packages:
 
+  '@anthropic-ai/sdk@0.39.0':
+    resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
+
   '@babel/generator@7.28.5':
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
     engines: {node: '>=6.9.0'}
@@ -4852,8 +4867,14 @@ packages:
   '@types/mustache@4.2.6':
     resolution: {integrity: sha512-t+8/QWTAhOFlrF1IVZqKnMRJi84EgkIK5Kh0p2JV4OLywUvCwJPFxbJAl7XAow7DVIHsF+xW9f1MVzg0L6Szjw==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@24.10.2':
     resolution: {integrity: sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==}
@@ -5122,6 +5143,10 @@ packages:
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -6088,6 +6113,10 @@ packages:
   event-stream@4.0.1:
     resolution: {integrity: sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -6195,6 +6224,9 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
   form-data-encoder@1.9.0:
     resolution: {integrity: sha512-rahaRMkN8P8d/tgK/BLPX+WBVM27NbvdXBxqQujBtkDAIFspaRqN7Od7lfdGQA6KAD+f82fYCLBq1ipvcu8qLw==}
@@ -7474,6 +7506,15 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-gyp@9.4.1:
     resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
     engines: {node: ^12.13 || ^14.13 || >=16}
@@ -8619,6 +8660,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -8732,6 +8776,9 @@ packages:
 
   unconfig-core@7.4.2:
     resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -8948,6 +8995,9 @@ packages:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
@@ -8959,6 +9009,9 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -9102,6 +9155,18 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.39.0(encoding@0.1.13)':
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
 
   '@babel/generator@7.28.5':
     dependencies:
@@ -10265,7 +10330,16 @@ snapshots:
 
   '@types/mustache@4.2.6': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.10.2
+      form-data: 4.0.4
+
   '@types/node@10.17.60': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@24.10.2':
     dependencies:
@@ -10550,6 +10624,10 @@ snapshots:
   abbrev@1.1.1: {}
 
   abbrev@2.0.0: {}
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
 
   accepts@1.3.8:
     dependencies:
@@ -11621,6 +11699,8 @@ snapshots:
       stream-combiner: 0.2.2
       through: 2.3.8
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.1: {}
 
   execa@5.1.1:
@@ -11778,6 +11858,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data-encoder@1.7.2: {}
 
   form-data-encoder@1.9.0: {}
 
@@ -13185,6 +13267,12 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0(encoding@0.1.13):
+    dependencies:
+      whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
+
   node-gyp@9.4.1:
     dependencies:
       env-paths: 2.2.1
@@ -14480,6 +14568,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
 
   treeverse@3.0.0: {}
@@ -14599,6 +14689,8 @@ snapshots:
     dependencies:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
+
+  undici-types@5.26.5: {}
 
   undici-types@7.16.0: {}
 
@@ -14898,6 +14990,8 @@ snapshots:
 
   web-streams-polyfill@4.0.0-beta.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2:
     optional: true
 
@@ -14906,6 +15000,11 @@ snapshots:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
…ment

Introduces an evaluation system using Vitest to test skill routing decisions and answer quality via LLM-as-Judge. Includes PTY-based claude CLI wrapper (via macOS `script`) to bypass Vitest stdio capture, robust JSON extraction from LLM output, and static skill YAML validation tests.