### PR TITLE
fix(ci): reorder release workflow to run build after version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run build
-        run: pnpm build
-
       - name: Configure Git
         run: |
           git config --local user.email "action@github.com"
@@ -109,6 +106,9 @@ jobs:
 
           # Push changes and tags
           git push origin ${{ github.event.inputs.branch }} --tags
+
+      - name: Run build
+        run: pnpm build
 
       - name: Publish packages (dry run)
         if: ${{ github.event.inputs.dry_run == 'true' }}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -38,7 +38,6 @@
   "scripts": {
     "build": "tsdown",
     "clean": "rimraf dist",
-    "prepublishOnly": "npm run build",
     "lint": "oxlint --type-aware",
     "typecheck": "tsgo --noEmit",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- Move `pnpm build` step after version bump in the release workflow
- tsdown with `devExports: true` modifies `package.json` exports during build, causing `scripts/version.js` to fail with "Git working directory is not clean"
- Build output is only needed for the publish step, which already uses `--no-git-checks`

## Test plan
- [ ] Trigger Manual Release workflow with dry_run to verify version bump succeeds
- [ ] Trigger Manual Release workflow to verify full release flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reordered release pipeline so the build now runs after version bump and after pushing changes/tags, adjusting the release sequence.
  * Removed an obsolete pre-publish script from the logger package to simplify package scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->