### PR TITLE
feat(skills): add Middleware and unittest skills

### DIFF
--- a/packages/skills/CLAUDE.md
+++ b/packages/skills/CLAUDE.md
@@ -117,8 +117,8 @@ packages/skills/eval/
 ├── evals-egg-core.json        # egg-core skill 评测用例
 ├── evals-egg-controller.json  # egg-controller skill 评测用例
 ├── evals-routing.json         # 入口路由评测用例
-├── .gitignore                 # 忽略 workspace/ 和 egg-workspace/
-└── egg-workspace/             # 评测输出（gitignored），由 /skill-creator 管理
+├── .gitignore                 # 忽略 *-workspace/ 目录
+└── <skill-name>-workspace/    # 评测输出（gitignored），由 /skill-creator 管理
     └── iteration-N/
         ├── REPORT.md          # 对比评分报告
         ├── GRADING.md         # with-skill 通过率报告
@@ -195,7 +195,7 @@ site-docs 环境：
 
 **输出目录：**
 
-评测结果保存到 `egg-workspace/iteration-N/` 目录下，具体目录结构由 `/skill-creator` 管理。
+评测结果保存到 `packages/skills/eval/<skill-name>-workspace/iteration-N/` 目录下（已在 `.gitignore` 中通过 `*-workspace/` 忽略），具体目录结构由 `/skill-creator` 管理。
 
 **评测用例设计原则：**
 

--- a/packages/skills/egg-controller/SKILL.md
+++ b/packages/skills/egg-controller/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: egg-controller
-description: Use when creating API endpoints, implementing protocol handlers, exposing interfaces for specific clients, or adding parameter validation. Covers HTTP, MCP and Schedule controllers, and Ajv/TypeBox parameter validation for EGG framework applications.
+description: Use when creating API endpoints, implementing protocol handlers, exposing interfaces for specific clients, adding parameter validation, or applying middleware to controllers. Covers HTTP, MCP and Schedule controllers, Ajv/TypeBox parameter validation, and Middleware (function-style and AOP) for EGG framework applications.
 allowed-tools: Read
 ---
 
@@ -22,6 +22,10 @@ allowed-tools: Read
 需要做参数校验？
 
 4. 使用 Ajv + TypeBox 做入参校验，参考 `references/ajv-validate.md`
+
+需要给控制器加中间件（日志、鉴权、耗时统计等横切逻辑）？
+
+5. 使用 Middleware，支持函数式写法和 AOP 写法，参考 `references/middleware.md`
 ```
 
 ---
@@ -53,17 +57,26 @@ allowed-tools: Read
 - **特点**：TypeBox 定义一次 Schema，同时获得校验和 TypeScript 类型
 - **详细文档**：`references/ajv-validate.md`
 
+### Middleware 中间件
+
+- **导入**：`import { Middleware } from 'egg'`（AOP 类从 `import { Advice } from 'egg/aop'`）
+- **写法**：函数式（Koa 中间件函数）和 AOP（@Advice 类），通过 `@Middleware()` 应用
+- **特点**：支持类级别和方法级别，函数式和 AOP 不能在同一个 `@Middleware()` 中混用
+- **详细文档**：`references/middleware.md`
+
 ---
 
 ## 常见问题排查
 
-| 现象                   | 原因                       | 解决方案                                                           |
-| ---------------------- | -------------------------- | ------------------------------------------------------------------ |
-| MCP 装饰器 import 报错 | 从 `'egg'` 导入            | MCP 装饰器从 `'@eggjs/tegg'` 导入，zod 从 `'@eggjs/tegg/zod'` 导入 |
-| MCP Schema 报错        | 用了 `z.object()` 包装     | 直接用普通对象 `{ name: z.string() }`                              |
-| 定时任务不生效         | 放在 `app/schedule` 目录   | 放在模块目录中，避免和 egg 默认扫描冲突                            |
-| Ajv 校验 import 报错   | 从 `typebox` 或 `ajv` 导入 | 统一从 `'egg/ajv'` 导入 Type、Static、Ajv 等                       |
-| type 推导不完整        | 用 `type` 定义             | 用 `interface Foo extends Static<typeof Schema> {}` 代替           |
+| 现象                   | 原因                                     | 解决方案                                                           |
+| ---------------------- | ---------------------------------------- | ------------------------------------------------------------------ |
+| MCP 装饰器 import 报错 | 从 `'egg'` 导入                          | MCP 装饰器从 `'@eggjs/tegg'` 导入，zod 从 `'@eggjs/tegg/zod'` 导入 |
+| MCP Schema 报错        | 用了 `z.object()` 包装                   | 直接用普通对象 `{ name: z.string() }`                              |
+| 定时任务不生效         | 放在 `app/schedule` 目录                 | 放在模块目录中，避免和 egg 默认扫描冲突                            |
+| Ajv 校验 import 报错   | 从 `typebox` 或 `ajv` 导入               | 统一从 `'egg/ajv'` 导入 Type、Static、Ajv 等                       |
+| type 推导不完整        | 用 `type` 定义                           | 用 `interface Foo extends Static<typeof Schema> {}` 代替           |
+| Middleware 混用报错    | 函数和 Advice 类放同一个 `@Middleware()` | 分开写多个 `@Middleware()`，每个内部类型一致                       |
+| AOP Middleware 不生效  | Advice 类没加 `@Advice()` 装饰器         | 必须同时有 `@Advice()` 装饰器才能被识别为 AOP                      |
 
 ---
 
@@ -85,5 +98,6 @@ allowed-tools: Read
 - `references/mcp-controller.md` - MCP 接口开发
 - `references/schedule.md` - 定时任务
 - `references/ajv-validate.md` - Ajv 参数校验
+- `references/middleware.md` - Middleware 中间件（函数式 + AOP）
 
 核心概念（`egg-core` skill）：模块、依赖注入、对象生命周期

--- a/packages/skills/egg-controller/SKILL.md
+++ b/packages/skills/egg-controller/SKILL.md
@@ -101,3 +101,5 @@ allowed-tools: Read
 - `references/middleware.md` - Middleware 中间件（函数式 + AOP）
 
 核心概念（`egg-core` skill）：模块、依赖注入、对象生命周期
+
+单元测试（`egg-unittest` skill）：HTTP 接口测试、Service 测试、Mock

--- a/packages/skills/egg-controller/references/middleware.md
+++ b/packages/skills/egg-controller/references/middleware.md
@@ -106,7 +106,7 @@ export class FooController {
   @Middleware(methodMw)
   async hello() {}
 
-  // 多个 @Middleware 从上到下执行
+  // 多个 @Middleware 从下往上执行（靠近方法的先注册）
   // 进：globalMw → mw3 → mw2 → mw1 → multiple()
   // 出：multiple() → mw1 → mw2 → mw3 → globalMw
   @Middleware(mw1)
@@ -129,5 +129,5 @@ export class FooController {
 
 // 实际执行顺序：
 // countMw → timeMw → LogAdvice → AuthAdvice → hello()
-// （先所有函数式，再所有 AOP，与装饰器书写顺序无关）
+// （先所有函数式，再所有 AOP；各阶段内类级别先于方法级别）
 ```

--- a/packages/skills/egg-controller/references/middleware.md
+++ b/packages/skills/egg-controller/references/middleware.md
@@ -1,0 +1,133 @@
+# Middleware 中间件指南
+
+## 常见错误
+
+| 错误写法                                   | 正确写法                           | 说明                                            |
+| ------------------------------------------ | ---------------------------------- | ----------------------------------------------- |
+| `import { Middleware } from '@eggjs/tegg'` | `import { Middleware } from 'egg'` | Middleware 从 `egg` 导入                        |
+| `import { Advice } from 'egg'`             | `import { Advice } from 'egg/aop'` | AOP 装饰器从 `egg/aop` 导入                     |
+| `@Middleware(funcMw, AdviceClass)`         | 分开写两个 `@Middleware`           | 同一个 `@Middleware()` 中不能混用函数式和 AOP   |
+| AOP Advice 中用实例属性存请求级状态        | 使用 `ctx.set()`/`ctx.get()`       | Advice 默认 Singleton，实例属性会被并发请求共享 |
+| 把中间件文件放在 `app/middleware/`         | 放在模块目录下                     | 函数式中间件放在模块中，通过 import 引用        |
+
+---
+
+## 两种中间件模式
+
+Egg 的 `@Middleware` 装饰器支持两种中间件写法，根据传入参数类型自动识别：
+
+- **AOP 写法（推荐）**：使用 `@Advice` 类，支持 `@Inject` 注入 Proto 依赖，拥有丰富的生命周期钩子
+- **函数式写法（旧版兼容）**：标准 Koa 中间件函数，需要从 `ctx` 对象上手动获取依赖
+
+新项目应优先使用 AOP 写法。函数式写法主要用于兼容旧的 egg 中间件或非常简单的场景。
+
+---
+
+## 实现中间件
+
+### AOP 写法（推荐）
+
+使用 `@Advice()` 装饰器定义类，实现 `IAdvice` 的 `around` 方法，写法与 Koa 中间件一致（`next` 调用目标方法）。Advice 本身是 Proto，支持 `@Inject` 注入依赖。`around` 中可以修改入参（`ctx.args`）和返回值：
+
+```typescript
+// app/modules/foo/advice/LogAdvice.ts
+import { AccessLevel, Inject, Logger } from 'egg';
+import { Advice, IAdvice, AdviceContext } from 'egg/aop';
+
+// 跨模块使用时需设置 accessLevel: AccessLevel.PUBLIC
+@Advice({ accessLevel: AccessLevel.PUBLIC })
+export class LogAdvice implements IAdvice {
+  @Inject()
+  logger: Logger;
+
+  async around(ctx: AdviceContext, next: () => Promise<any>): Promise<any> {
+    // 修改入参：ctx.args 对应控制器方法的参数列表
+    // ctx.args[0] = sanitize(ctx.args[0]);
+
+    const start = Date.now();
+    const result = await next();
+    this.logger.info('%s cost %dms', ctx.method, Date.now() - start);
+
+    // 修改返回值：直接返回新的值即可
+    return { success: true, data: result };
+  }
+}
+```
+
+### 函数式写法（旧版兼容）
+
+标准 Koa 中间件函数，签名为 `(ctx: Context, next: Next) => Promise<void>`。旧版 egg 写法，无法使用 `@Inject`，需要从 `ctx` 对象上手动获取依赖：
+
+```typescript
+// app/modules/foo/middleware/count.ts
+import type { Context, Next } from 'egg';
+
+export async function countMw(ctx: Context, next: Next): Promise<void> {
+  const start = Date.now();
+  await next();
+  ctx.set('X-Response-Time', `${Date.now() - start}ms`);
+}
+```
+
+---
+
+## 应用中间件
+
+通过 `@Middleware()` 装饰器将中间件应用到控制器，支持类级别和方法级别：
+
+```typescript
+// app/modules/foo/FooController.ts
+import { HTTPController, HTTPMethod, HTTPMethodEnum, Middleware } from 'egg';
+import { LogAdvice } from '../common/advice/LogAdvice.ts';
+import { countMw } from './middleware/count.ts';
+
+@HTTPController({ path: '/api' })
+@Middleware(LogAdvice)  // 类级别：所有方法都会执行
+export class FooController {
+  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/profile' })
+  @Middleware(countMw)  // 方法级别：仅此方法执行
+  async getProfile() {
+    return { name: 'test' };
+  }
+}
+```
+
+---
+
+## 执行顺序
+
+遵循洋葱模型，类级别先执行，方法级别后执行：
+
+```typescript
+@Middleware(globalMw)
+export class FooController {
+  // 进：globalMw → methodMw → hello()
+  // 出：hello() → methodMw → globalMw
+  @Middleware(methodMw)
+  async hello() {}
+
+  // 多个 @Middleware 从上到下执行
+  // 进：globalMw → mw3 → mw2 → mw1 → multiple()
+  // 出：multiple() → mw1 → mw2 → mw3 → globalMw
+  @Middleware(mw1)
+  @Middleware(mw2)
+  @Middleware(mw3)
+  async multiple() {}
+}
+```
+
+**若混用函数式和 AOP 中间件，所有函数式中间件（无论类级别还是方法级别）会先于所有 AOP 中间件执行。** 即函数式和 AOP 分属两个独立的执行阶段，函数式阶段在前，AOP 阶段在后：
+
+```typescript
+@Middleware(countMw)       // 函数式 - 类级别
+@Middleware(LogAdvice)     // AOP - 类级别
+export class FooController {
+  @Middleware(timeMw)      // 函数式 - 方法级别
+  @Middleware(AuthAdvice)  // AOP - 方法级别
+  async hello() {}
+}
+
+// 实际执行顺序：
+// countMw → timeMw → LogAdvice → AuthAdvice → hello()
+// （先所有函数式，再所有 AOP，与装饰器书写顺序无关）
+```

--- a/packages/skills/egg-core/SKILL.md
+++ b/packages/skills/egg-core/SKILL.md
@@ -244,3 +244,5 @@ AOP 用于将日志、鉴权、缓存、事务等横切关注点从业务代码�
 - 请求后异步任务（BackgroundTaskHelper），请参阅：`references/background-task.md`
 - 事件总线（EventBus），请参阅：`references/eventbus.md`
 - AOP 切面编程（Advice、Pointcut、Crosscut），请参阅：`references/aop.md`
+
+单元测试（`egg-unittest` skill）：Service 测试、BackgroundTask 测试、EventBus 测试

--- a/packages/skills/egg-core/references/background-task.md
+++ b/packages/skills/egg-core/references/background-task.md
@@ -113,3 +113,9 @@ BackgroundTaskHelper 的作用是：
 4. 等待结束后才释放上下文
 
 这就是为什么必须用 `backgroundTaskHelper.run()` 而不是 `setTimeout` — 后者绕过了框架的上下文生命周期管理，执行时上下文可能已被释放。
+
+---
+
+## 单元测试
+
+BackgroundTaskHelper 的测试方法参考 `egg-unittest` skill 的 `references/background-task-test.md`。

--- a/packages/skills/egg-core/references/eventbus.md
+++ b/packages/skills/egg-core/references/eventbus.md
@@ -135,39 +135,4 @@ export class BatchService {
 
 ## 单元测试
 
-使用 `app.getEventWaiter()` 等待事件被处理完成，避免使用 `sleep`：
-
-```typescript
-import { describe, it, expect } from 'vitest';
-import { mm, type MockApplication } from '@eggjs/mock';
-import { OrderService } from './path/to/OrderService.ts';
-
-describe('order events', () => {
-  let app: MockApplication;
-
-  it('should emit orderCreated event', async () => {
-    await app.mockModuleContextScope(async (ctx) => {
-      const orderService = await ctx.getEggObject(OrderService);
-      const eventWaiter = await app.getEventWaiter();
-
-      // 准备等待事件
-      const eventPromise = eventWaiter.await('orderCreated');
-
-      // 触发业务逻辑
-      await orderService.createOrder('user1', []);
-
-      // 等待事件处理完成
-      await eventPromise;
-
-      // 断言 handler 的执行结果
-    });
-  });
-});
-```
-
-**EventWaiter API：**
-
-- `eventWaiter.await('eventName')` — 等待指定事件触发
-- `eventWaiter.awaitFirst('event1', 'event2')` — 等待多个事件中最先触发的一个
-
-**注意：** `eventWaiter.await()` 必须在 `emit()` 之前调用（先注册等待，再触发事件），否则可能错过事件。
+EventBus 的测试方法参考 `egg-unittest` skill 的 `references/eventbus-test.md`。

--- a/packages/skills/egg-unittest/SKILL.md
+++ b/packages/skills/egg-unittest/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: egg-unittest
+description: 本技能用于编写 EGG 应用的单元测试。覆盖 HTTP 接口测试、Service/DI 对象测试、Mock 数据模拟、BackgroundTask 和 EventBus 测试。使用 @eggjs/mock、app.httpRequest()、app.getEggObject()、mm() 等 API。
+allowed-tools: Read
+---
+
+# EGG 单元测试
+
+---
+
+## 原理
+
+`egg-bin test` 使用 Vitest 运行测试，自动完成以下工作：
+
+- 以当前项目目录为 baseDir，创建并启动一个 MockApplication 实例（即 `app`）
+- 注入 `@eggjs/mock/setup_vitest` 管理 app 生命周期（`beforeAll` 启动 app、`afterEach` 恢复 mock、`afterAll` 关闭 app）
+- 注入 Vitest 全局变量（`describe`、`it`、`beforeAll` 等），无需手动 import
+  测试代码中通过 `import { app, mm } from '@eggjs/mock/bootstrap'` 获取已启动的 app 实例和 mock 工具，直接使用即可。
+
+---
+
+## 配置检查
+
+确保项目中有以下配置：
+
+**package.json：**
+
+```json
+{
+  "scripts": {
+    "test": "egg-bin test"
+  },
+  "devDependencies": {
+    "@eggjs/bin": "^8",
+    "@eggjs/mock": "^8"
+  }
+}
+```
+
+**测试文件约定：**
+
+- 测试目录：`test/`
+- 文件命名：`*.test.ts`
+
+**自定义 setup 文件（可选）：**
+
+如果存在 `test/.setup.ts`，egg-bin 会自动将其加入 vitest setupFiles，在 `@eggjs/mock/setup_vitest` 之前执行（即 app 启动之前）。可用于设置环境变量等全局初始化：
+
+```typescript
+// test/.setup.ts
+beforeAll(() => {
+  process.env.SOME_CONFIG = 'test-value';
+});
+```
+
+---
+
+## 简单示例
+
+### HTTP 接口测试
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+
+describe('test/controller/home.test.ts', () => {
+  it('should GET /', () => {
+    return app.httpRequest()
+      .get('/')
+      .expect(200)
+      .expect('hello world');
+  });
+});
+```
+
+### Service 测试
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+import { UserService } from '../app/modules/user/UserService.ts';
+
+describe('test/service/user.test.ts', () => {
+  it('should get user', async () => {
+    const userService = await app.getEggObject(UserService);
+    const user = await userService.getById('1');
+    assert(user);
+    assert.equal(user.name, 'test');
+  });
+});
+```
+
+---
+
+## 测试场景决策树
+
+```
+要测什么？
+
+1. HTTP 接口（GET/POST/PUT/DELETE）？
+   → 参考 references/http-test.md
+
+2. Service / DI 对象的方法？
+   → 参考 references/service-test.md
+
+3. 需要 mock 外部依赖？（HTTP 调用、Service 方法、Session、CSRF）
+   → 参考 references/mock.md
+
+4. BackgroundTaskHelper（后台异步任务）？
+   → 参考 references/background-task-test.md
+
+5. EventBus（事件驱动）？
+   → 参考 references/eventbus-test.md
+```
+
+---
+
+## 快速参考
+
+| API                                                  | 说明                            |
+| ---------------------------------------------------- | ------------------------------- |
+| `import { app, mm } from '@eggjs/mock/bootstrap'`    | 标准测试入口                    |
+| `app.httpRequest().get('/path').expect(200)`         | HTTP 接口测试                   |
+| `app.getEggObject(Class)`                            | 获取 Singleton 实例             |
+| `app.mockModuleContextScope(async (ctx) => { ... })` | ContextProto 测试作用域         |
+| `mm(Class.prototype, 'method', fn)`                  | Mock Proto 方法                 |
+| `app.mockCsrf()`                                     | 跳过 CSRF 校验（POST 测试必备） |
+| `app.mockHttpclient(url, data)`                      | Mock 外部 HTTP 调用             |
+| `app.getEventWaiter()`                               | 获取 EventBus 事件等待器        |
+
+---
+
+## 常见错误
+
+| 错误写法                               | 正确写法                                                    | 说明                                  |
+| -------------------------------------- | ----------------------------------------------------------- | ------------------------------------- |
+| `import { app } from 'egg'`            | `import { app } from '@eggjs/mock/bootstrap'`               | 测试使用 mock 包                      |
+| `before()` / `after()`                 | `beforeAll()` / `afterAll()`                                | Vitest 钩子，不是 Mocha               |
+| POST 测试报 403                        | 加 `app.mockCsrf()`                                         | 安全插件默认开启 CSRF                 |
+| 手动写 `afterEach(mm.restore)`         | 不需要                                                      | egg-bin 自动注入 mock 恢复            |
+| `app.getEggObject()` 获取 ContextProto | 在 `app.mockModuleContextScope()` 内用 `ctx.getEggObject()` | `app.getEggObject` 只能获取 Singleton |
+| 代码写在 describe 内、hooks 外         | 放入 `beforeAll` / `beforeEach`                             | describe 体在加载阶段就执行           |
+| `await app.ready()` 配合 bootstrap     | 不需要                                                      | bootstrap 自动处理生命周期            |
+
+---
+
+## 参考资料
+
+- `references/http-test.md` — HTTP 接口测试
+- `references/service-test.md` — Service/DI 对象测试
+- `references/mock.md` — Mock 模式
+- `references/background-task-test.md` — BackgroundTaskHelper 测试
+- `references/eventbus-test.md` — EventBus 测试

--- a/packages/skills/egg-unittest/SKILL.md
+++ b/packages/skills/egg-unittest/SKILL.md
@@ -117,30 +117,29 @@ describe('test/service/user.test.ts', () => {
 
 ## 快速参考
 
-| API                                                  | 说明                            |
-| ---------------------------------------------------- | ------------------------------- |
-| `import { app, mm } from '@eggjs/mock/bootstrap'`    | 标准测试入口                    |
-| `app.httpRequest().get('/path').expect(200)`         | HTTP 接口测试                   |
-| `app.getEggObject(Class)`                            | 获取 Singleton 实例             |
-| `app.mockModuleContextScope(async (ctx) => { ... })` | ContextProto 测试作用域         |
-| `mm(Class.prototype, 'method', fn)`                  | Mock Proto 方法                 |
-| `app.mockCsrf()`                                     | 跳过 CSRF 校验（POST 测试必备） |
-| `app.mockHttpclient(url, data)`                      | Mock 外部 HTTP 调用             |
-| `app.getEventWaiter()`                               | 获取 EventBus 事件等待器        |
+| API                                                  | 说明                                    |
+| ---------------------------------------------------- | --------------------------------------- |
+| `import { app, mm } from '@eggjs/mock/bootstrap'`    | 标准测试入口                            |
+| `app.httpRequest().get('/path').expect(200)`         | HTTP 接口测试                           |
+| `app.getEggObject(Class)`                            | 获取 SingletonProto / ContextProto 实例 |
+| `app.mockModuleContextScope(async (ctx) => { ... })` | ContextProto 测试作用域                 |
+| `mm(Class.prototype, 'method', fn)`                  | Mock Proto 方法                         |
+| `app.mockCsrf()`                                     | 跳过 CSRF 校验（POST 测试必备）         |
+| `app.mockHttpclient(url, data)`                      | Mock 外部 HTTP 调用                     |
+| `app.getEventWaiter()`                               | 获取 EventBus 事件等待器                |
 
 ---
 
 ## 常见错误
 
-| 错误写法                               | 正确写法                                                    | 说明                                  |
-| -------------------------------------- | ----------------------------------------------------------- | ------------------------------------- |
-| `import { app } from 'egg'`            | `import { app } from '@eggjs/mock/bootstrap'`               | 测试使用 mock 包                      |
-| `before()` / `after()`                 | `beforeAll()` / `afterAll()`                                | Vitest 钩子，不是 Mocha               |
-| POST 测试报 403                        | 加 `app.mockCsrf()`                                         | 安全插件默认开启 CSRF                 |
-| 手动写 `afterEach(mm.restore)`         | 不需要                                                      | egg-bin 自动注入 mock 恢复            |
-| `app.getEggObject()` 获取 ContextProto | 在 `app.mockModuleContextScope()` 内用 `ctx.getEggObject()` | `app.getEggObject` 只能获取 Singleton |
-| 代码写在 describe 内、hooks 外         | 放入 `beforeAll` / `beforeEach`                             | describe 体在加载阶段就执行           |
-| `await app.ready()` 配合 bootstrap     | 不需要                                                      | bootstrap 自动处理生命周期            |
+| 错误写法                           | 正确写法                                      | 说明                        |
+| ---------------------------------- | --------------------------------------------- | --------------------------- |
+| `import { app } from 'egg'`        | `import { app } from '@eggjs/mock/bootstrap'` | 测试使用 mock 包            |
+| `before()` / `after()`             | `beforeAll()` / `afterAll()`                  | Vitest 钩子，不是 Mocha     |
+| POST 测试报 403                    | 加 `app.mockCsrf()`                           | 安全插件默认开启 CSRF       |
+| 手动写 `afterEach(mm.restore)`     | 不需要                                        | egg-bin 自动注入 mock 恢复  |
+| 代码写在 describe 内、hooks 外     | 放入 `beforeAll` / `beforeEach`               | describe 体在加载阶段就执行 |
+| `await app.ready()` 配合 bootstrap | 不需要                                        | bootstrap 自动处理生命周期  |
 
 ---
 

--- a/packages/skills/egg-unittest/references/background-task-test.md
+++ b/packages/skills/egg-unittest/references/background-task-test.md
@@ -1,0 +1,55 @@
+# BackgroundTaskHelper 测试
+
+## 常见错误
+
+| 错误写法                                           | 正确写法                                                                              | 说明                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| 不等待就断言                                       | 用 `mockModuleContextScope`（自动等待）或 `app.backgroundTasksFinished()`（手动等待） | 后台任务异步执行，必须等待完成后再断言               |
+| 在 `mockModuleContextScope` 回调内断言后台任务结果 | 在 `mockModuleContextScope` 返回后断言                                                | 回调内任务尚未完成，返回后才会等待完成               |
+| 用 `TimerUtil.sleep` 等待                          | 用 `app.backgroundTasksFinished()`                                                    | sleep 时间不确定，`backgroundTasksFinished` 精确等待 |
+
+---
+
+## 使用 mockModuleContextScope
+
+`mockModuleContextScope` 退出时会自动等待所有后台任务完成（内部触发 `doPreDestroy`），scope 退出后直接断言即可：
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+import { CountService } from '../app/modules/count/CountService.ts';
+
+it('should complete background task', async () => {
+  await app.mockModuleContextScope(async (ctx) => {
+    const countService = await ctx.getEggObject(CountService);
+    // countService 内部通过 backgroundTaskHelper.run() 触发后台任务
+    await countService.doSomething();
+  });
+
+  // scope 退出后，后台任务已完成，直接断言
+  const countService = await app.getEggObject(CountService);
+  assert.equal(countService.count, 1);
+});
+```
+
+## 使用 backgroundTasksFinished
+
+不通过 `mockModuleContextScope` 触发的场景（如 HTTP 接口测试），scope 退出的自动等待机制不适用，需要手动调用 `app.backgroundTasksFinished()` 等待所有后台任务完成后，再做断言：
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+import { CountService } from '../app/modules/count/CountService.ts';
+
+it('should complete background task', async () => {
+  await app.httpRequest()
+    .get('/api/trigger-task')
+    .expect(200);
+
+  // 等待后台任务完成
+  await app.backgroundTasksFinished();
+
+  const countService = await app.getEggObject(CountService);
+  assert.equal(countService.count, 1);
+});
+```

--- a/packages/skills/egg-unittest/references/eventbus-test.md
+++ b/packages/skills/egg-unittest/references/eventbus-test.md
@@ -1,0 +1,47 @@
+# EventBus 测试
+
+## 常见错误
+
+| 错误写法                         | 正确写法                                           | 说明                                         |
+| -------------------------------- | -------------------------------------------------- | -------------------------------------------- |
+| 先 emit 再 `eventWaiter.await()` | 先 `eventWaiter.await()` 再触发业务逻辑            | await 注册监听器，必须在事件发出前           |
+| 不等待事件处理完成就断言         | 使用 `eventWaiter.await('eventName')` 等待后再断言 | handler 异步执行，不等待则断言时可能尚未完成 |
+
+---
+
+## 基本测试模式
+
+使用 `app.getEventWaiter()` 等待事件被处理完成：
+
+```typescript
+import assert from 'node:assert';
+import { app, mm } from '@eggjs/mock/bootstrap';
+import { HelloService } from '../app/modules/hello/HelloService.ts';
+import { HelloHandler } from '../app/modules/hello/HelloHandler.ts';
+
+describe('EventBus', () => {
+  it('should handle event', async () => {
+    // mock handler 捕获调用参数
+    const mockFn = async (msg: string) => {};
+    mm(HelloHandler.prototype, 'handle', mockFn);
+
+    await app.mockModuleContextScope(async (ctx) => {
+      const helloService = await ctx.getEggObject(HelloService);
+      const eventWaiter = await app.getEventWaiter();
+
+      // 1. 先注册等待（必须在 emit 之前）
+      const eventPromise = eventWaiter.await('helloEgg');
+
+      // 2. 触发业务逻辑（内部会 emit 事件）
+      helloService.hello();
+
+      // 3. 等待 handler 执行完成
+      await eventPromise;
+    });
+
+    // 4. 验证 handler 被调用及参数
+    assert.equal(mockFn.called, 1);
+    assert.deepStrictEqual(mockFn.lastCalledArguments, ['hello']);
+  });
+});
+```

--- a/packages/skills/egg-unittest/references/http-test.md
+++ b/packages/skills/egg-unittest/references/http-test.md
@@ -1,0 +1,159 @@
+# HTTP 接口测试
+
+## 常见错误
+
+| 错误写法                                                 | 正确写法                        | 说明                                          |
+| -------------------------------------------------------- | ------------------------------- | --------------------------------------------- |
+| POST 测试不加 `app.mockCsrf()`                           | 在 POST 前调用 `app.mockCsrf()` | 安全插件默认开启 CSRF，不 mock 会返回 403     |
+| `app.httpRequest().get('/').expect(200)` 不 return/await | 必须 `return` 或 `await`        | 否则断言不会执行，测试永远通过                |
+| `.expect({ foo: 'bar' })` 用于部分匹配                   | 使用 `result.body` 手动断言     | `.expect(body)` 是全量匹配（deepStrictEqual） |
+
+---
+
+## 基本用法
+
+通过 `app.httpRequest()` 发起 HTTP 请求，返回 SuperTest 对象：
+
+```typescript
+import { app } from '@eggjs/mock/bootstrap';
+
+describe('UserController', () => {
+  it('should GET /api/users', () => {
+    return app.httpRequest()
+      .get('/api/users')
+      .expect(200)
+      .expect({ users: [] });
+  });
+});
+```
+
+---
+
+## POST 请求 + CSRF
+
+POST/PUT/DELETE 请求需要先调用 `app.mockCsrf()` 跳过 CSRF 校验：
+
+```typescript
+it('should POST /api/users', () => {
+  app.mockCsrf();
+  return app.httpRequest()
+    .post('/api/users')
+    .send({ name: 'test', email: 'test@example.com' })
+    .expect(200)
+    .expect({ id: '1', name: 'test' });
+});
+```
+
+表单提交使用 `.type('form')`：
+
+```typescript
+it('should POST form data', () => {
+  app.mockCsrf();
+  return app.httpRequest()
+    .post('/api/login')
+    .type('form')
+    .send({ username: 'admin', password: '123' })
+    .expect(200);
+});
+```
+
+---
+
+## 请求构造
+
+```typescript
+app.httpRequest()
+  .get('/api/users')
+  .set('Authorization', 'Bearer token123')     // 设置 header
+  .set('Accept', 'application/json')            // 设置 Accept
+  .query({ page: 1, limit: 10 })               // 查询参数
+  .expect(200);
+```
+
+---
+
+## 响应断言
+
+使用 `.expect()` 链式断言：
+
+```typescript
+import { app } from '@eggjs/mock/bootstrap';
+
+it('should validate response', () => {
+  return app.httpRequest()
+    .get('/api/users/1')
+    .expect(200)                               // 只校验状态码
+    .expect({ id: '1', name: 'test' })         // 只校验 body（deepStrictEqual）
+    .expect(200, { id: '1', name: 'test' })    // 状态码 + body 合并
+    .expect('hello world')                     // body 字符串匹配
+    .expect(/hello/)                           // body 正则匹配
+    .expect('content-type', /json/)            // header 匹配
+    .expect([200, 302])                        // 多状态码匹配（任一即可）
+    .expect(res => {                           // 自定义断言函数
+      assert(res.body.id);
+    });
+});
+```
+
+使用 `result` 做更灵活的断言：
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+
+it('should validate response', async () => {
+  const result = await app.httpRequest()
+    .get('/api/users/1');
+
+  assert.equal(result.status, 200);
+  assert.equal(result.body.name, 'test');
+  assert(result.body.id);
+  assert.match(result.headers['content-type'], /json/);
+});
+```
+
+完整的请求构造和断言 API 可查看项目 node_modules 中 `@eggjs/supertest` 的类型定义。
+
+---
+
+## 端到端示例
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+
+describe('test/controller/user.test.ts', () => {
+  describe('GET /api/users/:id', () => {
+    it('should return user', () => {
+      return app.httpRequest()
+        .get('/api/users/1')
+        .expect(200)
+        .expect({ id: '1', name: 'test' });
+    });
+
+    it('should return 404 when user not found', () => {
+      return app.httpRequest()
+        .get('/api/users/999')
+        .expect(404);
+    });
+  });
+
+  describe('POST /api/users', () => {
+    it('should create user', () => {
+      app.mockCsrf();
+      return app.httpRequest()
+        .post('/api/users')
+        .send({ name: 'new user', email: 'new@example.com' })
+        .expect(201);
+    });
+
+    it('should return 422 with invalid params', () => {
+      app.mockCsrf();
+      return app.httpRequest()
+        .post('/api/users')
+        .send({ name: '' })
+        .expect(422);
+    });
+  });
+});
+```

--- a/packages/skills/egg-unittest/references/http-test.md
+++ b/packages/skills/egg-unittest/references/http-test.md
@@ -77,6 +77,7 @@ app.httpRequest()
 使用 `.expect()` 链式断言：
 
 ```typescript
+import assert from 'node:assert';
 import { app } from '@eggjs/mock/bootstrap';
 
 it('should validate response', () => {

--- a/packages/skills/egg-unittest/references/mock.md
+++ b/packages/skills/egg-unittest/references/mock.md
@@ -15,6 +15,7 @@
 最常用的 mock 方式，mock DI 对象的原型方法：
 
 ```typescript
+import assert from 'node:assert';
 import { app, mm } from '@eggjs/mock/bootstrap';
 import { UserService } from '../app/modules/user/UserService.ts';
 import { OrderService } from '../app/modules/order/OrderService.ts';

--- a/packages/skills/egg-unittest/references/mock.md
+++ b/packages/skills/egg-unittest/references/mock.md
@@ -1,0 +1,113 @@
+# Mock 模式
+
+## 常见错误
+
+| 错误写法                       | 正确写法                                   | 说明                           |
+| ------------------------------ | ------------------------------------------ | ------------------------------ |
+| `mm(service, 'method', fn)`    | `mm(ServiceClass.prototype, 'method', fn)` | DI 对象需 mock 原型，不是实例  |
+| 手动写 `afterEach(mm.restore)` | 不需要                                     | egg-bin 自动注入 mock 恢复     |
+| `new Ajv()` mock 单独实例      | mock 原型方法                              | DI 容器管理的对象通过原型 mock |
+
+---
+
+## mm() — Mock Proto 方法
+
+最常用的 mock 方式，mock DI 对象的原型方法：
+
+```typescript
+import { app, mm } from '@eggjs/mock/bootstrap';
+import { UserService } from '../app/modules/user/UserService.ts';
+import { OrderService } from '../app/modules/order/OrderService.ts';
+
+describe('OrderService', () => {
+  it('should mock user service', async () => {
+    mm(UserService.prototype, 'getById', async () => {
+      return { id: '1', name: 'mocked user' };
+    });
+
+    const orderService = await app.getEggObject(OrderService);
+    const result = await orderService.createForUser('1');
+    assert.equal(result.userName, 'mocked user');
+  });
+});
+```
+
+mock 函数会自动记录调用信息，可以用来断言调用参数：
+
+```typescript
+import assert from 'node:assert';
+import { app, mm } from '@eggjs/mock/bootstrap';
+import { NotifyService } from '../app/modules/notify/NotifyService.ts';
+import { OrderService } from '../app/modules/order/OrderService.ts';
+
+it('should call notify with correct args', async () => {
+  const mockFn = async (userId: string, message: string) => {};
+  mm(NotifyService.prototype, 'send', mockFn);
+
+  const orderService = await app.getEggObject(OrderService);
+  await orderService.create({ productId: '1' });
+
+  assert.equal(mockFn.called, 1);                         // 调用次数
+  assert.deepStrictEqual(mockFn.lastCalledArguments, ['user-1', '订单创建成功']);  // 最后一次调用参数
+  // mockFn.calledArguments — 所有调用参数的数组
+});
+```
+
+---
+
+## mm.spy() — 不替换实现，只记录调用
+
+```typescript
+it('should spy on method', async () => {
+  mm.spy(NotifyService.prototype, 'send');
+
+  const orderService = await app.getEggObject(OrderService);
+  await orderService.create({ productId: '1' });
+
+  // 原方法正常执行，同时记录了调用信息
+  const sendFn = NotifyService.prototype.send;
+  assert.equal(sendFn.called, 1);
+  assert.equal(sendFn.lastCalledArguments[0], 'user-1');
+});
+```
+
+---
+
+## app.mockHttpclient() — Mock HttpClient 请求
+
+Mock 通过 `@Inject() httpclient: HttpClient` 注入的 HttpClient 发送的请求：
+
+```typescript
+it('should mock external API', () => {
+  app.mockHttpclient('https://api.example.com/users', {
+    data: JSON.stringify({ name: 'test' }),
+  });
+
+  return app.httpRequest()
+    .get('/api/proxy/users')
+    .expect(200)
+    .expect({ name: 'test' });
+});
+```
+
+---
+
+## app.mockCsrf() — 跳过 CSRF
+
+POST/PUT/DELETE 测试时跳过 CSRF 校验：
+
+```typescript
+it('should POST without CSRF error', () => {
+  app.mockCsrf();
+  return app.httpRequest()
+    .post('/api/users')
+    .send({ name: 'test' })
+    .expect(200);
+});
+```
+
+---
+
+## Mock 恢复
+
+egg-bin 自动注入 `@eggjs/mock/setup_vitest`，会在 `afterEach` 钩子中自动调用 `mm.restore()`，无需手动编写。

--- a/packages/skills/egg-unittest/references/service-test.md
+++ b/packages/skills/egg-unittest/references/service-test.md
@@ -1,0 +1,75 @@
+# Service / DI 对象测试
+
+## 常见错误
+
+| 错误写法                              | 正确写法                                                               | 说明                                  |
+| ------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------- |
+| `app.getEggObject(ContextProtoClass)` | `app.mockModuleContextScope(async (ctx) => { ctx.getEggObject(...) })` | `app.getEggObject` 只能获取 Singleton |
+| `ctx.service.user.get()`              | `ctx.getEggObject(UserService)`                                        | 旧写法，新项目用 DI                   |
+| 不 await `getEggObject`               | `const svc = await ctx.getEggObject(Svc)`                              | 返回 Promise                          |
+
+---
+
+## Singleton 测试
+
+`@SingletonProto` 对象直接通过 `app.getEggObject()` 获取：
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+import { ConfigService } from '../app/modules/foo/ConfigService.ts';
+
+describe('ConfigService', () => {
+  it('should get config', async () => {
+    const configService = await app.getEggObject(ConfigService);
+    const value = configService.get('key');
+    assert.equal(value, 'expected');
+  });
+});
+```
+
+---
+
+## ContextProto 测试
+
+`@ContextProto` 对象需要在 `app.mockModuleContextScope` 中通过 `ctx.getEggObject()` 获取。该方法会创建带 DI 生命周期的 ctx，退出时自动销毁：
+
+```typescript
+import assert from 'node:assert';
+import { app } from '@eggjs/mock/bootstrap';
+import { UserService } from '../app/modules/user/UserService.ts';
+
+describe('UserService', () => {
+  it('should get user in context scope', async () => {
+    await app.mockModuleContextScope(async (ctx) => {
+      const userService = await ctx.getEggObject(UserService);
+      const user = await userService.getById('1');
+      assert(user);
+    });
+  });
+});
+```
+
+---
+
+## Mock 被注入的依赖
+
+当 Service A 依赖 Service B 时，mock B 的原型方法：
+
+```typescript
+import { app, mm } from '@eggjs/mock/bootstrap';
+import { OrderService } from '../app/modules/order/OrderService.ts';
+import { PaymentService } from '../app/modules/payment/PaymentService.ts';
+
+describe('OrderService', () => {
+  it('should create order with mocked payment', async () => {
+    mm(PaymentService.prototype, 'charge', async () => {
+      return { transactionId: 'mock-tx-001' };
+    });
+
+    const orderService = await app.getEggObject(OrderService);
+    const order = await orderService.create({ productId: '1', amount: 100 });
+    assert.equal(order.transactionId, 'mock-tx-001');
+  });
+});
+```

--- a/packages/skills/egg-unittest/references/service-test.md
+++ b/packages/skills/egg-unittest/references/service-test.md
@@ -57,6 +57,7 @@ describe('UserService', () => {
 当 Service A 依赖 Service B 时，mock B 的原型方法：
 
 ```typescript
+import assert from 'node:assert';
 import { app, mm } from '@eggjs/mock/bootstrap';
 import { OrderService } from '../app/modules/order/OrderService.ts';
 import { PaymentService } from '../app/modules/payment/PaymentService.ts';

--- a/packages/skills/egg-unittest/references/service-test.md
+++ b/packages/skills/egg-unittest/references/service-test.md
@@ -2,11 +2,10 @@
 
 ## 常见错误
 
-| 错误写法                              | 正确写法                                                               | 说明                                  |
-| ------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------- |
-| `app.getEggObject(ContextProtoClass)` | `app.mockModuleContextScope(async (ctx) => { ctx.getEggObject(...) })` | `app.getEggObject` 只能获取 Singleton |
-| `ctx.service.user.get()`              | `ctx.getEggObject(UserService)`                                        | 旧写法，新项目用 DI                   |
-| 不 await `getEggObject`               | `const svc = await ctx.getEggObject(Svc)`                              | 返回 Promise                          |
+| 错误写法                 | 正确写法                                  | 说明                |
+| ------------------------ | ----------------------------------------- | ------------------- |
+| `ctx.service.user.get()` | `ctx.getEggObject(UserService)`           | 旧写法，新项目用 DI |
+| 不 await `getEggObject`  | `const svc = await ctx.getEggObject(Svc)` | 返回 Promise        |
 
 ---
 
@@ -32,7 +31,7 @@ describe('ConfigService', () => {
 
 ## ContextProto 测试
 
-`@ContextProto` 对象需要在 `app.mockModuleContextScope` 中通过 `ctx.getEggObject()` 获取。该方法会创建带 DI 生命周期的 ctx，退出时自动销毁：
+`@ContextProto` 对象可以直接通过 `app.getEggObject()` 获取，也可以在 `app.mockModuleContextScope` 中通过 `ctx.getEggObject()` 获取。后者会创建带 DI 生命周期的 ctx，退出时自动销毁：
 
 ```typescript
 import assert from 'node:assert';

--- a/packages/skills/egg/SKILL.md
+++ b/packages/skills/egg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: egg
-description: 本技能用于处理 EGG 框架。它提供基于用户意图在核心概念和控制器之间做选择的决策指导。作为所有 EGG 相关问题的入口点使用。覆盖模块架构、依赖注入、后台任务、EventBus 事件总线、AOP 切面编程、HTTP/MCP/Schedule 控制器、Ajv 参数校验等。
+description: 本技能用于处理 EGG 框架。它提供基于用户意图在核心概念、控制器和单元测试之间做选择的决策指导。作为所有 EGG 相关问题的入口点使用。覆盖模块架构、依赖注入、后台任务、EventBus 事件总线、AOP 切面编程、HTTP/MCP/Schedule 控制器、Ajv 参数校验、单元测试等。
 allowed-tools: Read
 ---
 
@@ -12,6 +12,7 @@ allowed-tools: Read
 
 1. **核心概念**（`egg-core` skill）：模块架构、依赖注入、对象生命周期、EventBus 事件总线、AOP 切面编程
 2. **控制器**（`egg-controller` skill）：用于 API 端点的各种协议特定控制器
+3. **单元测试**（`egg-unittest` skill）：HTTP 接口测试、Service/DI 对象测试、Mock 模拟、BackgroundTask 和 EventBus 测试
 
 ## 技能选择逻辑
 
@@ -85,6 +86,36 @@ allowed-tools: Read
 - "如何给控制器加中间件？"
 - "怎么写一个鉴权中间件？"
 
+### 使用 `egg-unittest` skill 当用户询问：
+
+**用户询问关于：**
+
+- 编写单元测试或集成测试
+- 使用 @eggjs/mock 进行测试
+- 测试 HTTP 接口（app.httpRequest）
+- 测试 Service/DI 对象
+- Mock 数据或依赖
+- 测试 BackgroundTaskHelper 或 EventBus
+
+**触发关键词：**
+
+- test、测试、单测、单元测试、unittest、unit test
+- mock、mm、@eggjs/mock、mockCsrf、mockHttpclient、mockSession、mockContext
+- httpRequest、supertest
+- getEggObject、mockModuleContextScope
+- eventWaiter、BackgroundTaskHelper 测试
+- vitest、describe、it、beforeAll
+
+**示例查询：**
+
+- "如何写单元测试？"
+- "如何测试 HTTP 接口？"
+- "如何 mock 一个 Service？"
+- "POST 请求测试报 CSRF 错误"
+- "如何测试 ContextProto 的 Service？"
+- "怎么测试后台任务是否执行完成？"
+- "怎么测试 EventBus 事件是否被正确处理？"
+
 ---
 
 ## 决策框架
@@ -135,6 +166,8 @@ allowed-tools: Read
 | Cross-module injection  | `egg-core`       | -        |
 | Module structure        | `egg-core`       | -        |
 | Object lifecycle        | `egg-core`       | -        |
+| Unit Testing            | `egg-unittest`   | -        |
+| Mock / Test helpers     | `egg-unittest`   | -        |
 
 ## 冲突解决规则
 
@@ -182,6 +215,8 @@ allowed-tools: Read
 | Scheduling           | schedule、cron、timer                   | `egg-controller` skill |
 | Param validation     | validate、校验、ajv、typebox、schema    | `egg-controller` skill |
 | Middleware 中间件    | middleware、中间件、拦截器、@Middleware | `egg-controller` skill |
+| Unit testing         | test、mock、unittest、单测              | `egg-unittest` skill   |
+| Mock dependencies    | mock、mm、mockCsrf、mockHttpclient      | `egg-unittest` skill   |
 
 ---
 
@@ -232,6 +267,18 @@ allowed-tools: Read
 2. 简要解释 @Inject 如何工作（核心概念摘要）
 3. 注意："包含限定符的详细 @Inject 使用，请使用 `egg-core` skill"
 
+### 示例 5：测试相关
+
+**用户**："帮我写个 UserController 的单元测试"
+
+**分析**：问题关于编写测试代码
+**决策**：使用 `egg-unittest` skill
+
+**用户**："POST 请求测试报 403 错误"
+
+**分析**：测试中遇到 CSRF 问题
+**决策**：使用 `egg-unittest` skill
+
 ## 路由最佳实践
 
 1. **优先考虑显式控制器提及**：如果用户命名特定控制器（HTTP），即使涉及核心概念也使用控制器技能
@@ -252,5 +299,6 @@ allowed-tools: Read
 
 - 为框架内部概念路由到 `egg-core` skill
 - 为协议特定实现路由到 `egg-controller` skill
+- 为测试相关问题路由到 `egg-unittest` skill
 - 当意图模糊时提供决策指导
 - 当存在有用的上下文时交叉引用技能

--- a/packages/skills/egg/SKILL.md
+++ b/packages/skills/egg/SKILL.md
@@ -64,6 +64,7 @@ allowed-tools: Read
 - 处理传入的请求/响应
 - 控制器级别的装饰器和模式
 - 参数校验（Ajv + TypeBox）
+- 控制器中间件（Middleware，函数式或 AOP 写法）
 
 **触发关键词：**
 
@@ -73,6 +74,7 @@ allowed-tools: Read
 - schedule、timer、cron、scheduled、定时
 - SSE、streaming、server-sent events
 - validate、校验、参数校验、ajv、typebox、schema
+- middleware、中间件、拦截器、洋葱模型、@Middleware
 
 **示例查询：**
 
@@ -80,6 +82,8 @@ allowed-tools: Read
 - "如何实现 MCP 接口？"
 - "怎么实现定时任务？"
 - "帮我给接口加上参数校验"
+- "如何给控制器加中间件？"
+- "怎么写一个鉴权中间件？"
 
 ---
 
@@ -124,6 +128,7 @@ allowed-tools: Read
 | MCP                     | `egg-controller` | -        |
 | Scheduled Tasks         | `egg-controller` | -        |
 | Parameter validation    | `egg-controller` | -        |
+| Controller Middleware   | `egg-controller` | -        |
 | Background tasks        | `egg-core`       | -        |
 | Event-driven / EventBus | `egg-core`       | -        |
 | AOP / 切面编程          | `egg-core`       | -        |
@@ -163,19 +168,20 @@ allowed-tools: Read
 
 ## 快速参考表
 
-| 用户意图             | 关键词                                | 使用技能               |
-| -------------------- | ------------------------------------- | ---------------------- |
-| Module architecture  | module、workspace、organization       | `egg-core` skill       |
-| Object lifecycle     | singleton、context、lifecycle         | `egg-core` skill       |
-| Dependency injection | inject、@Inject、dependency           | `egg-core` skill       |
-| Access control       | private、public、cross-module         | `egg-core` skill       |
-| Background tasks     | background task、异步任务、后台任务   | `egg-core` skill       |
-| Event-driven         | eventbus、事件总线、@Event、emit      | `egg-core` skill       |
-| AOP 切面编程         | aop、切面、advice、pointcut、crosscut | `egg-core` skill       |
-| HTTP endpoints       | HTTP、API、REST                       | `egg-controller` skill |
-| LLM/AI integration   | MCP、tool、prompt                     | `egg-controller` skill |
-| Scheduling           | schedule、cron、timer                 | `egg-controller` skill |
-| Param validation     | validate、校验、ajv、typebox、schema  | `egg-controller` skill |
+| 用户意图             | 关键词                                  | 使用技能               |
+| -------------------- | --------------------------------------- | ---------------------- |
+| Module architecture  | module、workspace、organization         | `egg-core` skill       |
+| Object lifecycle     | singleton、context、lifecycle           | `egg-core` skill       |
+| Dependency injection | inject、@Inject、dependency             | `egg-core` skill       |
+| Access control       | private、public、cross-module           | `egg-core` skill       |
+| Background tasks     | background task、异步任务、后台任务     | `egg-core` skill       |
+| Event-driven         | eventbus、事件总线、@Event、emit        | `egg-core` skill       |
+| AOP 切面编程         | aop、切面、advice、pointcut、crosscut   | `egg-core` skill       |
+| HTTP endpoints       | HTTP、API、REST                         | `egg-controller` skill |
+| LLM/AI integration   | MCP、tool、prompt                       | `egg-controller` skill |
+| Scheduling           | schedule、cron、timer                   | `egg-controller` skill |
+| Param validation     | validate、校验、ajv、typebox、schema    | `egg-controller` skill |
+| Middleware 中间件    | middleware、中间件、拦截器、@Middleware | `egg-controller` skill |
 
 ---
 

--- a/packages/skills/eval/.gitignore
+++ b/packages/skills/eval/.gitignore
@@ -1,2 +1,1 @@
-workspace/
-egg-workspace/
+*-workspace/

--- a/packages/skills/eval/evals-egg-controller.json
+++ b/packages/skills/eval/evals-egg-controller.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "egg-controller",
-  "description": "控制器评测：覆盖 http-controller、mcp-controller、schedule、ajv-validate",
+  "description": "控制器评测：覆盖 http-controller、mcp-controller、schedule、ajv-validate、middleware",
   "evals": [
     {
       "id": 1,
@@ -196,6 +196,76 @@
         {
           "path": "app/orderModule/OrderService.ts",
           "content": "import { SingletonProto, AccessLevel } from 'egg';\n\n@SingletonProto({ accessLevel: AccessLevel.PUBLIC })\nexport class OrderService {\n  async create(data: { productId: string; quantity: number; remark?: string }) {\n    return { orderId: 'order-' + Date.now(), ...data };\n  }\n}"
+        }
+      ]
+    },
+    {
+      "id": 26,
+      "prompt": "帮我给这个 Controller 加个日志中间件，记录每个请求的耗时",
+      "expected_output": "使用 AOP 写法：定义 @Advice 类实现 IAdvice 的 around 方法，@Inject Logger，用 @Middleware 应用到 Controller。import Advice 从 egg/aop，Middleware 从 egg",
+      "files": [
+        {
+          "path": "app/modules/user/UserController.ts",
+          "content": "import { HTTPController, HTTPMethod, HTTPMethodEnum } from 'egg';\n\n@HTTPController({ path: '/api/users' })\nexport class UserController {\n  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/' })\n  async list() {\n    return { users: [] };\n  }\n\n  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/:id' })\n  async show() {\n    return { id: '1', name: 'test' };\n  }\n}"
+        }
+      ]
+    },
+    {
+      "id": 27,
+      "prompt": "帮我写一个鉴权中间件，从 header 取 token 校验，校验失败抛异常，只应用到部分接口",
+      "expected_output": "AOP @Advice 类 + around 方法中校验 token + @Middleware 应用到方法级别（而非类级别），import Advice/IAdvice/AdviceContext 从 egg/aop"
+    },
+    {
+      "id": 28,
+      "prompt": "中间件代码报错 AOP and MiddlewareFunc can not be mixed，帮我看看哪里写错了",
+      "expected_output": "指出不能在同一个 @Middleware() 中混用函数和 Advice 类，需要分开写两个 @Middleware",
+      "files": [
+        {
+          "path": "app/modules/api/ApiController.ts",
+          "content": "import { HTTPController, HTTPMethod, HTTPMethodEnum, Middleware } from 'egg';\nimport { LogAdvice } from '../common/advice/LogAdvice.ts';\nimport { countMw } from './middleware/count.ts';\n\n@HTTPController({ path: '/api' })\n@Middleware(LogAdvice, countMw)\nexport class ApiController {\n  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/hello' })\n  async hello() {\n    return { message: 'hello' };\n  }\n}"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "prompt": "我想写一个中间件统一包装接口返回值为 { success: true, data: ... } 的格式",
+      "expected_output": "AOP @Advice 类 + around 方法中 await next() 拿到返回值后包装为 { success: true, data: result }，用 @Middleware 应用"
+    },
+    {
+      "id": 30,
+      "prompt": "AOP 中间件和函数式中间件有什么区别？什么时候用哪种",
+      "expected_output": "AOP 为推荐写法，支持 @Inject 注入依赖；函数式为旧版兼容写法，需从 ctx 手动获取依赖。新项目优先用 AOP"
+    },
+    {
+      "id": 31,
+      "prompt": "帮我把这个老的 egg 函数式中间件改成 AOP 写法",
+      "expected_output": "定义 @Advice 类 + 实现 around 方法，用 @Inject 注入 Logger 替代 ctx.logger，import 从 egg/aop",
+      "files": [
+        {
+          "path": "app/modules/api/middleware/log.ts",
+          "content": "import type { Context, Next } from 'egg';\n\nexport async function logMw(ctx: Context, next: Next): Promise<void> {\n  const start = Date.now();\n  await next();\n  ctx.logger.info('request %s %s cost %dms', ctx.method, ctx.url, Date.now() - start);\n}"
+        }
+      ]
+    },
+    {
+      "id": 32,
+      "prompt": "我在 Advice 中用了一个实例属性 count 来统计请求数，但是多个请求之间数据串了，帮我看看",
+      "expected_output": "指出 Advice 默认是 Singleton，实例属性会被并发请求共享。请求级状态应使用 ctx.set()/ctx.get() 传递",
+      "files": [
+        {
+          "path": "app/modules/api/advice/RequestCountAdvice.ts",
+          "content": "import { Advice, IAdvice, AdviceContext } from 'egg/aop';\n\n@Advice()\nexport class RequestCountAdvice implements IAdvice {\n  private requestId = '';\n\n  async around(ctx: AdviceContext, next: () => Promise<any>): Promise<any> {\n    this.requestId = Math.random().toString(36).slice(2);\n    const result = await next();\n    return { ...result, requestId: this.requestId };\n  }\n}"
+        }
+      ]
+    },
+    {
+      "id": 33,
+      "prompt": "帮我看看这个 Controller 上的中间件执行顺序是什么样的",
+      "expected_output": "函数式和 AOP 分属两个独立执行阶段：先执行所有函数式中间件（类级别 countMw → 方法级别 timeMw），再执行所有 AOP 中间件（类级别 LogAdvice → 方法级别 AuthAdvice），最后执行 hello()。即 countMw → timeMw → LogAdvice → AuthAdvice → hello()，与装饰器书写顺序无关",
+      "files": [
+        {
+          "path": "app/modules/api/ApiController.ts",
+          "content": "import { HTTPController, HTTPMethod, HTTPMethodEnum, Middleware } from 'egg';\nimport { LogAdvice } from '../common/advice/LogAdvice.ts';\nimport { AuthAdvice } from '../common/advice/AuthAdvice.ts';\nimport { countMw } from './middleware/count.ts';\nimport { timeMw } from './middleware/time.ts';\n\n@HTTPController({ path: '/api' })\n@Middleware(countMw)\n@Middleware(LogAdvice)\nexport class ApiController {\n  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/hello' })\n  @Middleware(timeMw)\n  @Middleware(AuthAdvice)\n  async hello() {\n    return { message: 'hello' };\n  }\n}"
         }
       ]
     }

--- a/packages/skills/eval/evals-egg-unittest.json
+++ b/packages/skills/eval/evals-egg-unittest.json
@@ -1,0 +1,184 @@
+{
+  "skill_name": "egg-unittest",
+  "description": "单元测试评测：覆盖 http-test、service-test、mock、background-task-test、eventbus-test",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "帮我给这个 UserController 写个单元测试，要测 GET 和 POST 接口",
+      "expected_output": "import { app } from '@eggjs/mock/bootstrap'，app.httpRequest() 测 GET 和 POST，POST 前调用 app.mockCsrf()，return 或 await httpRequest",
+      "files": [
+        {
+          "path": "app/modules/user/UserController.ts",
+          "content": "import { HTTPController, HTTPMethod, HTTPMethodEnum, HTTPParam, HTTPBody, Inject } from 'egg';\nimport { UserService } from './UserService.ts';\n\n@HTTPController({ path: '/api/users' })\nexport class UserController {\n  @Inject()\n  userService: UserService;\n\n  @HTTPMethod({ method: HTTPMethodEnum.GET, path: '/:id' })\n  async show(@HTTPParam() id: string) {\n    return await this.userService.getById(id);\n  }\n\n  @HTTPMethod({ method: HTTPMethodEnum.POST, path: '/' })\n  async create(@HTTPBody() body: { name: string; email: string }) {\n    return await this.userService.create(body);\n  }\n}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "POST 接口测试报 403 错误，帮我看看",
+      "expected_output": "指出需要调用 app.mockCsrf() 跳过 CSRF 校验",
+      "files": [
+        {
+          "path": "test/controller/user.test.ts",
+          "content": "import { app } from '@eggjs/mock/bootstrap';\n\ndescribe('UserController', () => {\n  it('should create user', () => {\n    return app.httpRequest()\n      .post('/api/users')\n      .send({ name: 'test', email: 'test@example.com' })\n      .expect(200);\n  });\n});"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "httpRequest 的 expect 有哪些用法",
+      "expected_output": "expect(status)、expect(body)、expect(status, body) 合并、expect('header', value)、expect(/regex/)、expect([200, 302]) 多状态码、expect(fn) 自定义断言"
+    },
+    {
+      "id": 4,
+      "prompt": "测试写了但永远通过，不管接口返回啥都不报错",
+      "expected_output": "httpRequest 必须 return 或 await，否则断言不会执行",
+      "files": [
+        {
+          "path": "test/controller/home.test.ts",
+          "content": "import { app } from '@eggjs/mock/bootstrap';\n\ndescribe('HomeController', () => {\n  it('should return 200', () => {\n    app.httpRequest()\n      .get('/')\n      .expect(200)\n      .expect('hello');\n  });\n});"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "帮我写一个完整的 CRUD 接口测试",
+      "expected_output": "GET/POST/PUT/DELETE 完整测试，POST/PUT/DELETE 都要 mockCsrf，import 从 @eggjs/mock/bootstrap"
+    },
+    {
+      "id": 6,
+      "prompt": "基于这个 OrderService 帮我写完整的单元测试",
+      "expected_output": "app.getEggObject(OrderService) 获取实例 + mm mock PaymentService 依赖 + 断言返回值",
+      "files": [
+        {
+          "path": "app/modules/order/OrderService.ts",
+          "content": "import { SingletonProto, Inject } from 'egg';\nimport { PaymentService } from '../payment/PaymentService.ts';\n\n@SingletonProto()\nexport class OrderService {\n  @Inject()\n  paymentService: PaymentService;\n\n  async create(data: { productId: string; amount: number }) {\n    const tx = await this.paymentService.charge(data.amount);\n    return { orderId: 'order-1', transactionId: tx.id };\n  }\n}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "测试代码跑不起来，getEggObject 报错了",
+      "expected_output": "指出 app.getEggObject 只能获取 Singleton，ContextProto 需要用 app.mockModuleContextScope",
+      "files": [
+        {
+          "path": "app/modules/cart/CartService.ts",
+          "content": "import { ContextProto } from 'egg';\n\n@ContextProto()\nexport class CartService {\n  async addItem(productId: string) {\n    return { productId, quantity: 1 };\n  }\n}"
+        },
+        {
+          "path": "test/service/cart.test.ts",
+          "content": "import { app } from '@eggjs/mock/bootstrap';\nimport assert from 'node:assert';\nimport { CartService } from '../app/modules/cart/CartService.ts';\n\ndescribe('CartService', () => {\n  it('should add item', async () => {\n    const cartService = await app.getEggObject(CartService);\n    const item = await cartService.addItem('p1');\n    assert.equal(item.productId, 'p1');\n  });\n});"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Singleton 和 ContextProto 的测试方式有什么区别",
+      "expected_output": "Singleton 用 app.getEggObject 直接获取，ContextProto 需在 app.mockModuleContextScope 回调内用 ctx.getEggObject 获取"
+    },
+    {
+      "id": 9,
+      "prompt": "怎么测试一个依赖其他 Service 的 Service",
+      "expected_output": "mm(DependencyClass.prototype, 'method', fn) mock 依赖的原型方法，再 getEggObject 获取被测 Service"
+    },
+    {
+      "id": 10,
+      "prompt": "mockModuleContextScope 回调里的断言通过了但实际上没执行，测试直接过了",
+      "expected_output": "mockModuleContextScope 的回调必须 await，否则 scope 提前退出",
+      "files": [
+        {
+          "path": "test/service/user.test.ts",
+          "content": "import { app } from '@eggjs/mock/bootstrap';\nimport assert from 'node:assert';\nimport { UserService } from '../app/modules/user/UserService.ts';\n\ndescribe('UserService', () => {\n  it('should get user', () => {\n    app.mockModuleContextScope(async (ctx) => {\n      const userService = await ctx.getEggObject(UserService);\n      const user = await userService.getById('1');\n      assert.equal(user.name, 'test');\n    });\n  });\n});"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "怎么 mock 一个被注入的 Service 的方法",
+      "expected_output": "mm(ServiceClass.prototype, 'methodName', async () => { ... })，import mm 从 @eggjs/mock/bootstrap，mock 原型而非实例"
+    },
+    {
+      "id": 12,
+      "prompt": "mm mock 了但没生效，帮我看看",
+      "expected_output": "mock 的是实例而非原型，应该用 mm(ServiceClass.prototype, ...)",
+      "files": [
+        {
+          "path": "test/service/order.test.ts",
+          "content": "import { app, mm } from '@eggjs/mock/bootstrap';\nimport assert from 'node:assert';\nimport { PaymentService } from '../app/modules/payment/PaymentService.ts';\nimport { OrderService } from '../app/modules/order/OrderService.ts';\n\ndescribe('OrderService', () => {\n  it('should mock payment', async () => {\n    const paymentService = await app.getEggObject(PaymentService);\n    mm(paymentService, 'charge', async () => ({ id: 'tx-mock' }));\n\n    const orderService = await app.getEggObject(OrderService);\n    const order = await orderService.create({ productId: '1', amount: 100 });\n    assert.equal(order.transactionId, 'tx-mock');\n  });\n});"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "怎么验证 mock 的方法被调用了几次、传了什么参数",
+      "expected_output": "mockFn.called 调用次数，mockFn.lastCalledArguments 最后一次参数，mockFn.calledArguments 所有参数"
+    },
+    {
+      "id": 14,
+      "prompt": "怎么 mock 外部 HTTP 请求，我的 Service 里用了 httpclient 调第三方 API",
+      "expected_output": "app.mockHttpclient(url, { data: ... })，mock 通过 @Inject 注入的 HttpClient 发送的请求"
+    },
+    {
+      "id": 15,
+      "prompt": "mm 和 mm.spy 有什么区别",
+      "expected_output": "mm 替换方法实现，spy 保留原实现不替换，两者都会记录调用信息（called、lastCalledArguments）"
+    },
+    {
+      "id": 16,
+      "prompt": "怎么 mock 一个方法让它抛出异常",
+      "expected_output": "mm.error(Class.prototype, 'method', new Error('...'))"
+    },
+    {
+      "id": 17,
+      "prompt": "怎么测试后台任务是否执行完成",
+      "expected_output": "两种方式：1. mockModuleContextScope 退出时自动等待（内部触发 doPreDestroy） 2. app.backgroundTasksFinished() 手动等待。不应该用 sleep"
+    },
+    {
+      "id": 18,
+      "prompt": "用 httpRequest 触发的后台任务怎么等它完成",
+      "expected_output": "await app.backgroundTasksFinished()"
+    },
+    {
+      "id": 19,
+      "prompt": "测试里用了 TimerUtil.sleep 等后台任务，CI 上经常超时不稳定",
+      "expected_output": "用 app.backgroundTasksFinished() 替代 sleep，精确等待任务完成",
+      "files": [
+        {
+          "path": "test/service/task.test.ts",
+          "content": "import { app } from '@eggjs/mock/bootstrap';\nimport assert from 'node:assert';\nimport { TimerUtil } from '@eggjs/tegg-common-util';\nimport { CountService } from '../app/modules/count/CountService.ts';\n\nit('should complete task', async () => {\n  await app.httpRequest().get('/api/trigger-task').expect(200);\n  await TimerUtil.sleep(3000);\n  const countService = await app.getEggObject(CountService);\n  assert.equal(countService.count, 1);\n});"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "prompt": "backgroundTasksFinished 调了但断言还是失败，count 一直是 0",
+      "expected_output": "检查用于验证的 Service 是否是 @SingletonProto，ContextProto 每次 getEggObject 拿到的是不同实例"
+    },
+    {
+      "id": 21,
+      "prompt": "怎么测试 EventBus 事件是否被正确处理",
+      "expected_output": "app.getEventWaiter() 获取 waiter，eventWaiter.await('eventName') 必须在 emit 之前注册，用 mm mock handler 验证调用"
+    },
+    {
+      "id": 22,
+      "prompt": "eventWaiter.await 一直挂着不返回，测试超时了",
+      "expected_output": "eventWaiter.await 必须在 emit 之前调用，先注册等待再触发业务逻辑",
+      "files": [
+        {
+          "path": "test/event/hello.test.ts",
+          "content": "import { app } from '@eggjs/mock/bootstrap';\nimport { HelloService } from '../app/modules/hello/HelloService.ts';\n\nit('should handle event', async () => {\n  await app.mockModuleContextScope(async (ctx) => {\n    const helloService = await ctx.getEggObject(HelloService);\n    helloService.hello();\n\n    const eventWaiter = await app.getEventWaiter();\n    await eventWaiter.await('helloEgg');\n  });\n});"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "prompt": "怎么验证 EventBus handler 收到的参数是否正确",
+      "expected_output": "mm mock handler 原型方法 + mockFn.lastCalledArguments 断言参数"
+    },
+    {
+      "id": 24,
+      "prompt": "帮我写一个 EventBus 事件的完整测试",
+      "expected_output": "完整示例：import bootstrap + mockModuleContextScope + getEventWaiter + await 在 emit 前 + mm mock handler + 断言"
+    }
+  ]
+}

--- a/packages/skills/eval/evals-egg-unittest.json
+++ b/packages/skills/eval/evals-egg-unittest.json
@@ -58,23 +58,13 @@
     },
     {
       "id": 7,
-      "prompt": "测试代码跑不起来，getEggObject 报错了",
-      "expected_output": "指出 app.getEggObject 只能获取 Singleton，ContextProto 需要用 app.mockModuleContextScope",
-      "files": [
-        {
-          "path": "app/modules/cart/CartService.ts",
-          "content": "import { ContextProto } from 'egg';\n\n@ContextProto()\nexport class CartService {\n  async addItem(productId: string) {\n    return { productId, quantity: 1 };\n  }\n}"
-        },
-        {
-          "path": "test/service/cart.test.ts",
-          "content": "import { app } from '@eggjs/mock/bootstrap';\nimport assert from 'node:assert';\nimport { CartService } from '../app/modules/cart/CartService.ts';\n\ndescribe('CartService', () => {\n  it('should add item', async () => {\n    const cartService = await app.getEggObject(CartService);\n    const item = await cartService.addItem('p1');\n    assert.equal(item.productId, 'p1');\n  });\n});"
-        }
-      ]
+      "prompt": "ContextProto 的 Service 怎么在测试里获取实例",
+      "expected_output": "app.getEggObject(ContextProtoClass) 可以直接获取，也可以在 app.mockModuleContextScope 回调内用 ctx.getEggObject 获取（后者提供上下文生命周期管理，退出时自动销毁）"
     },
     {
       "id": 8,
       "prompt": "Singleton 和 ContextProto 的测试方式有什么区别",
-      "expected_output": "Singleton 用 app.getEggObject 直接获取，ContextProto 需在 app.mockModuleContextScope 回调内用 ctx.getEggObject 获取"
+      "expected_output": "两者都可以用 app.getEggObject 直接获取。ContextProto 还可以在 app.mockModuleContextScope 回调内用 ctx.getEggObject 获取，提供上下文生命周期管理（退出时自动销毁、自动等待后台任务）"
     },
     {
       "id": 9,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -20,6 +20,7 @@
   "files": [
     "egg-controller/**/*.md",
     "egg-core/**/*.md",
+    "egg-unittest/**/*.md",
     "egg/**/*.md"
   ],
   "publishConfig": {

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -18,7 +18,9 @@
     "directory": "packages/skills"
   },
   "files": [
-    "**/*.md"
+    "egg-controller/**/*.md",
+    "egg-core/**/*.md",
+    "egg/**/*.md"
   ],
   "publishConfig": {
     "access": "public"

--- a/site/docs/zh-CN/basics/unittest.md
+++ b/site/docs/zh-CN/basics/unittest.md
@@ -68,7 +68,7 @@ describe('test', () => {
 export interface Application {
   /**
    * 通过一个类来获取实例
-   * 注：app.getEggObject 只能获取 Singleton 实例
+   * 注：app.getEggObject 可以获取 Singleton/Context 实例
    */
   getEggObject<T>(clazz: EggProtoImplClass<T>): Promise<T>;
 }


### PR DESCRIPTION
## Summary

- Add Middleware skill to `egg-controller`, covering AOP (recommended) and function-style (legacy) patterns
- Add `egg-unittest` skill with 5 reference docs: HTTP test, Service/DI test, Mock patterns, BackgroundTask test, EventBus test
- Update entry skill (`egg/SKILL.md`) routing for middleware and unittest queries
- Add cross-references from `egg-controller` and `egg-core` skills to `egg-unittest`
- Narrow `@eggjs/skills` package published files to skill directories only
- Add 8 middleware evals and 24 unittest evals

## Test plan

- [x] Middleware evals: with-skill 3.94/4 vs site-docs 3.06/4 (8 cases)
- [x] Unittest evals: with-skill 4.0/4 vs site-docs 3.52/4 (22 cases)
- [x] `npm pack --dry-run` verify only skill dirs included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new unit-testing skill with end-to-end guides and examples for HTTP, Service/DI, mocks, background tasks, and EventBus testing.
  * Added controller middleware guidance covering function-style and AOP middleware, application patterns, execution order, and troubleshooting.
  * Expanded core/controller decision guides and quick-reference entries to include testing and middleware scenarios; added many example tests and common-mistake tables.

* **Chores**
  * Narrowed published doc file inclusion and generalized workspace ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->