### PR TITLE
docs: add @eggjs/mock and mm documentation

### DIFF
--- a/site/docs/core/index.md
+++ b/site/docs/core/index.md
@@ -8,6 +8,7 @@ nav:
 
 - [Local Development](./development.md)
 - [Unit Testing](./unittest.md)
+- [Mock Helpers (@eggjs/mock / mm)](./mock.md)
 - [Deployment](./deployment.md)
 - [Logger](./logger.md)
 - [HttpClient](./httpclient.md)

--- a/site/docs/core/mock.md
+++ b/site/docs/core/mock.md
@@ -4,7 +4,7 @@ title: Mock Helpers ( @eggjs/mock / mm )
 
 Egg provides a dedicated mocking helper package for application unit tests: **`@eggjs/mock`** (historically known as **egg-mock**).
 
-- Repository (Egg 3.x): https://github.com/eggjs/mock/tree/4.x
+- Repository (Egg 3.x / egg-mock@5.x, peerDependencies.egg: ^3.12.0): https://github.com/eggjs/mock/tree/5.x
 - API reference: see README in the repo.
 
 `@eggjs/mock` is built on top of **`mm`** (Mock Mate), which provides low-level monkey-patching utilities.

--- a/site/docs/core/mock.md
+++ b/site/docs/core/mock.md
@@ -93,7 +93,7 @@ const { app, mm } = require('egg-mock/bootstrap');
 
 // or
 const mock = require('@eggjs/mock');
-mock(mmTarget, 'prop', value);
+mock(target, 'prop', value);
 mock.restore();
 ```
 

--- a/site/docs/core/mock.md
+++ b/site/docs/core/mock.md
@@ -1,0 +1,141 @@
+---
+title: Mock Helpers ( @eggjs/mock / mm )
+---
+
+Egg provides a dedicated mocking helper package for application unit tests: **`@eggjs/mock`** (historically known as **egg-mock**).
+
+- Repository (Egg 3.x): https://github.com/eggjs/mock/tree/4.x
+- API reference: see README in the repo.
+
+`@eggjs/mock` is built on top of **`mm`** (Mock Mate), which provides low-level monkey-patching utilities.
+
+- Repository: https://github.com/node-modules/mm
+
+## Install
+
+```bash
+npm i @eggjs/mock --save-dev
+```
+
+> In many docs / legacy code you may still see `egg-mock`. For Egg 3.x, the recommended package name is `@eggjs/mock`.
+
+## Quick Start
+
+### Create an app instance
+
+```js
+const mock = require('@eggjs/mock');
+
+describe('test/controller/home.test.js', () => {
+  let app;
+
+  before(async () => {
+    app = mock.app({ baseDir: 'path/to/your/app' });
+    await app.ready();
+  });
+
+  after(() => app.close());
+});
+```
+
+### Use bootstrap to avoid repeated setup
+
+```js
+const { app, mock, assert } = require('egg-mock/bootstrap');
+
+describe('test/controller/home.test.js', () => {
+  // test cases
+});
+```
+
+> The bootstrap helper wires common setup/teardown and is convenient for most projects.
+
+### Create a Context
+
+```js
+it('should get a ctx', () => {
+  const ctx = app.mockContext();
+  assert(ctx.method === 'GET');
+});
+
+it('should mock ctx.user', () => {
+  const ctx = app.mockContext({
+    user: { name: 'fengmk2' },
+  });
+  assert(ctx.user.name === 'fengmk2');
+});
+```
+
+## Restore after each test
+
+When using `mm` / `@eggjs/mock`, remember to restore mocked state:
+
+```js
+const mm = require('mm');
+
+afterEach(() => mm.restore());
+```
+
+If you use `egg-mock/bootstrap`, it already restores mocks for you in `afterEach`.
+
+## mm (Mock Mate) API
+
+`mm` is a general purpose monkey-patching library. `@eggjs/mock` is built on top of it, and many Egg tests use `mm` directly.
+
+### Prefer using `@eggjs/mock` exports
+
+For consistency inside the Egg ecosystem, prefer the `mm` that is exported by `@eggjs/mock` (egg-mock). It is compatible with `mm` and adds Egg-specific helpers.
+
+```js
+// CJS
+const { app, mm } = require('egg-mock/bootstrap');
+// mm.restore() in afterEach is already wired by bootstrap
+
+// or
+const mock = require('@eggjs/mock');
+mock(mmTarget, 'prop', value);
+mock.restore();
+```
+
+You can still use the standalone `mm` package directly if needed:
+
+```js
+import mm, { restore } from 'mm';
+```
+
+### Core
+
+- `mm(target, property, value)` / `mm.mock(...)`: monkey-patch a property.
+- `mm.restore()` / `restore()`: restore all patched properties.
+- `mm.isMocked(target, property)`: check if a property is mocked.
+- `mm.spy(target, method)`: spy a function (records call counts/args).
+
+> When a mocked property is a function, mm will attach spy fields like `called`, `calledArguments`, `lastCalledArguments`.
+
+### Callback-style helpers
+
+- `mm.data(target, method, data[, timeout])`: callback returns `(null, data)`.
+- `mm.datas(target, method, datas[, timeout])`: callback returns `(null, ...datas)`.
+- `mm.empty(target, method[, timeout])`: callback returns `(null, null)`.
+- `mm.error(target, method, error[, props|timeout][, timeout])`: callback returns an error.
+- `mm.errorOnce(...)`: like `error` but only once.
+
+### Sync helpers
+
+- `mm.syncData(target, method, value)`: return value.
+- `mm.syncEmpty(target, method)`: return `undefined`.
+- `mm.syncError(target, method, error[, props])`: throw error.
+
+### HTTP helpers
+
+- `mm.http.request(url, data[, headers][, delay])`: mock `http.request` / `http.get`.
+- `mm.http.requestError(url[, reqError][, resError][, delay])`: mock request/response errors.
+- `mm.https.request(...)` / `mm.https.requestError(...)`: same for https.
+
+### Other
+
+- `mm.spawn(code, stdout, stderr[, timeout])`: mock `child_process.spawn`.
+- `mm.classMethod(instance, method, mockFn)`: mock a class method via prototype.
+
+For complete and up-to-date details, see the mm repository:
+https://github.com/node-modules/mm

--- a/site/docs/core/unittest.md
+++ b/site/docs/core/unittest.md
@@ -125,7 +125,10 @@ This chapter introduces you how to write test, and introduction of tests for the
 
 Generally, a complete application test requires initialization and cleanup, such as deleting temporary files or destroy application. Also, we have to deal with exceptional situations like network problem and exception visit of server.
 
-We extracted an [egg-mock](https://github.com/eggjs/egg-mock)module for mock, help for quick implementation of application unit tests, supporting fast creation of ctx to test.
+We extracted a dedicated mocking helper package: **`@eggjs/mock`** (historically called **egg-mock**), to help implement application unit tests quickly and to create contexts easily.
+
+- Repo (Egg 3.x): https://github.com/eggjs/mock/tree/4.x
+- See also: [Mock Helpers (@eggjs/mock / mm)](./mock.md)
 
 ### app
 

--- a/site/docs/zh-CN/core/index.md
+++ b/site/docs/zh-CN/core/index.md
@@ -2,6 +2,7 @@
 
 - [本地开发](./development.md)
 - [单元测试](./unittest.md)
+- [测试 Mock 工具（@eggjs/mock / mm）](./mock.md)
 - [应用部署](./deployment.md)
 - [日志](./logger.md)
 - [HttpClient](./httpclient.md)

--- a/site/docs/zh-CN/core/mock.md
+++ b/site/docs/zh-CN/core/mock.md
@@ -4,7 +4,7 @@ title: 测试 Mock 工具（@eggjs/mock / mm）
 
 Egg 为应用单元测试抽取了专门的 Mock 辅助包：**`@eggjs/mock`**（历史上也常被称为 **egg-mock**）。
 
-- 仓库（Egg 3.x）：https://github.com/eggjs/mock/tree/4.x
+- 仓库（Egg 3.x）：https://github.com/eggjs/mock/tree/5.x
 - API 说明：请以仓库 README 为准。
 
 `@eggjs/mock` 底层基于 **`mm`**（Mock Mate），提供更通用的打桩/猴子补丁能力。

--- a/site/docs/zh-CN/core/mock.md
+++ b/site/docs/zh-CN/core/mock.md
@@ -1,0 +1,141 @@
+---
+title: 测试 Mock 工具（@eggjs/mock / mm）
+---
+
+Egg 为应用单元测试抽取了专门的 Mock 辅助包：**`@eggjs/mock`**（历史上也常被称为 **egg-mock**）。
+
+- 仓库（Egg 3.x）：https://github.com/eggjs/mock/tree/4.x
+- API 说明：请以仓库 README 为准。
+
+`@eggjs/mock` 底层基于 **`mm`**（Mock Mate），提供更通用的打桩/猴子补丁能力。
+
+- mm 仓库：https://github.com/node-modules/mm
+
+## 安装
+
+```bash
+npm i @eggjs/mock --save-dev
+```
+
+> 你可能会在旧文档/历史代码中看到 `egg-mock`。对 Egg 3.x，推荐直接使用 `@eggjs/mock`。
+
+## 快速开始
+
+### 创建 app 实例
+
+```js
+const mock = require('@eggjs/mock');
+
+describe('test/controller/home.test.js', () => {
+  let app;
+
+  before(async () => {
+    app = mock.app({ baseDir: 'path/to/your/app' });
+    await app.ready();
+  });
+
+  after(() => app.close());
+});
+```
+
+### 使用 bootstrap 避免重复初始化
+
+```js
+const { app, mock, assert } = require('egg-mock/bootstrap');
+
+describe('test/controller/home.test.js', () => {
+  // 测试用例
+});
+```
+
+> bootstrap 会帮你做常用的初始化/清理流程，大多数项目直接用它即可。
+
+### 创建 Context
+
+```js
+it('should get a ctx', () => {
+  const ctx = app.mockContext();
+  assert(ctx.method === 'GET');
+});
+
+it('should mock ctx.user', () => {
+  const ctx = app.mockContext({
+    user: { name: 'fengmk2' },
+  });
+  assert(ctx.user.name === 'fengmk2');
+});
+```
+
+## 每个用例后恢复 mock
+
+在使用 `mm` / `@eggjs/mock` 时，需要记得恢复被 mock 的状态，避免污染其它用例：
+
+```js
+const mm = require('mm');
+
+afterEach(() => mm.restore());
+```
+
+如果你使用了 `egg-mock/bootstrap`，它会在 `afterEach` 中自动帮你 restore。
+
+## mm（Mock Mate）API
+
+`mm` 是通用的 monkey-patch 工具库，`@eggjs/mock` 底层基于它实现，很多 Egg 的测试也会直接使用 `mm`。
+
+### 推荐使用 `@eggjs/mock` 的导出
+
+为了保持 Egg 生态的一体性，建议优先使用 `@eggjs/mock`（egg-mock）导出的 `mm`：它与 `mm` 兼容，同时还包含 Egg 相关的 mock 能力。
+
+```js
+// CJS
+const { app, mm } = require('egg-mock/bootstrap');
+// bootstrap 已经在 afterEach 中自动执行了 mm.restore()
+
+// 或者
+const mock = require('@eggjs/mock');
+mock(target, 'prop', value);
+mock.restore();
+```
+
+如果确实需要，也可以直接使用独立的 `mm` 包：
+
+```js
+import mm, { restore } from 'mm';
+```
+
+### 核心能力
+
+- `mm(target, property, value)` / `mm.mock(...)`：mock/打桩某个属性。
+- `mm.restore()` / `restore()`：还原所有被 mock 的属性。
+- `mm.isMocked(target, property)`：判断某个属性是否已被 mock。
+- `mm.spy(target, method)`：只做 spy（记录调用次数/参数）。
+
+> 当 mock 的属性是函数时，会自动附带 spy 字段：`called`、`calledArguments`、`lastCalledArguments`。
+
+### 回调风格（Node callback）辅助
+
+- `mm.data(target, method, data[, timeout])`：回调返回 `(null, data)`。
+- `mm.datas(target, method, datas[, timeout])`：回调返回 `(null, ...datas)`。
+- `mm.empty(target, method[, timeout])`：回调返回 `(null, null)`。
+- `mm.error(target, method, error[, props|timeout][, timeout])`：回调返回 error。
+- `mm.errorOnce(...)`：类似 `error`，但只生效一次。
+
+### 同步函数辅助
+
+- `mm.syncData(target, method, value)`：直接 return。
+- `mm.syncEmpty(target, method)`：return `undefined`。
+- `mm.syncError(target, method, error[, props])`：直接 throw。
+
+### HTTP mock
+
+- `mm.http.request(url, data[, headers][, delay])`：mock `http.request` / `http.get`。
+- `mm.http.requestError(url[, reqError][, resError][, delay])`：mock request/response error。
+- `mm.https.request(...)` / `mm.https.requestError(...)`：同理（https）。
+
+### 其它
+
+- `mm.spawn(code, stdout, stderr[, timeout])`：mock `child_process.spawn`。
+- `mm.classMethod(instance, method, mockFn)`：通过 prototype mock class method。
+
+完整、最新的 API 仍建议以 mm 仓库为准：
+https://github.com/node-modules/mm

--- a/site/docs/zh-CN/core/unittest.md
+++ b/site/docs/zh-CN/core/unittest.md
@@ -124,7 +124,10 @@ npm test
 
 我们可能还需要模拟各种网络异常、服务访问异常等特殊情况。
 
-因此我们单独为框架抽取了一个测试 mock 辅助模块：[egg-mock](https://github.com/eggjs/egg-mock)，有了它我们就可以非常快速地编写一个 app 的单元测试，并且还能快速创建一个 ctx 来测试它的属性、方法和 Service 等。
+因此我们单独为框架抽取了一个测试 mock 辅助模块：**`@eggjs/mock`**（历史上也常被称为 egg-mock）。有了它我们就可以非常快速地编写应用单元测试，并且还能快速创建 ctx 来测试属性、方法和 Service 等。
+
+- 仓库（Egg 3.x）：https://github.com/eggjs/mock/tree/4.x
+- 也可以参考：[测试 Mock 工具（@eggjs/mock / mm）](./mock.md)
 
 ### app
 


### PR DESCRIPTION
This PR improves Egg 3.x docs (next/site/docs) around mocking:

- Add new docs page: core/mock.md (EN) + zh-CN/core/mock.md (CN)
  - Introduces @eggjs/mock (egg-mock) repo for Egg 3.x: https://github.com/eggjs/mock/tree/4.x
  - Adds a concise mm API reference and recommends using the mm exported by @eggjs/mock/egg-mock for ecosystem consistency
- Link the new page from core/index.md (EN + CN)
- Update core/unittest.md (EN + CN) to point egg-mock to @eggjs/mock and add cross reference

Commit: b3b9407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Mock Helpers (@eggjs/mock / mm) docs covering installation, quick-start, bootstrap usage, context mocking, restore semantics, and an API overview with examples.
  * Updated unit testing docs to reference the dedicated @eggjs/mock package and added repository pointers for Egg 3.x.
  * Added a new Mock Helpers navigation entry in Core for easier discovery.
  * All docs provided in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->