### PR TITLE
feat(ci): use npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,10 @@ jobs:
           echo "🧪 Running publish in dry-run mode..."
           if [[ "${{ github.event.inputs.version_type }}" == pre* ]]; then
             echo "Setting npm tag to: ${{ github.event.inputs.prerelease_tag }}"
-            pnpm -r publish --dry-run --no-git-checks --tag=${{ github.event.inputs.prerelease_tag }}
+            pnpm -r publish --dry-run --no-git-checks --access public --tag=${{ github.event.inputs.prerelease_tag }}
           else
             echo "Setting npm tag to: latest"
-            pnpm -r publish --dry-run --no-git-checks --tag=latest
+            pnpm -r publish --dry-run --no-git-checks --access public --tag=latest
           fi
 
       - name: Publish packages
@@ -128,10 +128,10 @@ jobs:
           echo "📦 Publishing packages..."
           if [[ "${{ github.event.inputs.version_type }}" == pre* ]]; then
             echo "Setting npm tag to: ${{ github.event.inputs.prerelease_tag }}"
-            pnpm -r publish --no-git-checks --tag=${{ github.event.inputs.prerelease_tag }}
+            NPM_CONFIG_LOGLEVEL=verbose pnpm -r publish --no-git-checks --access public --provenance --tag=${{ github.event.inputs.prerelease_tag }} || tail -n 100 ~/.npm/_logs/*.log && exit 1
           else
             echo "Setting npm tag to: latest"
-            pnpm -r publish --no-git-checks --tag=latest
+            NPM_CONFIG_LOGLEVEL=verbose pnpm -r publish --no-git-checks --access public --provenance --tag=latest || tail -n 100 ~/.npm/_logs/*.log || tail -n 100 ~/.npm/_logs/*.log && exit 1
           fi
 
       - name: Create GitHub Release (draft)


### PR DESCRIPTION
## Summary
- Switch release workflow from static npm tokens to OIDC-based trusted publishing
- npm CLI auto-detects OIDC environment, no `NODE_AUTH_TOKEN` needed
- Provenance attestation is automatically generated
- Add `--access public` for automatic first-time publishing of new scoped packages

## Required npm configuration
Each package needs trusted publisher configured on npmjs.com:
- Settings → Trusted Publisher → GitHub Actions
- Organization: `eggjs`, Repository: `egg`, Workflow: `release.yml`

## Test plan
- [ ] Configure trusted publisher on npmjs.com for all packages
- [ ] Trigger Manual Release workflow with dry_run to verify
- [ ] Trigger Manual Release workflow for full release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Publish workflow now uses public access for dry-run and real publishes.
  * Real publishes include verbose logging and attach provenance metadata.
* **Releases**
  * Many packages, plugins, and tools received patch/beta version bumps across the monorepo (metadata-only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->