### PR TITLE
fix: add eggPlugin config to all plugin package.json

### DIFF
--- a/plugins/development/package.json
+++ b/plugins/development/package.json
@@ -66,5 +66,11 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "development",
+    "dependencies": [
+      "watcher"
+    ]
   }
 }

--- a/plugins/i18n/package.json
+++ b/plugins/i18n/package.json
@@ -75,5 +75,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "i18n"
   }
 }

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -66,5 +66,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "jsonp"
   }
 }

--- a/plugins/logrotator/package.json
+++ b/plugins/logrotator/package.json
@@ -91,5 +91,11 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "logrotator",
+    "dependencies": [
+      "schedule"
+    ]
   }
 }

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -81,5 +81,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "multipart"
   }
 }

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -66,5 +66,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "onerror"
   }
 }

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -68,5 +68,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "redis"
   }
 }

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -92,5 +92,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "schedule"
   }
 }

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -143,5 +143,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "security"
   }
 }

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -68,5 +68,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "session"
   }
 }

--- a/plugins/static/package.json
+++ b/plugins/static/package.json
@@ -68,5 +68,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "static"
   }
 }

--- a/plugins/tracer/package.json
+++ b/plugins/tracer/package.json
@@ -72,5 +72,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "tracer"
   }
 }

--- a/plugins/typebox-validate/package.json
+++ b/plugins/typebox-validate/package.json
@@ -73,5 +73,8 @@
   },
   "engines": {
     "node": ">= 22.18.0"
+  },
+  "eggPlugin": {
+    "name": "typeboxValidate"
   }
 }

--- a/plugins/view-nunjucks/package.json
+++ b/plugins/view-nunjucks/package.json
@@ -82,5 +82,12 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "nunjucks",
+    "dependencies": [
+      "security",
+      "view"
+    ]
   }
 }

--- a/plugins/view/package.json
+++ b/plugins/view/package.json
@@ -70,5 +70,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "view"
   }
 }

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -78,5 +78,8 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "eggPlugin": {
+    "name": "watcher"
   }
 }


### PR DESCRIPTION
## Problem

When plugins are loaded via the `package` field pattern:
```ts
redis: {
  enable: true,
  package: '@eggjs/redis',
}
```

The egg loader (`@eggjs/core/egg_loader`) reads `eggPlugin` from the plugin's `package.json` for plugin name and dependency resolution. All plugins in the monorepo were missing this field, causing warnings like:

```
WARN [@eggjs/core/egg_loader] pkg.eggPlugin is missing in .../node_modules/@eggjs/redis/package.json
```

## Fix

Added `eggPlugin` to all 16 plugin `package.json` files with the correct `name` and `dependencies` (matching their `definePluginFactory` config):

| Plugin | Name | Dependencies |
|--------|------|-------------|
| @eggjs/development | development | watcher |
| @eggjs/i18n | i18n | |
| @eggjs/jsonp | jsonp | |
| @eggjs/logrotator | logrotator | schedule |
| @eggjs/multipart | multipart | |
| @eggjs/onerror | onerror | |
| @eggjs/redis | redis | |
| @eggjs/schedule | schedule | |
| @eggjs/security | security | |
| @eggjs/session | session | |
| @eggjs/static | static | |
| @eggjs/tracer | tracer | |
| @eggjs/typebox-validate | typeboxValidate | |
| @eggjs/view | view | |
| @eggjs/view-nunjucks | nunjucks | security, view |
| @eggjs/watcher | watcher | |

Found via cnpmcore docker build logs: https://github.com/cnpm/cnpmcore/issues/887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit plugin metadata declarations and dependency specifications across the plugin framework. Includes plugin identifier and dependency configurations for development, i18n, jsonp, logrotator, multipart, onerror, redis, schedule, security, session, static, tracer, typebox-validate, view-nunjucks, view, and watcher plugins to improve system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->