### PR TITLE
fix: add .husky/_ to .gitignore to fix release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ run
 .DS_Store
 .tmp
 .egg
+.husky/_
 
 *-lock.json
 *-lock.yaml


### PR DESCRIPTION
## Summary

- Add `.husky/_` to `.gitignore` to prevent release workflow failures
- `pnpm install` runs `husky` via the `prepare` hook, generating `.husky/_/` directory with git hook scripts
- This untracked directory makes `git status --porcelain` report dirty state, causing `scripts/version.js` clean check to fail
- Fixes: https://github.com/eggjs/egg/actions/runs/23141355029/job/67219178270

## Test plan

- [x] Verify `.husky/_` is now ignored by git
- [ ] Re-run Manual Release workflow to confirm version bump succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->