### PR TITLE
fix(mock): fail fast when app startup fails in vitest

### DIFF
--- a/plugins/mock/src/lib/app_handler.ts
+++ b/plugins/mock/src/lib/app_handler.ts
@@ -41,21 +41,25 @@ export function setupApp(): ApplicationUnittest {
     debug('mockParallelApp app: %s', !!app);
   } else {
     app = createApp(options) as unknown as ApplicationUnittest;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if (typeof beforeAll === 'function') {
+    // Skip hook registration when vitest setup_vitest.ts is handling the lifecycle
+    const vitestSetup = (globalThis as Record<string, unknown>).__eggMockVitestSetup;
+    if (!vitestSetup) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      // jest
-      beforeAll(() => app.ready());
-    }
-    // @ts-ignore mocha tsd
-    if (typeof afterEach === 'function') {
-      // mocha and jest
+      if (typeof beforeAll === 'function') {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        // jest
+        beforeAll(() => app.ready());
+      }
       // @ts-ignore mocha tsd
-      afterEach(() => app.backgroundTasksFinished());
-      // @ts-ignore mocha tsd
-      afterEach(restore);
+      if (typeof afterEach === 'function') {
+        // mocha and jest
+        // @ts-ignore mocha tsd
+        afterEach(() => app.backgroundTasksFinished());
+        // @ts-ignore mocha tsd
+        afterEach(restore);
+      }
     }
   }
   globalThis.__eggMockAppInstance = app;

--- a/plugins/mock/src/setup_vitest.ts
+++ b/plugins/mock/src/setup_vitest.ts
@@ -10,12 +10,30 @@ if (!g.after) g.after = afterAll;
 if (!g.beforeEach) g.beforeEach = beforeEach;
 if (!g.afterEach) g.afterEach = afterEach;
 
+// Signal that vitest setup is handling the lifecycle hooks,
+// so setupApp() in app_handler.ts should skip registering duplicate hooks
+(globalThis as Record<string, unknown>).__eggMockVitestSetup = true;
+
 let app: MockApplication | undefined;
 
+// Cache the startup promise so that:
+// 1. Only one startup attempt is made per worker
+// 2. If startup fails, subsequent test files fail immediately
+// 3. If startup hangs, all files share the same pending promise
+let startupPromise: Promise<void> | undefined;
+
 beforeAll(async () => {
-  const { app: bootstrapApp } = await import('./bootstrap.ts');
-  app = bootstrapApp;
-  await app.ready();
+  if (!startupPromise) {
+    startupPromise = (async () => {
+      const { app: bootstrapApp } = await import('./bootstrap.ts');
+      app = bootstrapApp;
+      await app.ready();
+    })();
+    // Prevent unhandled promise rejection when startup fails
+    // (the error will be re-thrown via await in each beforeAll)
+    startupPromise.catch(() => {});
+  }
+  await startupPromise;
 });
 
 afterEach(async () => {

--- a/plugins/mock/test/setup_vitest.test.ts
+++ b/plugins/mock/test/setup_vitest.test.ts
@@ -1,0 +1,118 @@
+import { strict as assert } from 'node:assert';
+
+import { describe, it, afterEach } from 'vitest';
+
+import mm from '../src/index.ts';
+import { getFixtures } from './helper.ts';
+
+describe('test/setup_vitest.test.ts', () => {
+  afterEach(mm.restore);
+
+  it('should fail fast with cached startupPromise vs old pattern', async () => {
+    const FILE_COUNT = 10;
+    const baseDir = getFixtures('app-fail');
+
+    // --- Old pattern ---
+    // Old setup_vitest.ts: each beforeAll creates a new `await app.ready()` call.
+    // Old app_handler.ts (with globals: true) also registered a duplicate
+    // `beforeAll(() => app.ready())` + two afterEach hooks.
+    // Per file: 2x beforeAll + 2x afterEach = 4 hook executions.
+    const oldApp = mm.app({ baseDir, cache: false });
+    const oldDurations: number[] = [];
+
+    for (let i = 0; i < FILE_COUNT; i++) {
+      const start = Date.now();
+      // setup_vitest.ts beforeAll: await app.ready()
+      try {
+        await oldApp.ready();
+      } catch {
+        /* expected */
+      }
+      // app_handler.ts duplicate beforeAll: app.ready()
+      try {
+        await oldApp.ready();
+      } catch {
+        /* expected */
+      }
+      // app_handler.ts afterEach: app.backgroundTasksFinished()
+      try {
+        await (oldApp as any).backgroundTasksFinished?.();
+      } catch {
+        /* expected */
+      }
+      // app_handler.ts afterEach: restore()
+      try {
+        await mm.restore();
+      } catch {
+        /* expected */
+      }
+      oldDurations.push(Date.now() - start);
+    }
+    await oldApp.close();
+
+    // --- New pattern ---
+    // Single cached startupPromise, no duplicate hooks.
+    // Per file: 1x await startupPromise (instant if cached).
+    const newApp = mm.app({ baseDir, cache: false });
+    const newDurations: number[] = [];
+
+    let startupPromise: Promise<void> | undefined;
+    for (let i = 0; i < FILE_COUNT; i++) {
+      const start = Date.now();
+      if (!startupPromise) {
+        startupPromise = (async () => {
+          await newApp.ready();
+        })();
+        startupPromise.catch(() => {});
+      }
+      try {
+        await startupPromise;
+      } catch {
+        /* expected */
+      }
+      newDurations.push(Date.now() - start);
+    }
+    await newApp.close();
+
+    const oldTotal = oldDurations.reduce((a, b) => a + b, 0);
+    const newTotal = newDurations.reduce((a, b) => a + b, 0);
+
+    console.log(`Old pattern (${FILE_COUNT} files, 2x ready + 2x afterEach each):`);
+    console.log(`  durations: [${oldDurations.join(', ')}]ms, total=${oldTotal}ms`);
+    console.log(`New pattern (${FILE_COUNT} files, cached promise):`);
+    console.log(`  durations: [${newDurations.join(', ')}]ms, total=${newTotal}ms`);
+
+    // New pattern: files after the first should be 0ms
+    for (let i = 1; i < FILE_COUNT; i++) {
+      assert(newDurations[i] < 50, `new pattern file ${i + 1} should be instant, got ${newDurations[i]}ms`);
+    }
+  });
+
+  it('should not re-attempt startup when startupPromise is cached', async () => {
+    let initCount = 0;
+    const baseDir = getFixtures('app-fail');
+
+    let startupPromise: Promise<void> | undefined;
+
+    // Simulate the setup_vitest.ts beforeAll pattern for 3 test files
+    for (let i = 0; i < 3; i++) {
+      if (!startupPromise) {
+        initCount++;
+        const app = mm.app({ baseDir, cache: false });
+        startupPromise = (async () => {
+          await app.ready();
+        })();
+        startupPromise.catch(() => {});
+      }
+
+      try {
+        await startupPromise;
+      } catch {
+        // expected
+      }
+    }
+
+    // Should only have attempted startup once
+    assert.equal(initCount, 1, 'should only attempt startup once, not once per test file');
+  });
+});


### PR DESCRIPTION
## Summary

- Cache the startup promise in `setup_vitest.ts` so that when app startup fails, subsequent test files in the same vitest worker fail immediately instead of re-attempting `app.ready()`
- Skip duplicate `beforeAll`/`afterEach` hook registration from `setupApp()` when vitest setup is handling the lifecycle, via `__eggMockVitestSetup` global flag

## Motivation

When an application fails to start during vitest test runs, all test files would independently call `app.ready()` in their `beforeAll` hooks. Although `sdk-base` caches the error state, each test file still created separate promise chains. By caching a single `startupPromise`, all test files within the same worker share the exact same promise — if it rejects, subsequent files fail instantly.

Additionally, `setupApp()` in `app_handler.ts` registered redundant `beforeAll`/`afterEach` hooks when `globals: true` was set (the default in egg-bin), duplicating what `setup_vitest.ts` already handles.

## Test plan

- [x] `@eggjs/mock` tests pass (`plugins/mock/test/app.test.ts`, `bootstrap.test.ts`, `mm.test.ts`, `ctx.test.ts`)
- [x] `egg` package tests pass (`test/egg.test.ts`, `test/index.test.ts`)
- [x] TypeScript type check passes (`tsgo --noEmit`)
- [x] Lint passes (pre-commit hook with oxlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate test lifecycle hook registration when the test runner is already managing setup.
  * Make teardown restore conditional to avoid redundant restores in mixed environments.

* **Tests**
  * Added tests verifying a shared startup across test files: ensures single startup attempt, cached startup behavior, and faster fail-fast semantics across files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->