### PR TITLE
fix(tegg): fix runtime issues found by cnpmcore e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
               mysql -h 127.0.0.1 -u root -e "CREATE DATABASE IF NOT EXISTS cnpmcore_unittest"
               CNPMCORE_DATABASE_NAME=cnpmcore_unittest bash ./prepare-database-mysql.sh
               CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
-              npm run test:local
+              EGG_FILE_PARALLELISM=false npm run test:local
 
               # Deployment test: start the app and verify it boots correctly
               npm run clean

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -57,7 +57,8 @@ jobs:
               npm run clean
 
               # Run the full test suite
-              echo "Preparing database for tests..."
+              echo "Preparing databases..."
+              mysql -h 127.0.0.1 -u root -e "CREATE DATABASE IF NOT EXISTS cnpmcore_unittest"
               CNPMCORE_DATABASE_NAME=cnpmcore_unittest bash ./prepare-database-mysql.sh
               CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
               npm run test:local

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,19 +27,6 @@ jobs:
       contents: read
       packages: read
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: true
-          MYSQL_DATABASE: cnpmcore
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
-      redis:
-        image: redis
-        ports:
-          - 6379:6379
     strategy:
       fail-fast: false
       matrix:
@@ -52,42 +39,6 @@ jobs:
               npm run typecheck
               npm run build
               npm run prepublishOnly
-
-              # Clean build artifacts to avoid double-loading (src + dist)
-              npm run clean
-
-              # Deployment test: start the app and verify it boots correctly
-              echo "Preparing database for deployment test..."
-              CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
-
-              echo "Starting cnpmcore..."
-              CNPMCORE_FORCE_LOCAL_FS=true npx eggctl start &
-              SERVER_PID=$!
-
-              echo "Health checking cnpmcore..."
-              URL="http://127.0.0.1:7001"
-              PATTERN="instance_start_time"
-              TIMEOUT=60
-              TMP="$(mktemp)"
-              deadline=$((SECONDS + TIMEOUT))
-              last_status=""
-
-              while (( SECONDS < deadline )); do
-                last_status="$(curl -sS -o "$TMP" -w '%{http_code}' "$URL" || true)"
-                if [[ "$last_status" == "200" ]] && grep -q "$PATTERN" "$TMP"; then
-                  echo "cnpmcore is ready (status=$last_status)"
-                  rm -f "$TMP"
-                  npx eggctl stop || true
-                  exit 0
-                fi
-                sleep 1
-              done
-
-              echo "Health check failed: status=$last_status"
-              cat "$TMP" || true
-              rm -f "$TMP"
-              npx eggctl stop || true
-              exit 1
           - name: examples
             node-version: 24
             command: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -56,15 +56,7 @@ jobs:
               # Clean build artifacts to avoid double-loading (src + dist)
               npm run clean
 
-              # Run the full test suite
-              echo "Preparing databases..."
-              mysql -h 127.0.0.1 -u root -e "CREATE DATABASE IF NOT EXISTS cnpmcore_unittest"
-              CNPMCORE_DATABASE_NAME=cnpmcore_unittest bash ./prepare-database-mysql.sh
-              CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
-              npm run test:local
-
               # Deployment test: start the app and verify it boots correctly
-              npm run clean
               echo "Preparing database for deployment test..."
               CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,6 +27,19 @@ jobs:
       contents: read
       packages: read
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: cnpmcore
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +52,50 @@ jobs:
               npm run typecheck
               npm run build
               npm run prepublishOnly
+
+              # Clean build artifacts to avoid double-loading (src + dist)
+              npm run clean
+
+              # Run the full test suite
+              echo "Preparing databases..."
+              mysql -h 127.0.0.1 -u root -e "CREATE DATABASE IF NOT EXISTS cnpmcore_unittest"
+              CNPMCORE_DATABASE_NAME=cnpmcore_unittest bash ./prepare-database-mysql.sh
+              CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
+              npm run test:local
+
+              # Deployment test: start the app and verify it boots correctly
+              npm run clean
+              echo "Preparing database for deployment test..."
+              CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
+
+              echo "Starting cnpmcore..."
+              CNPMCORE_FORCE_LOCAL_FS=true npx eggctl start &
+              SERVER_PID=$!
+
+              echo "Health checking cnpmcore..."
+              URL="http://127.0.0.1:7001"
+              PATTERN="instance_start_time"
+              TIMEOUT=60
+              TMP="$(mktemp)"
+              deadline=$((SECONDS + TIMEOUT))
+              last_status=""
+
+              while (( SECONDS < deadline )); do
+                last_status="$(curl -sS -o "$TMP" -w '%{http_code}' "$URL" || true)"
+                if [[ "$last_status" == "200" ]] && grep -q "$PATTERN" "$TMP"; then
+                  echo "cnpmcore is ready (status=$last_status)"
+                  rm -f "$TMP"
+                  npx eggctl stop || true
+                  exit 0
+                fi
+                sleep 1
+              done
+
+              echo "Health check failed: status=$last_status"
+              cat "$TMP" || true
+              rm -f "$TMP"
+              npx eggctl stop || true
+              exit 1
           - name: examples
             node-version: 24
             command: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -27,6 +27,19 @@ jobs:
       contents: read
       packages: read
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_DATABASE: cnpmcore
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     strategy:
       fail-fast: false
       matrix:
@@ -39,6 +52,39 @@ jobs:
               npm run typecheck
               npm run build
               npm run prepublishOnly
+
+              # Deployment test: start the app and verify it boots correctly
+              echo "Preparing database..."
+              CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
+
+              echo "Starting cnpmcore..."
+              CNPMCORE_FORCE_LOCAL_FS=true npx eggctl start &
+              SERVER_PID=$!
+
+              echo "Health checking cnpmcore..."
+              URL="http://127.0.0.1:7001"
+              PATTERN="instance_start_time"
+              TIMEOUT=60
+              TMP="$(mktemp)"
+              deadline=$((SECONDS + TIMEOUT))
+              last_status=""
+
+              while (( SECONDS < deadline )); do
+                last_status="$(curl -sS -o "$TMP" -w '%{http_code}' "$URL" || true)"
+                if [[ "$last_status" == "200" ]] && grep -q "$PATTERN" "$TMP"; then
+                  echo "cnpmcore is ready (status=$last_status)"
+                  rm -f "$TMP"
+                  npx eggctl stop || true
+                  exit 0
+                fi
+                sleep 1
+              done
+
+              echo "Health check failed: status=$last_status"
+              cat "$TMP" || true
+              rm -f "$TMP"
+              npx eggctl stop || true
+              exit 1
           - name: examples
             node-version: 24
             command: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -58,6 +58,7 @@ jobs:
 
               # Run the full test suite
               echo "Preparing database for tests..."
+              CNPMCORE_DATABASE_NAME=cnpmcore_unittest bash ./prepare-database-mysql.sh
               CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
               npm run test:local
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -53,8 +53,17 @@ jobs:
               npm run build
               npm run prepublishOnly
 
+              # Clean build artifacts to avoid double-loading (src + dist)
+              npm run clean
+
+              # Run the full test suite
+              echo "Preparing database for tests..."
+              CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
+              npm run test:local
+
               # Deployment test: start the app and verify it boots correctly
-              echo "Preparing database..."
+              npm run clean
+              echo "Preparing database for deployment test..."
               CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
 
               echo "Starting cnpmcore..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -694,6 +694,41 @@ NODE_OPTIONS='--inspect-brk' pnpm --filter=egg run test test/app/extend/context.
 - `EGG_TYPESCRIPT` - Enable TypeScript support (true/false)
 - `DEBUG` - Enable debug output (egg:\*)
 
+### Debugging E2E Tests Locally
+
+The `ecosystem-ci/` directory contains E2E test infrastructure for downstream projects (e.g., cnpmcore). To reproduce and debug E2E failures locally:
+
+```bash
+# 1. Build all monorepo packages
+pnpm run build
+
+# 2. Pack all packages as tgz files (placed at workspace root)
+pnpm -r pack
+
+# 3. Clone the downstream project into ecosystem-ci/
+git clone https://github.com/cnpmjs/cnpmcore.git ecosystem-ci/cnpmcore
+
+# 4. Patch the project's package.json with local tgz overrides
+npx tsx ecosystem-ci/patch-project.ts cnpmcore
+
+# 5. Install (clean cache to avoid stale tgz)
+cd ecosystem-ci/cnpmcore
+npm cache clean --force
+npm install
+
+# 6. Run tests
+npm run clean
+npx egg-bin test test/path/to/specific.test.ts
+```
+
+After making changes to monorepo packages, repeat steps 1-5 (build → pack → patch → clean install).
+
+**Key files:**
+
+- `ecosystem-ci/patch-project.ts` - Generates `overrides` field in target project's package.json pointing to local tgz files
+- `ecosystem-ci/repo.json` - Defines which downstream projects can be tested
+- `.github/workflows/e2e-test.yml` - CI workflow that runs E2E tests with MySQL/Redis services
+
 ### Common Development Patterns
 
 #### Creating a New Service

--- a/plugins/mock/src/setup_vitest.ts
+++ b/plugins/mock/src/setup_vitest.ts
@@ -14,6 +14,19 @@ if (!g.afterEach) g.afterEach = afterEach;
 // so setupApp() in app_handler.ts should skip registering duplicate hooks
 (globalThis as Record<string, unknown>).__eggMockVitestSetup = true;
 
+// Auto-configure @eggjs/tegg-vitest runner for context injection.
+// The runner checks __teggVitestConfig to decide whether to create
+// per-test tegg module scopes (so app.currentContext is available).
+if (!(globalThis as Record<string, unknown>).__teggVitestConfig) {
+  (globalThis as Record<string, unknown>).__teggVitestConfig = {
+    restoreMocks: true,
+    getApp: async () => {
+      const bootstrap = await import('./bootstrap.ts');
+      return (bootstrap as any)?.app;
+    },
+  };
+}
+
 let app: MockApplication | undefined;
 
 // Cache the startup promise so that:
@@ -21,6 +34,11 @@ let app: MockApplication | undefined;
 // 2. If startup fails, subsequent test files fail immediately
 // 3. If startup hangs, all files share the same pending promise
 let startupPromise: Promise<void> | undefined;
+
+// Per-test tegg module scope state (used when @eggjs/tegg-vitest runner is NOT active)
+let heldScopeEndFn: (() => void) | null = null;
+let heldScopePromise: Promise<void> | null = null;
+let suiteCtx: any = null;
 
 beforeAll(async () => {
   if (!startupPromise) {
@@ -34,9 +52,83 @@ beforeAll(async () => {
     startupPromise.catch(() => {});
   }
   await startupPromise;
+
+  // Create a suite-level context for tegg if the runner is not handling it.
+  // The runner sets fileScopeMap entries; if it's not active we handle it here.
+  if (app && typeof (app as any).mockContext === 'function' && (app as any).ctxStorage) {
+    suiteCtx = (app as any).mockContext(undefined, {
+      mockCtxStorage: false,
+      reuseCtxStorage: false,
+    });
+    (app as any).ctxStorage.enterWith(suiteCtx);
+
+    if (typeof suiteCtx.beginModuleScope === 'function') {
+      let endScope!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        endScope = resolve;
+      });
+      let ready!: () => void;
+      const readyP = new Promise<void>((resolve) => {
+        ready = resolve;
+      });
+      const scopeP = suiteCtx.beginModuleScope(async () => {
+        ready();
+        await gate;
+      });
+      await Promise.race([readyP, scopeP]);
+      heldScopeEndFn = endScope;
+      heldScopePromise = scopeP;
+    }
+  }
+});
+
+beforeEach(async () => {
+  // Create a per-test context so app.currentContext is available
+  if (app && typeof (app as any).mockContext === 'function' && (app as any).ctxStorage) {
+    const testCtx = (app as any).mockContext(undefined, {
+      mockCtxStorage: false,
+      reuseCtxStorage: false,
+    });
+    (app as any).ctxStorage.enterWith(testCtx);
+
+    if (typeof testCtx.beginModuleScope === 'function') {
+      let endScope!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        endScope = resolve;
+      });
+      let ready!: () => void;
+      const readyP = new Promise<void>((resolve) => {
+        ready = resolve;
+      });
+      const scopeP = testCtx.beginModuleScope(async () => {
+        ready();
+        await gate;
+      });
+      await Promise.race([readyP, scopeP]);
+
+      // Store for cleanup in afterEach
+      (globalThis as Record<string, unknown>).__eggTestScopeEnd = endScope;
+      (globalThis as Record<string, unknown>).__eggTestScopePromise = scopeP;
+    }
+  }
 });
 
 afterEach(async () => {
+  // Release per-test tegg module scope
+  const endScope = (globalThis as Record<string, unknown>).__eggTestScopeEnd as (() => void) | undefined;
+  const scopePromise = (globalThis as Record<string, unknown>).__eggTestScopePromise as Promise<void> | undefined;
+  if (endScope) {
+    endScope();
+    await scopePromise;
+    (globalThis as Record<string, unknown>).__eggTestScopeEnd = undefined;
+    (globalThis as Record<string, unknown>).__eggTestScopePromise = undefined;
+  }
+
+  // Restore suite context
+  if (suiteCtx && app && (app as any).ctxStorage) {
+    (app as any).ctxStorage.enterWith(suiteCtx);
+  }
+
   if (app && typeof app.backgroundTasksFinished === 'function') {
     await app.backgroundTasksFinished();
   }
@@ -44,5 +136,13 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
+  // Release suite-level scope
+  if (heldScopeEndFn) {
+    heldScopeEndFn();
+    await heldScopePromise;
+    heldScopeEndFn = null;
+    heldScopePromise = null;
+  }
+  suiteCtx = null;
   if (app) await app.close();
 });

--- a/plugins/mock/src/setup_vitest.ts
+++ b/plugins/mock/src/setup_vitest.ts
@@ -17,6 +17,7 @@ if (!g.afterEach) g.afterEach = afterEach;
 // Auto-configure @eggjs/tegg-vitest runner for context injection.
 // The runner checks __teggVitestConfig to decide whether to create
 // per-test tegg module scopes (so app.currentContext is available).
+// Tegg scope creation is handled exclusively by the runner, not here.
 if (!(globalThis as Record<string, unknown>).__teggVitestConfig) {
   (globalThis as Record<string, unknown>).__teggVitestConfig = {
     restoreMocks: true,
@@ -35,11 +36,6 @@ let app: MockApplication | undefined;
 // 3. If startup hangs, all files share the same pending promise
 let startupPromise: Promise<void> | undefined;
 
-// Per-test tegg module scope state (used when @eggjs/tegg-vitest runner is NOT active)
-let heldScopeEndFn: (() => void) | null = null;
-let heldScopePromise: Promise<void> | null = null;
-let suiteCtx: any = null;
-
 beforeAll(async () => {
   if (!startupPromise) {
     startupPromise = (async () => {
@@ -52,83 +48,9 @@ beforeAll(async () => {
     startupPromise.catch(() => {});
   }
   await startupPromise;
-
-  // Create a suite-level context for tegg if the runner is not handling it.
-  // The runner sets fileScopeMap entries; if it's not active we handle it here.
-  if (app && typeof (app as any).mockContext === 'function' && (app as any).ctxStorage) {
-    suiteCtx = (app as any).mockContext(undefined, {
-      mockCtxStorage: false,
-      reuseCtxStorage: false,
-    });
-    (app as any).ctxStorage.enterWith(suiteCtx);
-
-    if (typeof suiteCtx.beginModuleScope === 'function') {
-      let endScope!: () => void;
-      const gate = new Promise<void>((resolve) => {
-        endScope = resolve;
-      });
-      let ready!: () => void;
-      const readyP = new Promise<void>((resolve) => {
-        ready = resolve;
-      });
-      const scopeP = suiteCtx.beginModuleScope(async () => {
-        ready();
-        await gate;
-      });
-      await Promise.race([readyP, scopeP]);
-      heldScopeEndFn = endScope;
-      heldScopePromise = scopeP;
-    }
-  }
-});
-
-beforeEach(async () => {
-  // Create a per-test context so app.currentContext is available
-  if (app && typeof (app as any).mockContext === 'function' && (app as any).ctxStorage) {
-    const testCtx = (app as any).mockContext(undefined, {
-      mockCtxStorage: false,
-      reuseCtxStorage: false,
-    });
-    (app as any).ctxStorage.enterWith(testCtx);
-
-    if (typeof testCtx.beginModuleScope === 'function') {
-      let endScope!: () => void;
-      const gate = new Promise<void>((resolve) => {
-        endScope = resolve;
-      });
-      let ready!: () => void;
-      const readyP = new Promise<void>((resolve) => {
-        ready = resolve;
-      });
-      const scopeP = testCtx.beginModuleScope(async () => {
-        ready();
-        await gate;
-      });
-      await Promise.race([readyP, scopeP]);
-
-      // Store for cleanup in afterEach
-      (globalThis as Record<string, unknown>).__eggTestScopeEnd = endScope;
-      (globalThis as Record<string, unknown>).__eggTestScopePromise = scopeP;
-    }
-  }
 });
 
 afterEach(async () => {
-  // Release per-test tegg module scope
-  const endScope = (globalThis as Record<string, unknown>).__eggTestScopeEnd as (() => void) | undefined;
-  const scopePromise = (globalThis as Record<string, unknown>).__eggTestScopePromise as Promise<void> | undefined;
-  if (endScope) {
-    endScope();
-    await scopePromise;
-    (globalThis as Record<string, unknown>).__eggTestScopeEnd = undefined;
-    (globalThis as Record<string, unknown>).__eggTestScopePromise = undefined;
-  }
-
-  // Restore suite context
-  if (suiteCtx && app && (app as any).ctxStorage) {
-    (app as any).ctxStorage.enterWith(suiteCtx);
-  }
-
   if (app && typeof app.backgroundTasksFinished === 'function') {
     await app.backgroundTasksFinished();
   }
@@ -136,13 +58,5 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
-  // Release suite-level scope
-  if (heldScopeEndFn) {
-    heldScopeEndFn();
-    await heldScopePromise;
-    heldScopeEndFn = null;
-    heldScopePromise = null;
-  }
-  suiteCtx = null;
   if (app) await app.close();
 });

--- a/plugins/redis/src/lib/redis.ts
+++ b/plugins/redis/src/lib/redis.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert';
 import { once } from 'node:events';
 
 import type { ILifecycleBoot, EggApplicationCore } from 'egg';
-import { Redis } from 'ioredis';
+import type { Redis } from 'ioredis';
+import IoRedis from 'ioredis';
 
 import type { RedisClusterOptions, RedisClientOptions } from '../config/config.default.ts';
 
@@ -25,7 +26,10 @@ export class RedisBoot implements ILifecycleBoot {
 
 let count = 0;
 function createClient(options: RedisClusterOptions | RedisClientOptions, app: EggApplicationCore) {
-  const RedisClass = app.config.redis.Redis ?? Redis;
+  // Use default import for ioredis CJS module to avoid named export interop issues.
+  // ioredis uses `exports = module.exports = require("./Redis").default` which causes
+  // cjs-module-lexer to fail resolving named exports in some ESM interop scenarios.
+  const RedisClass: typeof Redis = app.config.redis.Redis ?? (IoRedis as unknown as typeof Redis);
   let client;
 
   if ('cluster' in options && options.cluster === true) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3613,6 +3613,9 @@ importers:
 
   tools/egg-bin:
     dependencies:
+      '@eggjs/tegg-vitest':
+        specifier: workspace:*
+        version: link:../../tegg/core/vitest
       '@eggjs/utils':
         specifier: workspace:*
         version: link:../../packages/utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3432,6 +3432,9 @@ importers:
       '@eggjs/tegg-runtime':
         specifier: workspace:*
         version: link:../../core/runtime
+      '@eggjs/utils':
+        specifier: workspace:*
+        version: link:../../../packages/utils
     devDependencies:
       '@eggjs/mock':
         specifier: workspace:*

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -23,7 +23,7 @@ const isDryRun = args.includes('--dry-run');
 const useProvenance = args.includes('--provenance');
 
 let npmTag = 'latest';
-const tagArg = args.find(arg => arg.startsWith('--tag='));
+const tagArg = args.find((arg) => arg.startsWith('--tag='));
 if (tagArg) {
   npmTag = tagArg.split('=')[1];
 }
@@ -31,7 +31,9 @@ if (tagArg) {
 const baseDir = path.join(import.meta.dirname, '..');
 const packages = getPublishablePackages(baseDir);
 
-console.log(`📦 Publishing ${packages.length} packages (tag: ${npmTag}${isDryRun ? ', dry-run' : ''}${useProvenance ? ', provenance' : ''})`);
+console.log(
+  `📦 Publishing ${packages.length} packages (tag: ${npmTag}${isDryRun ? ', dry-run' : ''}${useProvenance ? ', provenance' : ''})`,
+);
 
 /**
  * Check if a specific version of a package is already published on npm.
@@ -56,10 +58,7 @@ function isPublished(name, version) {
  * so that workspace: protocol references are properly resolved).
  */
 function publishOne(pkg) {
-  const publishArgs = [
-    '--filter', pkg.name,
-    'publish', '--no-git-checks', '--access', 'public', '--tag', npmTag,
-  ];
+  const publishArgs = ['--filter', pkg.name, 'publish', '--no-git-checks', '--access', 'public', '--tag', npmTag];
   if (useProvenance) publishArgs.push('--provenance');
   if (isDryRun) publishArgs.push('--dry-run');
 

--- a/tegg/core/common-util/src/NameUtil.ts
+++ b/tegg/core/common-util/src/NameUtil.ts
@@ -1,5 +1,15 @@
 export class NameUtil {
+  /**
+   * Strip $N suffix added by compiler decorator transforms (e.g., oxc/tsdown).
+   * During decorator downlevel, compilers may rename class expressions to avoid
+   * name conflicts (e.g., BackgroundTaskHelper -> BackgroundTaskHelper$1).
+   */
+  static cleanName(name: string): string {
+    return name.replace(/\$\d+$/, '');
+  }
+
   static getClassName(constructor: Function): string {
-    return constructor.name[0].toLowerCase() + constructor.name.substring(1);
+    const name = NameUtil.cleanName(constructor.name);
+    return name[0].toLowerCase() + name.substring(1);
   }
 }

--- a/tegg/core/core-decorator/src/decorator/MultiInstanceProto.ts
+++ b/tegg/core/core-decorator/src/decorator/MultiInstanceProto.ts
@@ -1,4 +1,4 @@
-import { StackUtil } from '@eggjs/tegg-common-util';
+import { NameUtil, StackUtil } from '@eggjs/tegg-common-util';
 import { ObjectInitType, AccessLevel, DEFAULT_PROTO_IMPL_TYPE } from '@eggjs/tegg-types';
 import type {
   EggMultiInstanceCallbackPrototypeInfo,
@@ -24,14 +24,14 @@ export function MultiInstanceProto(param: MultiInstancePrototypeParams) {
       const property: EggMultiInstancePrototypeInfo = {
         ...DEFAULT_PARAMS,
         ...(param as MultiInstancePrototypeStaticParams),
-        className: clazz.name,
+        className: NameUtil.cleanName(clazz.name),
       };
       PrototypeUtil.setMultiInstanceStaticProperty(clazz, property);
     } else if ((param as MultiInstancePrototypeCallbackParams).getObjects) {
       const property: EggMultiInstanceCallbackPrototypeInfo = {
         ...DEFAULT_PARAMS,
         ...(param as MultiInstancePrototypeCallbackParams),
-        className: clazz.name,
+        className: NameUtil.cleanName(clazz.name),
       };
       PrototypeUtil.setMultiInstanceCallbackProperty(clazz, property);
     }

--- a/tegg/core/core-decorator/src/decorator/Prototype.ts
+++ b/tegg/core/core-decorator/src/decorator/Prototype.ts
@@ -23,7 +23,7 @@ export function Prototype(param?: PrototypeParams): PrototypeDecorator {
     const property: Partial<EggPrototypeInfo> = {
       ...DEFAULT_PARAMS,
       ...param,
-      className: clazz.name,
+      className: NameUtil.cleanName(clazz.name),
     };
     if (!property.name) {
       property.name = NameUtil.getClassName(clazz);

--- a/tegg/core/core-decorator/src/util/QualifierUtil.ts
+++ b/tegg/core/core-decorator/src/util/QualifierUtil.ts
@@ -81,7 +81,12 @@ export class QualifierUtil {
   }
 
   static getQualifierValue(clazz: EggProtoImplClass, attribute: QualifierAttribute): QualifierValue | undefined {
-    const qualifiers: Map<QualifierAttribute, QualifierValue> | undefined = MetadataUtil.getMetaData(
+    // Use getOwnMetaData instead of getMetaData to avoid reading qualifiers
+    // from parent classes via the prototype chain. Without this, subclasses
+    // (e.g., ElectronBinary extends GithubBinary) would incorrectly see the
+    // parent's qualifier as their own, causing the duplicate qualifier check
+    // in addProtoQualifier to throw a false positive.
+    const qualifiers: Map<QualifierAttribute, QualifierValue> | undefined = MetadataUtil.getOwnMetaData(
       QUALIFIER_META_DATA,
       clazz,
     );

--- a/tegg/core/loader/src/LoaderUtil.ts
+++ b/tegg/core/loader/src/LoaderUtil.ts
@@ -58,6 +58,7 @@ export class LoaderUtil {
   }
 
   static async loadFile(filePath: string): Promise<EggProtoImplClass[]> {
+    const originalFilePath = filePath;
     if (process.platform === 'win32') {
       // convert to file:// url
       // avoid windows path issue: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
@@ -82,6 +83,10 @@ export class LoaderUtil {
       if (!isEggProto) {
         continue;
       }
+      // Correct FILE_PATH after async import, because decorators like @Schedule
+      // use StackUtil.getCalleeFromStack() which may return <anonymous> when
+      // modules are loaded via async import() (e.g., in vitest environment)
+      PrototypeUtil.setFilePath(clazz, originalFilePath);
       clazzList.push(clazz);
     }
     return clazzList;

--- a/tegg/core/metadata/src/model/ProtoDescriptor/ClassProtoDescriptor.ts
+++ b/tegg/core/metadata/src/model/ProtoDescriptor/ClassProtoDescriptor.ts
@@ -1,4 +1,5 @@
 import { QualifierUtil } from '@eggjs/core-decorator';
+import { NameUtil } from '@eggjs/tegg-common-util';
 import { type EggProtoImplClass, type ProtoDescriptor, ProtoDescriptorType } from '@eggjs/tegg-types';
 
 import { AbstractProtoDescriptor, type AbstractProtoDescriptorOptions } from './AbstractProtoDescriptor.ts';
@@ -21,7 +22,7 @@ export class ClassProtoDescriptor extends AbstractProtoDescriptor {
       ...options,
     });
     this.clazz = options.clazz;
-    this.className = this.clazz.name;
+    this.className = NameUtil.cleanName(this.clazz.name);
   }
 
   equal(protoDescriptor: ProtoDescriptor): boolean {

--- a/tegg/core/vitest/src/runner.ts
+++ b/tegg/core/vitest/src/runner.ts
@@ -101,18 +101,24 @@ export default class TeggVitestRunner extends VitestTestRunner {
     const result = await super.importFile(filepath, source);
 
     if (source === 'collect') {
+      // Use per-file config from configureTeggRunner() if available,
+      // otherwise fall back to default (auto-detect @eggjs/mock/bootstrap app)
       const rawConfig = (globalThis as any).__teggVitestConfig;
+      delete (globalThis as any).__teggVitestConfig;
+
+      const config: TeggRunnerConfig = {
+        restoreMocks: rawConfig?.restoreMocks ?? true,
+        getApp: rawConfig?.getApp ?? defaultGetApp,
+      };
+
       if (rawConfig) {
-        delete (globalThis as any).__teggVitestConfig;
-
-        const config: TeggRunnerConfig = {
-          restoreMocks: rawConfig.restoreMocks ?? true,
-          getApp: rawConfig.getApp ?? defaultGetApp,
-        };
-
         debugLog(`captured config for ${filepath}`);
+      } else {
+        debugLog(`auto-detect app for ${filepath}`);
+      }
 
-        // Resolve app and await ready during collection
+      // Resolve app and await ready during collection
+      if (!this.fileAppMap.has(filepath)) {
         try {
           const app = await config.getApp();
           if (app) {
@@ -120,11 +126,10 @@ export default class TeggVitestRunner extends VitestTestRunner {
             this.fileAppMap.set(filepath, { app, config });
             debugLog(`app ready for ${filepath}`);
           }
-        } catch (err) {
+        } catch {
           if (!this.warned) {
             this.warned = true;
-            // eslint-disable-next-line no-console
-            console.warn('[tegg-vitest] getApp failed, skip context injection.', err);
+            debugLog('getApp failed, skip context injection.');
           }
         }
       }

--- a/tegg/core/vitest/test/get_app_throw.test.ts
+++ b/tegg/core/vitest/test/get_app_throw.test.ts
@@ -1,11 +1,10 @@
 import assert from 'assert';
 
-import { describe, it, afterAll, vi } from 'vitest';
+import { describe, it } from 'vitest';
 
 import { configureTeggRunner } from '../src/index.ts';
 
 let getAppCalls = 0;
-const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 configureTeggRunner({
   getApp() {
@@ -17,12 +16,8 @@ configureTeggRunner({
 
 describe('getApp throw handling', () => {
   it('should not crash suite when getApp throws', () => {
-    // The runner calls getApp in onBeforeRunSuite, so it should have been called
+    // The runner calls getApp during importFile (collection phase),
+    // so it should have been called and the error handled gracefully.
     assert(getAppCalls > 0);
-    assert(warnSpy.mock.calls.length > 0);
-  });
-
-  afterAll(() => {
-    warnSpy.mockRestore();
   });
 });

--- a/tegg/plugin/langchain/src/lib/graph/GraphLoadUnitHook.ts
+++ b/tegg/plugin/langchain/src/lib/graph/GraphLoadUnitHook.ts
@@ -6,6 +6,7 @@ import { EggPrototypeCreatorFactory, EggPrototypeFactory, ProtoDescriptorHelper 
 import type { ClassProtoDescriptor, EggPrototypeWithClazz, LoadUnit, LoadUnitLifecycleContext } from '@eggjs/metadata';
 import { AccessLevel, LifecyclePostInject, MCPInfoUtil, SingletonProto } from '@eggjs/tegg';
 import type { EggProtoImplClass, LifecycleHook } from '@eggjs/tegg';
+import { NameUtil } from '@eggjs/tegg-common-util';
 import { EggContainerFactory } from '@eggjs/tegg-runtime';
 import { DynamicStructuredTool } from 'langchain';
 import * as z from 'zod/v4';
@@ -29,7 +30,7 @@ export class GraphLoadUnitHook implements LifecycleHook<LoadUnitLifecycleContext
     for (const clazz of clazzList) {
       const meta = this.clazzMap.get(clazz as EggProtoImplClass);
       if (meta) {
-        const protoName = clazz.name[0].toLowerCase() + clazz.name.substring(1);
+        const protoName = NameUtil.getClassName(clazz);
         const graphMetadata = GraphInfoUtil.getGraphMetadata(clazz as EggProtoImplClass);
         assert(graphMetadata, `${clazz.name} graphMetadata should not be null`);
         const proto = new CompiledStateGraphProto(

--- a/tegg/plugin/schedule/package.json
+++ b/tegg/plugin/schedule/package.json
@@ -67,7 +67,8 @@
     "@eggjs/module-common": "workspace:*",
     "@eggjs/schedule-decorator": "workspace:*",
     "@eggjs/tegg-loader": "workspace:*",
-    "@eggjs/tegg-runtime": "workspace:*"
+    "@eggjs/tegg-runtime": "workspace:*",
+    "@eggjs/utils": "workspace:*"
   },
   "devDependencies": {
     "@eggjs/mock": "workspace:*",

--- a/tegg/plugin/schedule/src/lib/ScheduleManager.ts
+++ b/tegg/plugin/schedule/src/lib/ScheduleManager.ts
@@ -1,5 +1,6 @@
 import { PrototypeUtil } from '@eggjs/core-decorator';
 import type { EggPrototype } from '@eggjs/metadata';
+import { importResolve } from '@eggjs/utils';
 import type { Application } from 'egg';
 
 /**
@@ -27,7 +28,9 @@ export class ScheduleManager {
    * Unregister a single schedule by prototype
    */
   unregister(proto: EggPrototype): void {
-    const key = proto.getMetaData(PrototypeUtil.FILE_PATH) as string;
+    const rawKey = proto.getMetaData(PrototypeUtil.FILE_PATH) as string;
+    // Normalize key with importResolve to match the normalized key used during registration
+    const key = importResolve(rawKey);
     if (this.registeredSchedules.has(key)) {
       (this.app as any).scheduleWorker.unregisterSchedule(key);
       this.registeredSchedules.delete(key);

--- a/tegg/plugin/schedule/src/lib/ScheduleWorkerRegister.ts
+++ b/tegg/plugin/schedule/src/lib/ScheduleWorkerRegister.ts
@@ -3,6 +3,7 @@ import { debuglog } from 'node:util';
 import { PrototypeUtil } from '@eggjs/core-decorator';
 import type { EggPrototype } from '@eggjs/metadata';
 import { ScheduleMetadata } from '@eggjs/schedule-decorator';
+import { importResolve } from '@eggjs/utils';
 
 import { eggScheduleAdapterFactory } from './EggScheduleAdapter.ts';
 import { EggScheduleMetadataConvertor } from './EggScheduleMetadataConvertor.ts';
@@ -20,15 +21,19 @@ export class ScheduleWorkerRegister {
   register(proto: EggPrototype, metadata: ScheduleMetadata<object>): void {
     const task = eggScheduleAdapterFactory(proto, metadata);
     const schedule = EggScheduleMetadataConvertor.convertToEggSchedule(metadata);
-    const key = proto.getMetaData<string>(PrototypeUtil.FILE_PATH) as string;
-    if (!key) {
+    const rawKey = proto.getMetaData<string>(PrototypeUtil.FILE_PATH) as string;
+    if (!rawKey) {
       throw new Error(`schedule prototype: ${proto.name as string} missing FILE_PATH metadata`);
     }
+    // Normalize the key with importResolve to match how runSchedule() resolves paths.
+    // Without this, tegg-registered schedules use the raw FILE_PATH (e.g., .ts source path)
+    // while runSchedule() applies importResolve() which may resolve to a different path.
+    const key = importResolve(rawKey);
     this.scheduleManager.register(proto, {
       schedule,
       task,
       key,
     });
-    debug('register schedule %s, config: %j', key, schedule);
+    debug('register schedule %s (raw: %s), config: %j', key, rawKey, schedule);
   }
 }

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -56,6 +56,7 @@
     "ci": "npm run cov"
   },
   "dependencies": {
+    "@eggjs/tegg-vitest": "workspace:*",
     "@eggjs/utils": "workspace:*",
     "@oclif/core": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/tools/egg-bin/src/commands/test.ts
+++ b/tools/egg-bin/src/commands/test.ts
@@ -216,15 +216,23 @@ export default class Test<T extends typeof Test> extends BaseCommand<T> {
     }
 
     // auto detect @eggjs/tegg-vitest/runner
+    // Try resolving from the project first, then from egg-bin's own dependencies.
+    // This ensures tegg context injection works even when the project doesn't
+    // explicitly depend on @eggjs/tegg-vitest (e.g. cnpmcore).
     let runner: string | undefined;
-    try {
-      runner = importResolve('@eggjs/tegg-vitest/runner', {
-        paths: [flags.base],
-      });
-      debug('auto use @eggjs/tegg-vitest/runner: %o', runner);
-    } catch (err) {
-      if (!(err instanceof ImportResolveError)) throw err;
-      debug('skip @eggjs/tegg-vitest/runner: @eggjs/tegg-vitest not installed');
+    for (const resolveFrom of [flags.base, import.meta.dirname]) {
+      try {
+        runner = importResolve('@eggjs/tegg-vitest/runner', {
+          paths: [resolveFrom],
+        });
+        debug('auto use @eggjs/tegg-vitest/runner from %s: %o', resolveFrom, runner);
+        break;
+      } catch (err) {
+        if (!(err instanceof ImportResolveError)) throw err;
+      }
+    }
+    if (!runner) {
+      debug('skip @eggjs/tegg-vitest/runner: not resolvable');
     }
 
     return {

--- a/tools/egg-bin/src/commands/test.ts
+++ b/tools/egg-bin/src/commands/test.ts
@@ -246,6 +246,7 @@ export default class Test<T extends typeof Test> extends BaseCommand<T> {
       runner,
       reporters: [process.env.TEST_REPORTER ?? 'default'],
       pool: 'forks',
+      fileParallelism: process.env.EGG_FILE_PARALLELISM !== 'false',
       // vitest 4 moved poolOptions to top-level
       execArgv: [...this.globalExecArgv],
       watch: flags.watch,


### PR DESCRIPTION
## Summary
- Fix `TypeError: RedisClass is not a constructor` in `@eggjs/redis` caused by ioredis CJS-ESM named export interop failure
- Add deployment test (MySQL + Redis + health check) to cnpmcore e2e workflow so runtime issues are caught

## Root Cause
ioredis CJS entry uses `exports = module.exports = require("./Redis").default`, which causes `cjs-module-lexer` to fail resolving named exports in some ESM interop scenarios. `import { Redis } from "ioredis"` returns `undefined` at runtime → `new RedisClass(config)` throws.

## Fix
Switch to default import (`import IoRedis from "ioredis"`) which reads `module.exports` directly.

## Why e2e didn't catch this
The cnpmcore e2e only ran `lint`/`typecheck`/`build`/`prepublishOnly` — all static analysis, never starting the application. Now it also starts cnpmcore and verifies the health endpoint responds.

## Test plan
- [x] `pnpm --filter=@eggjs/redis run typecheck` passes
- [x] `pnpm build --filter=@eggjs/redis` passes
- [x] Manually verified `RedisClass is not a constructor` is fixed in cnpmcore
- [ ] CI e2e deployment test passes with MySQL + Redis services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test workflow with MySQL and Redis services, build-clean steps, database preparation, background app startup, automated health checks with timeout, and diagnostic output on failure.

* **Refactor**
  * Normalized class-name handling across the system to a centralized utility for consistent naming.
  * Improved Redis client interop with a safer fallback when the configured client is unavailable.

* **Bug Fix**
  * Adjusted qualifier lookup to avoid inheriting parent-class qualifiers, preventing false duplicate detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->