### PR TITLE
fix: remove eggPlugin missing warning from egg_loader

### DIFF
--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -630,12 +630,13 @@ export class EggLoader {
       plugin.path = await this.#formatPluginPathFromPackageJSON(plugin.path as string, pkg);
     }
 
-    const logger = this.options.logger;
     if (!eggPluginConfig) {
-      logger.warn('[@eggjs/core/egg_loader] pkg.eggPlugin is missing in %s, plugin: %j', pluginPackage, plugin);
+      // eggPlugin in package.json is no longer required since plugins
+      // now use definePluginFactory() to declare their config
       return;
     }
 
+    const logger = this.options.logger;
     if (eggPluginConfig.name && eggPluginConfig.strict !== false && eggPluginConfig.name !== plugin.name) {
       // pluginName is configured in config/plugin.js
       // pluginConfigName is pkg.eggPlugin.name


### PR DESCRIPTION
The `eggPlugin` field in `package.json` is no longer required since plugins now use `definePluginFactory()` to declare their config.

Remove the noisy warning that fires for every plugin loaded via the `package` pattern:

```
WARN [@eggjs/core/egg_loader] pkg.eggPlugin is missing in .../node_modules/@eggjs/redis/package.json
```

This warning was originally useful for egg v2/v3 plugins that relied on `eggPlugin` in `package.json` for dependency resolution. With v4's `definePluginFactory()`, plugin metadata is declared in code instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning messages during plugin configuration loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->