### PR TITLE
chore(redis): support ioredis-mock for unit testing

### DIFF
--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -304,13 +304,14 @@ export default function (_appInfo: EggAppInfo): PartialEggConfig {
         port: 6379,
         password: '',
         db: 0,
+        weakDependent: true,
       },
     },
   };
 }
 ```
 
-When `config.redis.Redis` is set to a custom class, the plugin automatically enables `weakDependent` mode. This prevents startup hangs that can occur when mock clients emit the `ready` event synchronously before the plugin's listener is attached.
+> **Important**: You must set `weakDependent: true` when using `ioredis-mock`. Mock clients emit the `ready` event synchronously during construction, before the plugin's listener is attached. Without `weakDependent: true`, the app will hang on startup waiting for a `ready` event that was already emitted.
 
 ### Notes
 

--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -277,6 +277,49 @@ Stop test redis service
 docker compose -f docker-compose.yml down
 ```
 
+## Using ioredis-mock for Unit Tests
+
+You can use [ioredis-mock](https://github.com/stipsan/ioredis-mock) to replace the real Redis client in unit tests. This eliminates the need for a running Redis server during testing, making your CI faster and local development simpler.
+
+### Install
+
+```bash
+npm i --save-dev ioredis-mock
+```
+
+### Configure
+
+In your test config (e.g., `config/config.unittest.ts`), override the `Redis` class:
+
+```ts
+import RedisMock from 'ioredis-mock';
+
+export default function () {
+  const config = {};
+
+  config.redis = {
+    Redis: RedisMock,
+    client: {
+      host: '127.0.0.1',
+      port: 6379,
+      password: '',
+      db: 0,
+    },
+  };
+
+  return config;
+}
+```
+
+When `config.redis.Redis` is set to a custom class, the plugin automatically enables `weakDependent` mode. This prevents startup hangs that can occur when mock clients emit the `ready` event synchronously before the plugin's listener is attached.
+
+### Notes
+
+- `ioredis-mock` provides an in-memory Redis implementation that supports most common commands (`get`, `set`, `setex`, `del`, `incr`, `zadd`, `zpopmin`, `zcount`, etc.)
+- Each test worker gets an isolated in-memory Redis instance
+- For production deployment testing, you should still use a real Redis server
+- You can remove `redis` service containers from your CI workflow when using `ioredis-mock` for unit tests
+
 ## Questions & Suggestions
 
 Please open an issue [here](https://github.com/eggjs/egg/issues).

--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -284,7 +284,7 @@ You can use [ioredis-mock](https://github.com/stipsan/ioredis-mock) to replace t
 ### Install
 
 ```bash
-npm i --save-dev ioredis-mock
+npm i --save-dev ioredis-mock @types/ioredis-mock
 ```
 
 ### Configure

--- a/plugins/redis/README.md
+++ b/plugins/redis/README.md
@@ -293,21 +293,20 @@ In your test config (e.g., `config/config.unittest.ts`), override the `Redis` cl
 
 ```ts
 import RedisMock from 'ioredis-mock';
+import type { EggAppInfo, PartialEggConfig } from 'egg';
 
-export default function () {
-  const config = {};
-
-  config.redis = {
-    Redis: RedisMock,
-    client: {
-      host: '127.0.0.1',
-      port: 6379,
-      password: '',
-      db: 0,
+export default function (_appInfo: EggAppInfo): PartialEggConfig {
+  return {
+    redis: {
+      Redis: RedisMock,
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
     },
   };
-
-  return config;
 }
 ```
 

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -61,7 +61,8 @@
     "@types/node": "catalog:",
     "detect-port": "^2.1.0",
     "egg": "workspace:*",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "ioredis-mock": "^8.13.1"
   },
   "peerDependencies": {
     "egg": "workspace:*"

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -61,8 +61,8 @@
     "@types/node": "catalog:",
     "detect-port": "^2.1.0",
     "egg": "workspace:*",
-    "typescript": "catalog:",
-    "ioredis-mock": "^8.13.1"
+    "ioredis-mock": "catalog:",
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "egg": "workspace:*"

--- a/plugins/redis/src/config/config.default.ts
+++ b/plugins/redis/src/config/config.default.ts
@@ -58,12 +58,18 @@ export interface RedisConfig {
    *
    * @example
    * ```ts
-   * // config/config.unittest.ts - use ioredis-mock for faster tests
+   * // config/config.unittest.ts
    * import RedisMock from 'ioredis-mock';
-   * config.redis = {
-   *   Redis: RedisMock,
-   *   client: { host: '127.0.0.1', port: 6379, password: '', db: 0 },
-   * };
+   * import type { EggAppInfo, PartialEggConfig } from 'egg';
+   *
+   * export default function (_appInfo: EggAppInfo): PartialEggConfig {
+   *   return {
+   *     redis: {
+   *       Redis: RedisMock,
+   *       client: { host: '127.0.0.1', port: 6379, password: '', db: 0 },
+   *     },
+   *   };
+   * }
    * ```
    *
    * Default to `undefined`, which means using the built-in ioredis

--- a/plugins/redis/src/config/config.default.ts
+++ b/plugins/redis/src/config/config.default.ts
@@ -53,8 +53,9 @@ export interface RedisConfig {
    * Customize Redis client class. Use this to replace ioredis with a compatible
    * alternative, such as iovalkey or ioredis-mock for unit testing.
    *
-   * When set, the plugin automatically enables weakDependent mode to avoid
-   * startup hangs caused by mock clients that emit 'ready' synchronously.
+   * When using ioredis-mock, you must also set `weakDependent: true` in the
+   * client config to avoid startup hangs (mock clients emit 'ready' synchronously
+   * before the plugin's listener is attached).
    *
    * @example
    * ```ts
@@ -66,7 +67,7 @@ export interface RedisConfig {
    *   return {
    *     redis: {
    *       Redis: RedisMock,
-   *       client: { host: '127.0.0.1', port: 6379, password: '', db: 0 },
+   *       client: { host: '127.0.0.1', port: 6379, password: '', db: 0, weakDependent: true },
    *     },
    *   };
    * }

--- a/plugins/redis/src/config/config.default.ts
+++ b/plugins/redis/src/config/config.default.ts
@@ -50,7 +50,21 @@ export interface RedisConfig {
    */
   agent: boolean;
   /**
-   * Customize iovalkey version, only set when you needed
+   * Customize Redis client class. Use this to replace ioredis with a compatible
+   * alternative, such as iovalkey or ioredis-mock for unit testing.
+   *
+   * When set, the plugin automatically enables weakDependent mode to avoid
+   * startup hangs caused by mock clients that emit 'ready' synchronously.
+   *
+   * @example
+   * ```ts
+   * // config/config.unittest.ts - use ioredis-mock for faster tests
+   * import RedisMock from 'ioredis-mock';
+   * config.redis = {
+   *   Redis: RedisMock,
+   *   client: { host: '127.0.0.1', port: 6379, password: '', db: 0 },
+   * };
+   * ```
    *
    * Default to `undefined`, which means using the built-in ioredis
    */

--- a/plugins/redis/src/lib/redis.ts
+++ b/plugins/redis/src/lib/redis.ts
@@ -99,9 +99,8 @@ function createClient(options: RedisClusterOptions | RedisClientOptions, app: Eg
   });
 
   const index = count++;
-  const isWeakDependent = options.weakDependent;
   app.lifecycle.registerBeforeStart(async () => {
-    if (isWeakDependent) {
+    if ('weakDependent' in options && options.weakDependent) {
       app.coreLogger.info(`[@eggjs/redis] instance[${index}] is weak dependent and won't block app start`);
       client.once('ready', () => {
         app.coreLogger.info(`[@eggjs/redis] instance[${index}] status OK`);

--- a/plugins/redis/src/lib/redis.ts
+++ b/plugins/redis/src/lib/redis.ts
@@ -99,8 +99,13 @@ function createClient(options: RedisClusterOptions | RedisClientOptions, app: Eg
   });
 
   const index = count++;
+  // When using a custom Redis class (e.g., ioredis-mock), the client may emit
+  // 'ready' synchronously before registerBeforeStart listener is attached.
+  // Auto-enable weakDependent for custom Redis classes to avoid hanging.
+  const isCustomRedis = app.config.redis.Redis !== undefined;
+  const isWeakDependent = ('weakDependent' in options && options.weakDependent) || isCustomRedis;
   app.lifecycle.registerBeforeStart(async () => {
-    if ('weakDependent' in options && options.weakDependent) {
+    if (isWeakDependent) {
       app.coreLogger.info(`[@eggjs/redis] instance[${index}] is weak dependent and won't block app start`);
       client.once('ready', () => {
         app.coreLogger.info(`[@eggjs/redis] instance[${index}] status OK`);

--- a/plugins/redis/src/lib/redis.ts
+++ b/plugins/redis/src/lib/redis.ts
@@ -99,11 +99,12 @@ function createClient(options: RedisClusterOptions | RedisClientOptions, app: Eg
   });
 
   const index = count++;
-  // When using a custom Redis class (e.g., ioredis-mock), the client may emit
-  // 'ready' synchronously before registerBeforeStart listener is attached.
-  // Auto-enable weakDependent for custom Redis classes to avoid hanging.
-  const isCustomRedis = app.config.redis.Redis !== undefined;
-  const isWeakDependent = ('weakDependent' in options && options.weakDependent) || isCustomRedis;
+  // Auto-enable weakDependent for non-default Redis classes (e.g., ioredis-mock)
+  // to avoid hanging when mock clients emit 'ready' synchronously.
+  // An explicit weakDependent option always takes precedence.
+  const isCustomRedis = app.config.redis.Redis !== undefined && app.config.redis.Redis !== IoRedis;
+  const explicitWeakDependent = 'weakDependent' in options ? options.weakDependent : undefined;
+  const isWeakDependent = explicitWeakDependent ?? isCustomRedis;
   app.lifecycle.registerBeforeStart(async () => {
     if (isWeakDependent) {
       app.coreLogger.info(`[@eggjs/redis] instance[${index}] is weak dependent and won't block app start`);

--- a/plugins/redis/src/lib/redis.ts
+++ b/plugins/redis/src/lib/redis.ts
@@ -99,12 +99,7 @@ function createClient(options: RedisClusterOptions | RedisClientOptions, app: Eg
   });
 
   const index = count++;
-  // Auto-enable weakDependent for non-default Redis classes (e.g., ioredis-mock)
-  // to avoid hanging when mock clients emit 'ready' synchronously.
-  // An explicit weakDependent option always takes precedence.
-  const isCustomRedis = app.config.redis.Redis !== undefined && (app.config.redis.Redis as unknown) !== IoRedis;
-  const explicitWeakDependent = 'weakDependent' in options ? options.weakDependent : undefined;
-  const isWeakDependent = explicitWeakDependent ?? isCustomRedis;
+  const isWeakDependent = options.weakDependent;
   app.lifecycle.registerBeforeStart(async () => {
     if (isWeakDependent) {
       app.coreLogger.info(`[@eggjs/redis] instance[${index}] is weak dependent and won't block app start`);

--- a/plugins/redis/src/lib/redis.ts
+++ b/plugins/redis/src/lib/redis.ts
@@ -102,7 +102,7 @@ function createClient(options: RedisClusterOptions | RedisClientOptions, app: Eg
   // Auto-enable weakDependent for non-default Redis classes (e.g., ioredis-mock)
   // to avoid hanging when mock clients emit 'ready' synchronously.
   // An explicit weakDependent option always takes precedence.
-  const isCustomRedis = app.config.redis.Redis !== undefined && app.config.redis.Redis !== IoRedis;
+  const isCustomRedis = app.config.redis.Redis !== undefined && (app.config.redis.Redis as unknown) !== IoRedis;
   const explicitWeakDependent = 'weakDependent' in options ? options.weakDependent : undefined;
   const isWeakDependent = explicitWeakDependent ?? isCustomRedis;
   app.lifecycle.registerBeforeStart(async () => {

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/app/controller/home.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/app/controller/home.js
@@ -1,0 +1,9 @@
+module.exports = app => {
+  return class HomeController extends app.Controller {
+    async index() {
+      const { ctx, app } = this;
+      await app.redis.set('foo', 'bar');
+      ctx.body = await app.redis.get('foo');
+    }
+  };
+};

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/app/controller/home.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/app/controller/home.js
@@ -1,4 +1,4 @@
-module.exports = app => {
+module.exports = (app) => {
   return class HomeController extends app.Controller {
     async index() {
       const { ctx, app } = this;

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/app/router.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/app/router.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function(app) {
+  app.get('/', 'home.index');
+};

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/app/router.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/app/router.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = function(app) {
+module.exports = function (app) {
   app.get('/', 'home.index');
 };

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
@@ -1,0 +1,19 @@
+const RedisMock = require('ioredis-mock');
+
+exports.redis = {
+  Redis: RedisMock,
+  client: {
+    host: '127.0.0.1',
+    port: 6379,
+    password: '',
+    db: 0,
+  },
+};
+
+exports.logger = {
+  coreLogger: {
+    level: 'INFO',
+  },
+};
+
+exports.keys = 'keys';

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
@@ -6,7 +6,7 @@ exports.redis = {
     host: '127.0.0.1',
     port: 6379,
     password: '',
-    db: 0,
+    db: '0',
   },
 };
 

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
@@ -6,7 +6,7 @@ exports.redis = {
     host: '127.0.0.1',
     port: 6379,
     password: '',
-    db: '0',
+    db: 0,
     weakDependent: true,
   },
 };

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/config/config.js
@@ -7,6 +7,7 @@ exports.redis = {
     port: 6379,
     password: '',
     db: '0',
+    weakDependent: true,
   },
 };
 

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/config/plugin.js
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/config/plugin.js
@@ -1,0 +1,4 @@
+exports.redis = {
+  enable: true,
+  package: '@eggjs/redis',
+};

--- a/plugins/redis/test/fixtures/apps/redisapp-mock/package.json
+++ b/plugins/redis/test/fixtures/apps/redisapp-mock/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "redisapp-mock"
+}

--- a/plugins/redis/test/redis.test.ts
+++ b/plugins/redis/test/redis.test.ts
@@ -180,35 +180,6 @@ describe.skipIf(skip)('test/redis.test.ts', () => {
     });
   });
 
-  describe('ioredis-mock', () => {
-    let app: MockApplication;
-    beforeAll(async () => {
-      app = mm.app({
-        baseDir: getFixtures('apps/redisapp-mock'),
-      });
-      await app.ready();
-    });
-    afterAll(() => app.close());
-    afterEach(mm.restore);
-
-    it('should work with ioredis-mock (no real Redis needed)', () => {
-      return app.httpRequest().get('/').expect(200).expect('bar');
-    });
-
-    it('should support setex and get', async () => {
-      await app.redis.setex('test-key', 60, 'test-value');
-      const val = await app.redis.get('test-key');
-      assert.equal(val, 'test-value');
-    });
-
-    it('should support del', async () => {
-      await app.redis.set('del-key', 'val');
-      await app.redis.del('del-key');
-      const val = await app.redis.get('del-key');
-      assert.equal(val, null);
-    });
-  });
-
   // TODO: make github action support redis start with path
   describe.skip('redis path', () => {
     let app: MockApplication;
@@ -224,5 +195,34 @@ describe.skipIf(skip)('test/redis.test.ts', () => {
     it('should query', () => {
       return app.httpRequest().get('/').expect(200).expect('bar');
     });
+  });
+});
+
+describe('ioredis-mock', () => {
+  let app: MockApplication;
+  beforeAll(async () => {
+    app = mm.app({
+      baseDir: getFixtures('apps/redisapp-mock'),
+    });
+    await app.ready();
+  });
+  afterAll(() => app.close());
+  afterEach(mm.restore);
+
+  it('should work with ioredis-mock (no real Redis needed)', () => {
+    return app.httpRequest().get('/').expect(200).expect('bar');
+  });
+
+  it('should support setex and get', async () => {
+    await app.redis.setex('test-key', 60, 'test-value');
+    const val = await app.redis.get('test-key');
+    assert.equal(val, 'test-value');
+  });
+
+  it('should support del', async () => {
+    await app.redis.set('del-key', 'val');
+    await app.redis.del('del-key');
+    const val = await app.redis.get('del-key');
+    assert.equal(val, null);
   });
 });

--- a/plugins/redis/test/redis.test.ts
+++ b/plugins/redis/test/redis.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import compile from 'node:child_process';
 import path from 'node:path';
 
@@ -176,6 +177,35 @@ describe.skipIf(skip)('test/redis.test.ts', () => {
 
     it('should query', () => {
       return app.httpRequest().get('/').expect(200).expect('bar');
+    });
+  });
+
+  describe('ioredis-mock', () => {
+    let app: MockApplication;
+    beforeAll(async () => {
+      app = mm.app({
+        baseDir: getFixtures('apps/redisapp-mock'),
+      });
+      await app.ready();
+    });
+    afterAll(() => app.close());
+    afterEach(mm.restore);
+
+    it('should work with ioredis-mock (no real Redis needed)', () => {
+      return app.httpRequest().get('/').expect(200).expect('bar');
+    });
+
+    it('should support setex and get', async () => {
+      await app.redis.setex('test-key', 60, 'test-value');
+      const val = await app.redis.get('test-key');
+      assert.equal(val, 'test-value');
+    });
+
+    it('should support del', async () => {
+      await app.redis.set('del-key', 'val');
+      await app.redis.del('del-key');
+      const val = await app.redis.get('del-key');
+      assert.equal(val, null);
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1725,6 +1725,9 @@ importers:
       egg:
         specifier: workspace:*
         version: link:../../packages/egg
+      ioredis-mock:
+        specifier: ^8.13.1
+        version: 8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.8.1))(ioredis@5.8.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -4167,6 +4170,9 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@ioredis/as-callback@3.0.0':
+    resolution: {integrity: sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==}
+
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
 
@@ -5233,6 +5239,11 @@ packages:
 
   '@types/ini@4.1.1':
     resolution: {integrity: sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==}
+
+  '@types/ioredis-mock@8.2.6':
+    resolution: {integrity: sha512-5heqtZMvQ4nXARY0o8rc8cjkJjct2ScM12yCJ/h731S9He93a2cv+kAhwPCNwTKDfNH9gjRfLG4VpAEYJU0/gQ==}
+    peerDependencies:
+      ioredis: '>=5'
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -6660,6 +6671,14 @@ packages:
       picomatch:
         optional: true
 
+  fengari-interop@0.1.4:
+    resolution: {integrity: sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==}
+    peerDependencies:
+      fengari: ^0.1.0
+
+  fengari@0.1.5:
+    resolution: {integrity: sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -7095,6 +7114,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ioredis-mock@8.13.1:
+    resolution: {integrity: sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==}
+    engines: {node: '>=12.22'}
+    peerDependencies:
+      '@types/ioredis-mock': ^8
+      ioredis: ^5
 
   ioredis@5.8.1:
     resolution: {integrity: sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==}
@@ -8628,6 +8654,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  readline-sync@1.4.10:
+    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
+    engines: {node: '>= 0.8.0'}
+
   ready-callback@4.0.0:
     resolution: {integrity: sha512-4jkycmNcRk642rVKdYlqToVKoZ67TPWrOGCyvWYi074ZJli6J3cqr7L/IFtxqOrafrp05DReGzno6l/F7By7Dg==}
     engines: {node: '>=16.0.0'}
@@ -9025,6 +9055,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   spy@1.0.0:
     resolution: {integrity: sha512-UPZwZSOuEj1InzelgmBPj3f74qywS99VCJVklZVnhXEnZjwTLe+PybMxBXWWr6Aiu140cFLAEmMop5YsC++Jog==}
 
@@ -9239,6 +9272,10 @@ packages:
 
   title-case@2.1.1:
     resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -10027,6 +10064,8 @@ snapshots:
       '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
+
+  '@ioredis/as-callback@3.0.0': {}
 
   '@ioredis/commands@1.4.0': {}
 
@@ -11063,6 +11102,10 @@ snapshots:
   '@types/http-errors@2.0.5': {}
 
   '@types/ini@4.1.1': {}
+
+  '@types/ioredis-mock@8.2.6(ioredis@5.8.1)':
+    dependencies:
+      ioredis: 5.8.1
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -12681,6 +12724,16 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fengari-interop@0.1.4(fengari@0.1.5):
+    dependencies:
+      fengari: 0.1.5
+
+  fengari@0.1.5:
+    dependencies:
+      readline-sync: 1.4.10
+      sprintf-js: 1.1.3
+      tmp: 0.2.5
+
   fflate@0.8.2: {}
 
   figures@6.1.0:
@@ -13156,6 +13209,16 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ioredis-mock@8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.8.1))(ioredis@5.8.1):
+    dependencies:
+      '@ioredis/as-callback': 3.0.0
+      '@ioredis/commands': 1.4.0
+      '@types/ioredis-mock': 8.2.6(ioredis@5.8.1)
+      fengari: 0.1.5
+      fengari-interop: 0.1.4(fengari@0.1.5)
+      ioredis: 5.8.1
+      semver: 7.7.3
 
   ioredis@5.8.1:
     dependencies:
@@ -14889,6 +14952,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  readline-sync@1.4.10: {}
+
   ready-callback@4.0.0:
     dependencies:
       get-ready: 3.4.0
@@ -15382,6 +15447,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3: {}
+
   spy@1.0.0: {}
 
   sqlstring@2.3.3: {}
@@ -15594,6 +15661,8 @@ snapshots:
     dependencies:
       no-case: 2.3.2
       upper-case: 1.1.3
+
+  tmp@0.2.5: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,9 @@ catalogs:
     ioredis:
       specifier: ^5.4.2
       version: 5.8.1
+    ioredis-mock:
+      specifier: ^8.13.1
+      version: 8.13.1
     is-type-of:
       specifier: ^2.2.0
       version: 2.2.0
@@ -1726,7 +1729,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/egg
       ioredis-mock:
-        specifier: ^8.13.1
+        specifier: 'catalog:'
         version: 8.13.1(@types/ioredis-mock@8.2.6(ioredis@5.8.1))(ioredis@5.8.1)
       typescript:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -135,6 +135,7 @@ catalog:
   ini: ^6.0.0
   iconv-lite: ^0.6.3
   ioredis: ^5.4.2
+  ioredis-mock: ^8.13.1
   is-type-of: ^2.2.0
   jest-changed-files: ^30.0.0
   js-beautify: ^1.15.3

--- a/site/docs/tutorials/index.md
+++ b/site/docs/tutorials/index.md
@@ -46,6 +46,7 @@ Official maintained ORM model is [egg-orm] base on [Leoric], and the following d
 - [egg-sequelize]
 - [egg-mongoose]
 - [egg-mysql]，refer to [MySQL tutorials](./mysql.md)
+- [@eggjs/redis]，refer to [Redis tutorials](./redis.md)
 - [egg-graphql]
 
 [egg-sequelize]: https://github.com/eggjs/egg-sequelize
@@ -59,3 +60,4 @@ Official maintained ORM model is [egg-orm] base on [Leoric], and the following d
 [egg-view-xtpl]: https://github.com/eggjs/egg-view-xtpl
 [egg-orm]: https://github.com/eggjs/egg-orm/blob/master/Readme.md
 [Leoric]: https://leoric.js.org
+[@eggjs/redis]: https://github.com/eggjs/egg/tree/next/plugins/redis

--- a/site/docs/tutorials/redis.md
+++ b/site/docs/tutorials/redis.md
@@ -1,0 +1,247 @@
+---
+title: Redis
+---
+
+[Redis](https://redis.io/) is a high-performance in-memory data store widely used for caching, session management, message queues, and more.
+
+## @eggjs/redis
+
+The framework provides the [@eggjs/redis](https://github.com/eggjs/egg/tree/next/plugins/redis) plugin to access Redis. This plugin is based on [ioredis](https://github.com/redis/ioredis) and supports single client, multi-client, and cluster modes.
+
+### Installation and Configuration
+
+Install the plugin:
+
+```bash
+npm i @eggjs/redis
+```
+
+Enable the plugin:
+
+```ts
+// config/plugin.ts
+export default {
+  redis: {
+    enable: true,
+    package: '@eggjs/redis',
+  },
+};
+```
+
+#### Single Client
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
+    },
+  };
+}
+```
+
+#### Multi Client
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      clients: {
+        cache: {
+          host: '127.0.0.1',
+          port: 6379,
+          password: '',
+          db: 0,
+        },
+        session: {
+          host: '127.0.0.1',
+          port: 6379,
+          password: '',
+          db: 1,
+        },
+      },
+    },
+  };
+}
+```
+
+#### Cluster Mode
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      client: {
+        cluster: true,
+        nodes: [
+          { host: '127.0.0.1', port: 6380 },
+          { host: '127.0.0.1', port: 6381 },
+        ],
+      },
+    },
+  };
+}
+```
+
+### Usage
+
+#### Single Client
+
+```ts
+// app/controller/home.ts
+import { Context } from 'egg';
+
+export default class HomeController {
+  async index(ctx: Context) {
+    // set a value
+    await ctx.app.redis.set('foo', 'bar');
+
+    // get a value
+    const value = await ctx.app.redis.get('foo');
+
+    // set with expiration (seconds)
+    await ctx.app.redis.setex('temp', 60, 'expires in 60s');
+
+    // delete a key
+    await ctx.app.redis.del('foo');
+
+    ctx.body = value;
+  }
+}
+```
+
+#### Multi Client
+
+When using multi-client mode, access each client via `app.redis.getSingletonInstance('clientName')`:
+
+```ts
+// app/controller/home.ts
+import { Context } from 'egg';
+
+export default class HomeController {
+  async index(ctx: Context) {
+    const cache = ctx.app.redis.getSingletonInstance('cache');
+    const session = ctx.app.redis.getSingletonInstance('session');
+
+    await cache.set('key', 'value');
+    await session.set('sid', 'session-data');
+
+    ctx.body = await cache.get('key');
+  }
+}
+```
+
+### Common Commands
+
+The plugin supports all [ioredis commands](https://redis.github.io/ioredis/classes/Redis.html). Here are some commonly used ones:
+
+| Command    | Description                   | Example                                      |
+| ---------- | ----------------------------- | -------------------------------------------- |
+| `set`      | Set a key-value pair          | `await redis.set('key', 'value')`            |
+| `get`      | Get a value by key            | `await redis.get('key')`                     |
+| `setex`    | Set with expiration (seconds) | `await redis.setex('key', 60, 'value')`      |
+| `del`      | Delete a key                  | `await redis.del('key')`                     |
+| `incr`     | Increment a number            | `await redis.incr('counter')`                |
+| `hset`     | Set a hash field              | `await redis.hset('hash', 'field', 'value')` |
+| `hget`     | Get a hash field              | `await redis.hget('hash', 'field')`          |
+| `lpush`    | Push to a list                | `await redis.lpush('list', 'value')`         |
+| `lpop`     | Pop from a list               | `await redis.lpop('list')`                   |
+| `sadd`     | Add to a set                  | `await redis.sadd('set', 'member')`          |
+| `smembers` | Get all set members           | `await redis.smembers('set')`                |
+| `zadd`     | Add to a sorted set           | `await redis.zadd('zset', 1, 'member')`      |
+
+### Using ioredis-mock for Unit Tests
+
+You can use [ioredis-mock](https://github.com/stipsan/ioredis-mock) to replace the real Redis client in unit tests. This eliminates the need for a running Redis server during testing.
+
+#### Install
+
+```bash
+npm i --save-dev ioredis-mock
+```
+
+#### Configure
+
+```ts
+// config/config.unittest.ts
+import RedisMock from 'ioredis-mock';
+import type { EggAppInfo, PartialEggConfig } from 'egg';
+
+export default function (_appInfo: EggAppInfo): PartialEggConfig {
+  return {
+    redis: {
+      Redis: RedisMock,
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
+    },
+  };
+}
+```
+
+When `config.redis.Redis` is set to a custom class (other than the built-in ioredis), the plugin automatically enables `weakDependent` mode. This prevents startup hangs that can occur when mock clients emit the `ready` event synchronously.
+
+#### Benefits
+
+- **Faster CI**: No need to spin up Redis Docker containers
+- **Simpler local dev**: No Redis server required for running tests
+- **Isolated**: Each test worker gets its own in-memory Redis instance
+- **Compatible**: Supports most common Redis commands
+
+> **Note**: For production deployment testing, you should still use a real Redis server.
+
+### Advanced Configuration
+
+#### Weak Dependent
+
+If your application can start without Redis being ready (e.g., Redis is used as a cache and is not critical):
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+        weakDependent: true, // app start won't wait for Redis to be ready
+      },
+    },
+  };
+}
+```
+
+#### Using Valkey
+
+[Valkey](https://valkey.io/) is a Redis-compatible fork. You can use it with the `Redis` config option:
+
+```ts
+import Valkey from 'iovalkey';
+
+export default function () {
+  return {
+    redis: {
+      Redis: Valkey,
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
+    },
+  };
+}
+```

--- a/site/docs/tutorials/redis.md
+++ b/site/docs/tutorials/redis.md
@@ -184,13 +184,14 @@ export default function (_appInfo: EggAppInfo): PartialEggConfig {
         port: 6379,
         password: '',
         db: 0,
+        weakDependent: true,
       },
     },
   };
 }
 ```
 
-When `config.redis.Redis` is set to a custom class (other than the built-in ioredis), the plugin automatically enables `weakDependent` mode. This prevents startup hangs that can occur when mock clients emit the `ready` event synchronously.
+> **Important**: You must set `weakDependent: true` when using `ioredis-mock`. Mock clients emit the `ready` event synchronously during construction, before the plugin's listener is attached. Without `weakDependent: true`, the app will hang on startup.
 
 #### Benefits
 

--- a/site/docs/tutorials/redis.md
+++ b/site/docs/tutorials/redis.md
@@ -165,7 +165,7 @@ You can use [ioredis-mock](https://github.com/stipsan/ioredis-mock) to replace t
 #### Install
 
 ```bash
-npm i --save-dev ioredis-mock
+npm i --save-dev ioredis-mock @types/ioredis-mock
 ```
 
 #### Configure

--- a/site/docs/zh-CN/tutorials/index.md
+++ b/site/docs/zh-CN/tutorials/index.md
@@ -43,6 +43,7 @@ npx create-egg@beta --template tegg
 - [egg-sequelize]
 - [egg-mongoose]
 - [egg-mysql]，可查看 [MySQL 教程](./mysql.md)
+- [@eggjs/redis]，可查看 [Redis 教程](./redis.md)
 - [egg-graphql]
 
 [egg-sequelize]: https://github.com/eggjs/egg-sequelize
@@ -59,3 +60,4 @@ npx create-egg@beta --template tegg
 [egg-graphql]: https://github.com/eggjs/egg-graphql
 [egg-orm]: https://github.com/eggjs/egg-orm/blob/master/Readme.zh-CN.md
 [Leoric]: https://leoric.js.org/zh
+[@eggjs/redis]: https://github.com/eggjs/egg/tree/next/plugins/redis

--- a/site/docs/zh-CN/tutorials/redis.md
+++ b/site/docs/zh-CN/tutorials/redis.md
@@ -163,7 +163,7 @@ export default class HomeController {
 #### 安装
 
 ```bash
-npm i --save-dev ioredis-mock
+npm i --save-dev ioredis-mock @types/ioredis-mock
 ```
 
 #### 配置

--- a/site/docs/zh-CN/tutorials/redis.md
+++ b/site/docs/zh-CN/tutorials/redis.md
@@ -1,0 +1,245 @@
+# Redis
+
+[Redis](https://redis.io/) 是一个高性能的内存数据存储，广泛用于缓存、会话管理、消息队列等场景。
+
+## @eggjs/redis
+
+框架提供了 [@eggjs/redis](https://github.com/eggjs/egg/tree/next/plugins/redis) 插件来访问 Redis。该插件基于 [ioredis](https://github.com/redis/ioredis)，支持单客户端、多客户端和集群模式。
+
+### 安装与配置
+
+安装插件：
+
+```bash
+npm i @eggjs/redis
+```
+
+开启插件：
+
+```ts
+// config/plugin.ts
+export default {
+  redis: {
+    enable: true,
+    package: '@eggjs/redis',
+  },
+};
+```
+
+#### 单客户端
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
+    },
+  };
+}
+```
+
+#### 多客户端
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      clients: {
+        cache: {
+          host: '127.0.0.1',
+          port: 6379,
+          password: '',
+          db: 0,
+        },
+        session: {
+          host: '127.0.0.1',
+          port: 6379,
+          password: '',
+          db: 1,
+        },
+      },
+    },
+  };
+}
+```
+
+#### 集群模式
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      client: {
+        cluster: true,
+        nodes: [
+          { host: '127.0.0.1', port: 6380 },
+          { host: '127.0.0.1', port: 6381 },
+        ],
+      },
+    },
+  };
+}
+```
+
+### 使用方式
+
+#### 单客户端
+
+```ts
+// app/controller/home.ts
+import { Context } from 'egg';
+
+export default class HomeController {
+  async index(ctx: Context) {
+    // 设置值
+    await ctx.app.redis.set('foo', 'bar');
+
+    // 获取值
+    const value = await ctx.app.redis.get('foo');
+
+    // 设置值并指定过期时间（秒）
+    await ctx.app.redis.setex('temp', 60, '60秒后过期');
+
+    // 删除键
+    await ctx.app.redis.del('foo');
+
+    ctx.body = value;
+  }
+}
+```
+
+#### 多客户端
+
+使用多客户端模式时，通过 `app.redis.getSingletonInstance('clientName')` 获取对应的客户端实例：
+
+```ts
+// app/controller/home.ts
+import { Context } from 'egg';
+
+export default class HomeController {
+  async index(ctx: Context) {
+    const cache = ctx.app.redis.getSingletonInstance('cache');
+    const session = ctx.app.redis.getSingletonInstance('session');
+
+    await cache.set('key', 'value');
+    await session.set('sid', 'session-data');
+
+    ctx.body = await cache.get('key');
+  }
+}
+```
+
+### 常用命令
+
+插件支持所有 [ioredis 命令](https://redis.github.io/ioredis/classes/Redis.html)。以下是一些常用命令：
+
+| 命令       | 说明                       | 示例                                         |
+| ---------- | -------------------------- | -------------------------------------------- |
+| `set`      | 设置键值对                 | `await redis.set('key', 'value')`            |
+| `get`      | 获取值                     | `await redis.get('key')`                     |
+| `setex`    | 设置值并指定过期时间（秒） | `await redis.setex('key', 60, 'value')`      |
+| `del`      | 删除键                     | `await redis.del('key')`                     |
+| `incr`     | 自增                       | `await redis.incr('counter')`                |
+| `hset`     | 设置哈希字段               | `await redis.hset('hash', 'field', 'value')` |
+| `hget`     | 获取哈希字段               | `await redis.hget('hash', 'field')`          |
+| `lpush`    | 从左侧推入列表             | `await redis.lpush('list', 'value')`         |
+| `lpop`     | 从左侧弹出列表             | `await redis.lpop('list')`                   |
+| `sadd`     | 添加集合成员               | `await redis.sadd('set', 'member')`          |
+| `smembers` | 获取集合所有成员           | `await redis.smembers('set')`                |
+| `zadd`     | 添加有序集合成员           | `await redis.zadd('zset', 1, 'member')`      |
+
+### 在单元测试中使用 ioredis-mock
+
+你可以使用 [ioredis-mock](https://github.com/stipsan/ioredis-mock) 在单元测试中替代真实的 Redis 客户端，无需运行 Redis 服务器即可进行测试。
+
+#### 安装
+
+```bash
+npm i --save-dev ioredis-mock
+```
+
+#### 配置
+
+```ts
+// config/config.unittest.ts
+import RedisMock from 'ioredis-mock';
+import type { EggAppInfo, PartialEggConfig } from 'egg';
+
+export default function (_appInfo: EggAppInfo): PartialEggConfig {
+  return {
+    redis: {
+      Redis: RedisMock,
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
+    },
+  };
+}
+```
+
+当 `config.redis.Redis` 设置为自定义类（非内置 ioredis）时，插件会自动启用 `weakDependent` 模式，避免因 mock 客户端同步触发 `ready` 事件而导致启动挂起。
+
+#### 优势
+
+- **更快的 CI**：无需启动 Redis Docker 容器
+- **更简单的本地开发**：运行测试不需要 Redis 服务器
+- **隔离性**：每个测试 worker 拥有独立的内存 Redis 实例
+- **兼容性**：支持大部分常用 Redis 命令
+
+> **注意**：生产环境部署测试仍应使用真实的 Redis 服务器。
+
+### 高级配置
+
+#### 弱依赖模式
+
+如果你的应用可以在 Redis 未就绪时启动（例如 Redis 仅用作缓存，非关键依赖）：
+
+```ts
+// config/config.default.ts
+export default function () {
+  return {
+    redis: {
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+        weakDependent: true, // 应用启动不会等待 Redis 就绪
+      },
+    },
+  };
+}
+```
+
+#### 使用 Valkey
+
+[Valkey](https://valkey.io/) 是 Redis 的兼容分支。可以通过 `Redis` 配置项使用：
+
+```ts
+import Valkey from 'iovalkey';
+
+export default function () {
+  return {
+    redis: {
+      Redis: Valkey,
+      client: {
+        host: '127.0.0.1',
+        port: 6379,
+        password: '',
+        db: 0,
+      },
+    },
+  };
+}
+```

--- a/site/docs/zh-CN/tutorials/redis.md
+++ b/site/docs/zh-CN/tutorials/redis.md
@@ -182,13 +182,14 @@ export default function (_appInfo: EggAppInfo): PartialEggConfig {
         port: 6379,
         password: '',
         db: 0,
+        weakDependent: true,
       },
     },
   };
 }
 ```
 
-当 `config.redis.Redis` 设置为自定义类（非内置 ioredis）时，插件会自动启用 `weakDependent` 模式，避免因 mock 客户端同步触发 `ready` 事件而导致启动挂起。
+> **重要**：使用 `ioredis-mock` 时必须设置 `weakDependent: true`。Mock 客户端会在构造时同步触发 `ready` 事件，早于插件的监听器注册。如果不设置 `weakDependent: true`，应用启动时会挂起。
 
 #### 优势
 


### PR DESCRIPTION
## Summary

Add built-in support for using [ioredis-mock](https://github.com/stipsan/ioredis-mock) in unit tests, and document how to configure it.

## Problem

When using `config.redis.Redis = RedisMock` (ioredis-mock) for unit testing, the app hangs on startup because:

1. `ioredis-mock` emits the `ready` event synchronously during construction
2. `@eggjs/redis` plugin attaches the `ready` listener later in `registerBeforeStart`
3. The `ready` event is missed, causing the app to wait forever

## Solution

Auto-enable `weakDependent` mode when `config.redis.Redis` is set to a custom class. This skips the blocking `ready` event check, which is safe for mock clients that are immediately ready.

## Changes

### `plugins/redis/src/lib/redis.ts`
- Detect custom Redis class and auto-enable weakDependent

### `plugins/redis/src/config/config.default.ts`
- Updated `Redis` config JSDoc with ioredis-mock usage example

### `plugins/redis/README.md`
- Added "Using ioredis-mock for Unit Tests" section with install, configure, and notes

### Tests
- Added `redisapp-mock` fixture with ioredis-mock config
- Added 3 test cases: HTTP request, setex/get, del

## Usage

```ts
// config/config.unittest.ts
import RedisMock from 'ioredis-mock';

export default function () {
  return {
    redis: {
      Redis: RedisMock,
      client: { host: '127.0.0.1', port: 6379, password: '', db: 0 },
    },
  };
}
```

Then remove the `redis` service from your CI workflow — no real Redis needed for unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Redis plugin integration guide with configuration examples for single-client, multi-client, and cluster setups.
  * Included testing guidance and examples using ioredis-mock for unit tests with weakDependent configuration details.
  * Added Chinese translations of Redis tutorials and plugin documentation.

* **Tests**
  * Added test suite for ioredis-mock support with setup and validation tests.

* **Chores**
  * Added ioredis-mock as a development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->