### PR TITLE
feat: add AgentController support to standalone Runner

### DIFF
--- a/tegg/standalone/standalone/package.json
+++ b/tegg/standalone/standalone/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@eggjs/aop-runtime": "workspace:*",
+    "@eggjs/controller-plugin": "workspace:*",
     "@eggjs/dal-plugin": "workspace:*",
     "@eggjs/lifecycle": "workspace:*",
     "@eggjs/metadata": "workspace:*",

--- a/tegg/standalone/standalone/src/Runner.ts
+++ b/tegg/standalone/standalone/src/Runner.ts
@@ -15,6 +15,7 @@ import {
 } from '@eggjs/dal-plugin';
 import {
   type EggPrototype,
+  EggPrototypeCreatorFactory,
   EggPrototypeLifecycleUtil,
   GlobalGraph,
   type LoadUnit,
@@ -40,6 +41,7 @@ import {
   ContextHandler,
   EggContainerFactory,
   type EggContext,
+  EggObjectFactory,
   EggObjectLifecycleUtil,
   type LoadUnitInstance,
   LoadUnitInstanceFactory,
@@ -47,6 +49,9 @@ import {
 } from '@eggjs/tegg-runtime';
 import { CrosscutAdviceFactory } from '@eggjs/tegg/aop';
 import { StandaloneUtil, type MainRunner } from '@eggjs/tegg/standalone';
+
+import { AgentControllerObject } from '@eggjs/controller-plugin/lib/AgentControllerObject';
+import { AgentControllerProto } from '@eggjs/controller-plugin/lib/AgentControllerProto';
 
 import { ConfigSourceLoadUnitHook } from './ConfigSourceLoadUnitHook.ts';
 import { EggModuleLoader } from './EggModuleLoader.ts';
@@ -246,6 +251,17 @@ export class Runner {
     EggPrototypeLifecycleUtil.registerLifecycle(this.dalTableEggPrototypeHook);
     EggPrototypeLifecycleUtil.registerLifecycle(this.transactionPrototypeHook);
     LoadUnitLifecycleUtil.registerLifecycle(this.dalModuleLoadUnitHook);
+
+    // AgentController support
+    EggPrototypeCreatorFactory.registerPrototypeCreator(
+      'AGENT_CONTROLLER_PROTO',
+      AgentControllerProto.createProto,
+    );
+    EggObjectFactory.registerEggObjectCreateMethod(
+      AgentControllerProto,
+      AgentControllerObject.createObject,
+    );
+    AgentControllerObject.setLogger(logger as any);
   }
 
   async init(): Promise<void> {


### PR DESCRIPTION
## Summary

- Register `AgentControllerProto.createProto` via `EggPrototypeCreatorFactory` in standalone Runner's `initLoaderInstance()`
- Register `AgentControllerObject.createObject` via `EggObjectFactory` for object instantiation
- Set logger for `AgentControllerObject` using the Runner's available logger
- Add `@eggjs/controller-plugin` as a dependency of `@eggjs/standalone`

The standalone Runner bypasses egg plugin lifecycle (`app.ts`), so `@AgentController` decorator support requires manual registration of the prototype creator and object factory method — mirroring what `@eggjs/controller-plugin/app.ts` does in the plugin boot hook.

## Test plan

- [ ] Verify standalone Runner can resolve and instantiate classes decorated with `@AgentController`
- [ ] Confirm existing standalone tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added controller plugin dependency to the standalone package

* **Refactor**
  * Enhanced runner initialization with controller integration support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->