### PR TITLE
refactor(tegg): revert qualifier force replacement check

### DIFF
--- a/tegg/core/core-decorator/src/util/QualifierUtil.ts
+++ b/tegg/core/core-decorator/src/util/QualifierUtil.ts
@@ -5,15 +5,7 @@ import type { EggProtoImplClass, QualifierAttribute, QualifierInfo, QualifierVal
 import { MetadataUtil } from './MetadataUtil.ts';
 
 export class QualifierUtil {
-  static addProtoQualifier(
-    clazz: EggProtoImplClass,
-    attribute: QualifierAttribute,
-    value: QualifierValue,
-    isForceReplacement?: boolean,
-  ): void {
-    if (QualifierUtil.getQualifierValue(clazz, attribute) && !isForceReplacement) {
-      throw new Error(`Qualifier Error: clazz ${clazz.name} attribute ${attribute.toString()} has been implemented`);
-    }
+  static addProtoQualifier(clazz: EggProtoImplClass, attribute: QualifierAttribute, value: QualifierValue): void {
     const qualifiers = MetadataUtil.initOwnMapMetaData(
       QUALIFIER_META_DATA,
       clazz,

--- a/tegg/core/dynamic-inject/src/QualifierImplDecoratorUtil.ts
+++ b/tegg/core/dynamic-inject/src/QualifierImplDecoratorUtil.ts
@@ -14,10 +14,10 @@ export class QualifierImplDecoratorUtil {
     abstractClazz: EggAbstractClazz<T>,
     attribute: QualifierAttribute,
   ): ImplDecorator<T, Enum> {
-    return function (type: Enum[keyof Enum], isForceReplacement?: boolean) {
+    return function (type: Enum[keyof Enum]) {
       return function (clazz: EggProtoImplClass<T>) {
-        QualifierImplUtil.addQualifierImpl(abstractClazz, type, clazz, isForceReplacement);
-        QualifierUtil.addProtoQualifier(clazz, attribute, type, isForceReplacement);
+        QualifierImplUtil.addQualifierImpl(abstractClazz, type, clazz);
+        QualifierUtil.addProtoQualifier(clazz, attribute, type);
       };
     };
   }

--- a/tegg/core/dynamic-inject/src/QualifierImplUtil.ts
+++ b/tegg/core/dynamic-inject/src/QualifierImplUtil.ts
@@ -7,13 +7,7 @@ export class QualifierImplUtil {
     abstractClazz: EggAbstractClazz,
     qualifierValue: QualifierValue,
     implClazz: EggProtoImplClass,
-    isForceReplacement?: boolean,
   ): void {
-    if (QualifierImplUtil.getQualifierImp(abstractClazz, qualifierValue) && !isForceReplacement) {
-      throw new Error(
-        `Qualifier Error: abstractClazz ${abstractClazz.name} qualifierValue ${qualifierValue.toString()} has been implemented`,
-      );
-    }
     const implMap = MetadataUtil.initOwnMapMetaData(
       QUALIFIER_IMPL_MAP,
       abstractClazz as unknown as EggProtoImplClass,

--- a/tegg/plugin/tegg/src/lib/AppLoadUnit.ts
+++ b/tegg/plugin/tegg/src/lib/AppLoadUnit.ts
@@ -68,7 +68,7 @@ export class AppLoadUnit implements LoadUnit {
         },
       ];
       defaultQualifier.forEach((qualifier) => {
-        QualifierUtil.addProtoQualifier(clazz, qualifier.attribute, qualifier.value, true);
+        QualifierUtil.addProtoQualifier(clazz, qualifier.attribute, qualifier.value);
       });
       const protos = await EggPrototypeCreatorFactory.createProto(clazz, this);
       for (const proto of protos) {


### PR DESCRIPTION
## Summary
- Sync revert from https://github.com/eggjs/tegg/pull/301 to the `tegg/` directory
- Removes the `isForceReplacement` parameter and duplicate-qualifier error check added in tegg#295, allowing unconditional overwriting of qualifier values

## Changed files
- `tegg/core/core-decorator/src/util/QualifierUtil.ts`
- `tegg/core/dynamic-inject/src/QualifierImplDecoratorUtil.ts`
- `tegg/core/dynamic-inject/src/QualifierImplUtil.ts`
- `tegg/plugin/tegg/src/lib/AppLoadUnit.ts`

## Test plan
- No test changes needed — no tests referenced `isForceReplacement`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified qualifier API by removing the optional force replacement parameter from qualifier methods. Qualifiers can now be unconditionally set without explicit override flags, streamlining the dependency injection framework's decorator API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->