### PR TITLE
fix(tegg): align @eggjs/agent-runtime version to beta.3

### DIFF
--- a/tegg/core/agent-runtime/package.json
+++ b/tegg/core/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/agent-runtime",
-  "version": "4.0.2-beta.2",
+  "version": "4.0.2-beta.3",
   "description": "Agent runtime with store abstraction for Egg.js tegg",
   "keywords": [
     "agent",


### PR DESCRIPTION
## Summary

- Align `@eggjs/agent-runtime` version from `4.0.2-beta.2` to `4.0.2-beta.3` to match other tegg packages
- The version script bumped it from `beta.1` to `beta.2` instead of `beta.3` since it was one version behind

## Context

During the `prerelease` version bump, all other packages went from `beta.2` → `beta.3`, but `agent-runtime` was at `beta.1` so it only reached `beta.2`. This manual fix aligns it with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 4.0.2-beta.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->