### PR TITLE
chore: update pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1402,6 +1402,8 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/skills: {}
+
   packages/supertest:
     dependencies:
       '@types/superagent':


### PR DESCRIPTION
## Summary
- Update `pnpm-lock.yaml` to match current dependency versions
- Fixes CI release workflow failure: `pnpm install --frozen-lockfile` produces a clean lockfile, but the version bump script detects a dirty working directory because the committed lockfile was stale

## Context
Release workflow run [#23141893292](https://github.com/eggjs/egg/actions/runs/23141893292) failed with:
```
Git working directory is not clean. Please commit or stash your changes first.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)