### PR TITLE
feat(core): add startup manifest for faster cold starts

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -76,6 +76,10 @@ jobs:
               CNPMCORE_DATABASE_NAME=cnpmcore_unittest bash ./prepare-database-mysql.sh
               CNPMCORE_DATABASE_NAME=cnpmcore bash ./prepare-database-mysql.sh
 
+              # Generate startup manifest for faster cold start
+              EGG_TS_ENABLE=false npx egg-bin manifest generate --env=unittest
+              EGG_TS_ENABLE=false npx egg-bin manifest validate --env=unittest
+
               EGG_TS_ENABLE=false npx eggctl start --port=7001 --env=unittest --daemon
               HEALTH_URL="http://127.0.0.1:7001/"
               START_TIME=$(date +%s)
@@ -85,7 +89,6 @@ jobs:
 
               echo "Waiting for application to become healthy at ${HEALTH_URL} (timeout: ${TIMEOUT}s)..."
               while true; do
-                # Capture response body and status code
                 STATUS=$(curl -s -o /tmp/cnpmcore-health-response -w "%{http_code}" "${HEALTH_URL}" || echo "000")
                 echo "Health check attempt at $(date): status=${STATUS}"
 
@@ -115,6 +118,10 @@ jobs:
                 cat logs/cnpmcore/common-error.log 2>/dev/null || true
                 exit 1
               fi
+
+              # Verify manifest is loaded and used (zero extra resolve I/O)
+              cp ../scripts/verify-manifest.mjs .
+              EGG_TS_ENABLE=false EGG_SERVER_ENV=unittest node verify-manifest.mjs
           - name: examples
             node-version: 24
             command: |

--- a/ecosystem-ci/scripts/verify-manifest.mjs
+++ b/ecosystem-ci/scripts/verify-manifest.mjs
@@ -1,0 +1,42 @@
+/**
+ * Verify that the startup manifest is loaded and used during application boot.
+ * Asserts that resolveModule reads from cache with zero extra file I/O.
+ *
+ * Usage: EGG_SERVER_ENV=<env> node ecosystem-ci/scripts/verify-manifest.mjs
+ * Must be run from the application's baseDir (e.g., ecosystem-ci/cnpmcore/).
+ */
+async function main() {
+  const { startEgg } = await import('egg');
+
+  const app = await startEgg({
+    baseDir: process.cwd(),
+    mode: 'single',
+    metadataOnly: true,
+  });
+
+  if (!app.loader.manifest) {
+    console.error('FAIL: manifest not loaded');
+    process.exit(1);
+  }
+
+  const { resolveCache, fileDiscovery, tegg } = app.loader.manifest.data;
+  console.log('Manifest loaded successfully');
+  console.log('  resolveCache entries:', Object.keys(resolveCache).length);
+  console.log('  fileDiscovery entries:', Object.keys(fileDiscovery).length);
+  console.log('  tegg moduleRefs:', tegg?.moduleReferences?.length ?? 0);
+
+  // After ready(), the loader has run all loading phases with metadataOnly.
+  // With a valid manifest, resolveModule should have used the cache
+  // and produced zero new collector entries.
+  const newEntries = Object.keys(app.loader.resolveCacheCollector).length;
+  if (newEntries > 0) {
+    console.error('FAIL: resolve produced %d new I/O entries instead of using cache', newEntries);
+    process.exit(1);
+  }
+  console.log('  resolve cache: all hits, zero extra I/O');
+
+  await app.close();
+  process.exit(0);
+}
+
+void main();

--- a/packages/core/src/egg.ts
+++ b/packages/core/src/egg.ts
@@ -31,6 +31,8 @@ export interface EggCoreOptions {
   plugins?: any;
   serverScope?: string;
   env?: string;
+  /** Skip lifecycle hooks, only trigger loadMetadata for manifest generation */
+  metadataOnly?: boolean;
 }
 
 export type EggCoreInitOptions = Partial<EggCoreOptions>;
@@ -218,6 +220,7 @@ export class EggCore extends KoaApplication {
       serverScope: options.serverScope,
       env: options.env ?? '',
       EggCoreClass: EggCore,
+      metadataOnly: options.metadataOnly,
     });
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export * from './singleton.ts';
 export * from './loader/egg_loader.ts';
 export * from './loader/file_loader.ts';
 export * from './loader/context_loader.ts';
+export * from './loader/manifest.ts';
 export * from './utils/sequencify.ts';
 export * from './utils/timing.ts';
 export type * from './types.ts';

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -54,6 +54,13 @@ export interface ILifecycleBoot {
    * Do some thing before app close
    */
   beforeClose?(): Promise<void>;
+
+  /**
+   * Collect metadata for manifest generation (metadataOnly mode).
+   * Called instead of configWillLoad/configDidLoad/didLoad/willReady
+   * when the application is started with metadataOnly: true.
+   */
+  loadMetadata?(): Promise<void> | void;
 }
 
 export type BootImplClass<T = ILifecycleBoot> = new (...args: any[]) => T;
@@ -72,6 +79,7 @@ export class Lifecycle extends EventEmitter {
   #bootHooks: (BootImplClass | ILifecycleBoot)[];
   #boots: ILifecycleBoot[];
   #isClosed: boolean;
+  #metadataOnly: boolean;
   #closeFunctionSet: Set<FunWithFullPath>;
   loadReady: Ready;
   bootReady: Ready;
@@ -87,6 +95,7 @@ export class Lifecycle extends EventEmitter {
     this.#boots = [];
     this.#closeFunctionSet = new Set();
     this.#isClosed = false;
+    this.#metadataOnly = false;
     this.#init = false;
 
     this.timing.start(`${this.options.app.type} Start`);
@@ -110,7 +119,9 @@ export class Lifecycle extends EventEmitter {
     });
 
     this.ready((err) => {
-      this.triggerDidReady(err);
+      if (!this.#metadataOnly) {
+        void this.triggerDidReady(err);
+      }
       debug('app ready');
       this.timing.end(`${this.options.app.type} Start`);
     });
@@ -329,6 +340,24 @@ export class Lifecycle extends EventEmitter {
       }
       debug('trigger serverDidReady end');
     })();
+  }
+
+  async triggerLoadMetadata(): Promise<void> {
+    this.#metadataOnly = true;
+    debug('trigger loadMetadata start');
+    for (const boot of this.#boots) {
+      if (typeof boot.loadMetadata === 'function') {
+        debug('trigger loadMetadata at %o', boot.fullPath);
+        try {
+          await boot.loadMetadata();
+        } catch (err) {
+          debug('trigger loadMetadata error at %o, error: %s', boot.fullPath, err);
+          this.emit('error', err);
+        }
+      }
+    }
+    debug('trigger loadMetadata end');
+    this.ready(true);
   }
 
   #initReady(): void {

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -48,6 +48,8 @@ export interface EggLoaderOptions {
   serverScope?: string;
   /** custom plugins */
   plugins?: Record<string, EggPluginInfo>;
+  /** Skip lifecycle hooks, only trigger loadMetadata for manifest generation */
+  metadataOnly?: boolean;
 }
 
 export type EggDirInfoType = 'app' | 'plugin' | 'framework';
@@ -1248,7 +1250,11 @@ export class EggLoader {
    */
   async loadCustomApp(): Promise<void> {
     await this.#loadBootHook('app');
-    this.lifecycle.triggerConfigWillLoad();
+    if (this.options.metadataOnly) {
+      await this.lifecycle.triggerLoadMetadata();
+    } else {
+      this.lifecycle.triggerConfigWillLoad();
+    }
   }
 
   /**
@@ -1256,7 +1262,11 @@ export class EggLoader {
    */
   async loadCustomAgent(): Promise<void> {
     await this.#loadBootHook('agent');
-    this.lifecycle.triggerConfigWillLoad();
+    if (this.options.metadataOnly) {
+      await this.lifecycle.triggerLoadMetadata();
+    } else {
+      this.lifecycle.triggerConfigWillLoad();
+    }
   }
 
   // FIXME: no logger used after egg removed

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -23,6 +23,7 @@ import { sequencify } from '../utils/sequencify.ts';
 import { Timing } from '../utils/timing.ts';
 import { type ContextLoaderOptions, ContextLoader } from './context_loader.ts';
 import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';
+import { ManifestStore, type ManifestTegg, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
 
@@ -67,6 +68,14 @@ export class EggLoader {
   readonly appInfo: EggAppInfo;
   readonly outDir?: string;
   dirs?: EggDirInfo[];
+  /** Pre-computed startup manifest for skipping file I/O */
+  readonly manifest: ManifestStore | null;
+  /** Collected resolveModule results for manifest generation */
+  readonly resolveCacheCollector: Record<string, string | null> = {};
+  /** Collected file discovery results for manifest generation */
+  readonly fileDiscoveryCollector: Record<string, string[]> = {};
+  /** Collected tegg manifest data (populated by tegg plugin) */
+  teggManifestCollector?: ManifestTegg;
 
   /**
    * @class
@@ -154,6 +163,12 @@ export class EggLoader {
      * @since 1.0.0
      */
     this.appInfo = this.getAppInfo();
+
+    // Load pre-computed startup manifest if available
+    this.manifest = ManifestStore.load(this.options.baseDir, this.serverEnv, this.serverScope);
+    if (this.manifest) {
+      debug('startup manifest loaded, will skip redundant file I/O');
+    }
   }
 
   get app(): EggCore {
@@ -1627,6 +1642,8 @@ export class EggLoader {
       directory: options?.directory ?? directory,
       target,
       inject: this.app,
+      manifest: this.manifest,
+      fileDiscoveryCollector: this.fileDiscoveryCollector,
     };
 
     const timingKey = `Load "${String(property)}" to Application`;
@@ -1652,6 +1669,8 @@ export class EggLoader {
       directory: options?.directory || directory,
       property,
       inject: this.app,
+      manifest: this.manifest,
+      fileDiscoveryCollector: this.fileDiscoveryCollector,
     };
 
     const timingKey = `Load "${String(property)}" to Context`;
@@ -1688,6 +1707,15 @@ export class EggLoader {
   }
 
   resolveModule(filepath: string): string | undefined {
+    // Check manifest cache first
+    if (this.manifest) {
+      const cached = this.manifest.getResolveCache(filepath);
+      if (cached !== undefined) {
+        debug('[resolveModule:manifest] %o => %o', filepath, cached);
+        return cached ?? undefined;
+      }
+    }
+
     let fullPath: string | undefined;
     try {
       fullPath = utils.resolvePath(filepath);
@@ -1697,6 +1725,10 @@ export class EggLoader {
     if (!fullPath) {
       fullPath = this.#resolveFromOutDir(filepath);
     }
+
+    // Collect for manifest generation
+    this.resolveCacheCollector[filepath] = fullPath ?? null;
+
     return fullPath;
   }
 
@@ -1733,6 +1765,22 @@ export class EggLoader {
         return outDirPath;
       }
     }
+  }
+
+  /**
+   * Generate startup manifest from collected data.
+   * Should be called after all loading phases complete.
+   */
+  generateManifest(tegg?: ManifestTegg): StartupManifest {
+    return ManifestStore.generate({
+      baseDir: this.options.baseDir,
+      serverEnv: this.serverEnv,
+      serverScope: this.serverScope,
+      typescriptEnabled: isSupportTypeScript(),
+      tegg,
+      resolveCache: this.resolveCacheCollector,
+      fileDiscovery: this.fileDiscoveryCollector,
+    });
   }
 }
 

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -8,6 +8,7 @@ import globby from 'globby';
 import { isClass, isGeneratorFunction, isAsyncFunction, isPrimitive } from 'is-type-of';
 
 import utils, { type Fun } from '../utils/index.ts';
+import type { ManifestStore } from './manifest.ts';
 
 const debug = debuglog('egg/core/file_loader');
 
@@ -49,6 +50,10 @@ export interface FileLoaderOptions {
   /** set property's case when converting a filepath to property list. */
   caseStyle?: CaseStyle | CaseStyleFunction;
   lowercaseFirst?: boolean;
+  /** Pre-computed startup manifest for skipping globby scans */
+  manifest?: ManifestStore | null;
+  /** Collector for file discovery results during manifest generation */
+  fileDiscoveryCollector?: Record<string, string[]>;
 }
 
 export interface FileLoaderParseItem {
@@ -193,8 +198,17 @@ export class FileLoader {
     const items: FileLoaderParseItem[] = [];
     debug('[parse] parsing directories: %j', directories);
     for (const directory of directories) {
-      const filepaths = globby.sync(files, { cwd: directory });
-      debug('[parse] globby files: %o, cwd: %o => %o', files, directory, filepaths);
+      const cachedFiles = this.options.manifest?.getFileDiscovery(directory);
+      const filepaths = cachedFiles ?? globby.sync(files, { cwd: directory });
+      if (cachedFiles) {
+        debug('[parse:manifest] using cached files for %o, count: %d', directory, cachedFiles.length);
+      } else {
+        debug('[parse] globby files: %o, cwd: %o => %o', files, directory, filepaths);
+        // Collect for manifest generation
+        if (this.options.fileDiscoveryCollector) {
+          this.options.fileDiscoveryCollector[directory] = filepaths;
+        }
+      }
       for (const filepath of filepaths) {
         const fullpath = path.join(directory, filepath);
         if (!fs.statSync(fullpath).isFile()) continue;

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -103,10 +103,7 @@ export class ManifestStore {
       return false;
     }
 
-    if (inv.baseDir !== baseDir) {
-      debug('manifest baseDir mismatch: expected %s, got %s', baseDir, inv.baseDir);
-      return false;
-    }
+    // Note: baseDir is NOT validated — build env and runtime env may have different paths
 
     if (inv.serverEnv !== serverEnv) {
       debug('manifest serverEnv mismatch: expected %s, got %s', serverEnv, inv.serverEnv);
@@ -191,7 +188,7 @@ export class ManifestStore {
   // --- Fingerprint Utilities (stat-based, no content reads) ---
 
   /** Fingerprint a file by mtime+size — avoids reading file content. */
-  private static statFingerprint(filepath: string): string | null {
+  static #statFingerprint(filepath: string): string | null {
     try {
       const stat = fs.statSync(filepath);
       return `${stat.mtimeMs}:${stat.size}`;
@@ -203,7 +200,7 @@ export class ManifestStore {
   /** Find and fingerprint the project's lockfile. */
   static #lockfileFingerprint(baseDir: string): string {
     for (const name of LOCKFILE_NAMES) {
-      const fp = ManifestStore.statFingerprint(path.join(baseDir, name));
+      const fp = ManifestStore.#statFingerprint(path.join(baseDir, name));
       if (fp) return `${name}:${fp}`;
     }
     return '';
@@ -243,7 +240,7 @@ export class ManifestStore {
         ManifestStore.#fingerprintRecursive(fullPath, hash, visited);
       } else if (entry.isFile()) {
         // Use stat metadata instead of reading file contents
-        const fp = ManifestStore.statFingerprint(fullPath);
+        const fp = ManifestStore.#statFingerprint(fullPath);
         hash.update(`file:${entry.name}:${fp ?? 'missing'}\n`);
       }
     }

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -1,0 +1,261 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { debuglog } from 'node:util';
+
+const debug = debuglog('egg/core/loader/manifest');
+
+const MANIFEST_VERSION = 1;
+
+const LOCKFILE_NAMES = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock'] as const;
+
+export interface ManifestModuleReference {
+  name: string;
+  path: string;
+  optional?: boolean;
+}
+
+export interface ManifestModuleDescriptor {
+  name: string;
+  unitPath: string;
+  optional?: boolean;
+  /** Files containing decorated classes, relative to unitPath */
+  decoratedFiles: string[];
+}
+
+export interface ManifestTegg {
+  moduleReferences: ManifestModuleReference[];
+  moduleDescriptors: ManifestModuleDescriptor[];
+}
+
+export interface ManifestInvalidation {
+  lockfileFingerprint: string;
+  configFingerprint: string;
+  serverEnv: string;
+  serverScope: string;
+  baseDir: string;
+  typescriptEnabled: boolean;
+}
+
+export interface StartupManifest {
+  version: number;
+  generatedAt: string;
+  invalidation: ManifestInvalidation;
+  tegg: ManifestTegg;
+  /** resolveModule cache: filepath -> resolved path | null */
+  resolveCache: Record<string, string | null>;
+  /** directory path -> file relative paths (filtered) */
+  fileDiscovery: Record<string, string[]>;
+}
+
+export class ManifestStore {
+  readonly data: StartupManifest;
+
+  private constructor(data: StartupManifest) {
+    this.data = data;
+  }
+
+  /**
+   * Load and validate manifest from `.egg/manifest.json`.
+   * Returns null if manifest doesn't exist or is invalid.
+   */
+  static load(baseDir: string, serverEnv: string, serverScope: string): ManifestStore | null {
+    if (serverEnv === 'local' && process.env.EGG_MANIFEST !== 'true') {
+      debug('skip manifest in local env (set EGG_MANIFEST=true to enable)');
+      return null;
+    }
+
+    const manifestPath = path.join(baseDir, '.egg', 'manifest.json');
+    let raw: string;
+    try {
+      raw = fs.readFileSync(manifestPath, 'utf-8');
+    } catch {
+      debug('manifest not found at %s', manifestPath);
+      return null;
+    }
+
+    let data: StartupManifest;
+    try {
+      data = JSON.parse(raw);
+    } catch (e) {
+      debug('failed to parse manifest: %s', e);
+      return null;
+    }
+
+    if (!ManifestStore.#validate(data, baseDir, serverEnv, serverScope)) {
+      return null;
+    }
+
+    debug('manifest loaded successfully');
+    return new ManifestStore(data);
+  }
+
+  static #validate(data: StartupManifest, baseDir: string, serverEnv: string, serverScope: string): boolean {
+    if (data.version !== MANIFEST_VERSION) {
+      debug('manifest version mismatch: expected %d, got %d', MANIFEST_VERSION, data.version);
+      return false;
+    }
+
+    const inv = data.invalidation;
+    if (!inv) {
+      debug('manifest missing invalidation data');
+      return false;
+    }
+
+    if (inv.baseDir !== baseDir) {
+      debug('manifest baseDir mismatch: expected %s, got %s', baseDir, inv.baseDir);
+      return false;
+    }
+
+    if (inv.serverEnv !== serverEnv) {
+      debug('manifest serverEnv mismatch: expected %s, got %s', serverEnv, inv.serverEnv);
+      return false;
+    }
+
+    if (inv.serverScope !== serverScope) {
+      debug('manifest serverScope mismatch: expected %s, got %s', serverScope, inv.serverScope);
+      return false;
+    }
+
+    // Use stat-based fingerprint (mtime+size) for cheap validation
+    const currentLockfileFingerprint = ManifestStore.#lockfileFingerprint(baseDir);
+    if (inv.lockfileFingerprint !== currentLockfileFingerprint) {
+      debug('manifest lockfileFingerprint mismatch');
+      return false;
+    }
+
+    const currentConfigFingerprint = ManifestStore.#directoryFingerprint(path.join(baseDir, 'config'));
+    if (inv.configFingerprint !== currentConfigFingerprint) {
+      debug('manifest configFingerprint mismatch');
+      return false;
+    }
+
+    return true;
+  }
+
+  // --- Query APIs ---
+
+  getResolveCache(filepath: string): string | null | undefined {
+    const cache = this.data.resolveCache;
+    if (!cache || !(filepath in cache)) return undefined;
+    return cache[filepath];
+  }
+
+  getFileDiscovery(directory: string): string[] | undefined {
+    return this.data.fileDiscovery?.[directory];
+  }
+
+  get tegg(): ManifestTegg | undefined {
+    return this.data.tegg;
+  }
+
+  // --- Generation APIs ---
+
+  static generate(options: ManifestGenerateOptions): StartupManifest {
+    return {
+      version: MANIFEST_VERSION,
+      generatedAt: new Date().toISOString(),
+      invalidation: {
+        lockfileFingerprint: ManifestStore.#lockfileFingerprint(options.baseDir),
+        configFingerprint: ManifestStore.#directoryFingerprint(path.join(options.baseDir, 'config')),
+        serverEnv: options.serverEnv,
+        serverScope: options.serverScope,
+        baseDir: options.baseDir,
+        typescriptEnabled: options.typescriptEnabled,
+      },
+      tegg: options.tegg ?? { moduleReferences: [], moduleDescriptors: [] },
+      resolveCache: options.resolveCache ?? {},
+      fileDiscovery: options.fileDiscovery ?? {},
+    };
+  }
+
+  static async write(baseDir: string, manifest: StartupManifest): Promise<void> {
+    const dir = path.join(baseDir, '.egg');
+    await fsp.mkdir(dir, { recursive: true });
+    const manifestPath = path.join(dir, 'manifest.json');
+    await fsp.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+    debug('manifest written to %s', manifestPath);
+  }
+
+  static clean(baseDir: string): void {
+    const manifestPath = path.join(baseDir, '.egg', 'manifest.json');
+    try {
+      fs.unlinkSync(manifestPath);
+      debug('manifest removed: %s', manifestPath);
+    } catch {
+      // file doesn't exist, nothing to do
+    }
+  }
+
+  // --- Fingerprint Utilities (stat-based, no content reads) ---
+
+  /** Fingerprint a file by mtime+size — avoids reading file content. */
+  private static statFingerprint(filepath: string): string | null {
+    try {
+      const stat = fs.statSync(filepath);
+      return `${stat.mtimeMs}:${stat.size}`;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Find and fingerprint the project's lockfile. */
+  static #lockfileFingerprint(baseDir: string): string {
+    for (const name of LOCKFILE_NAMES) {
+      const fp = ManifestStore.statFingerprint(path.join(baseDir, name));
+      if (fp) return `${name}:${fp}`;
+    }
+    return '';
+  }
+
+  /** Fingerprint a directory tree by file names, mtimes, and sizes. */
+  static #directoryFingerprint(dirpath: string): string {
+    const hash = createHash('md5');
+    const visited = new Set<string>();
+    ManifestStore.#fingerprintRecursive(dirpath, hash, visited);
+    return hash.digest('hex');
+  }
+
+  static #fingerprintRecursive(dirpath: string, hash: ReturnType<typeof createHash>, visited: Set<string>): void {
+    let realPath: string;
+    try {
+      realPath = fs.realpathSync(dirpath);
+    } catch {
+      return;
+    }
+    // Prevent symlink cycles
+    if (visited.has(realPath)) return;
+    visited.add(realPath);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dirpath, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const fullPath = path.join(dirpath, entry.name);
+      if (entry.isDirectory()) {
+        hash.update(`dir:${entry.name}\n`);
+        ManifestStore.#fingerprintRecursive(fullPath, hash, visited);
+      } else if (entry.isFile()) {
+        // Use stat metadata instead of reading file contents
+        const fp = ManifestStore.statFingerprint(fullPath);
+        hash.update(`file:${entry.name}:${fp ?? 'missing'}\n`);
+      }
+    }
+  }
+}
+
+export interface ManifestGenerateOptions {
+  baseDir: string;
+  serverEnv: string;
+  serverScope: string;
+  typescriptEnabled: boolean;
+  tegg?: ManifestTegg;
+  resolveCache?: Record<string, string | null>;
+  fileDiscovery?: Record<string, string[]>;
+}

--- a/packages/core/test/__snapshots__/index.test.ts.snap
+++ b/packages/core/test/__snapshots__/index.test.ts.snap
@@ -18,6 +18,7 @@ exports[`should expose properties 1`] = `
   "KoaRequest",
   "KoaResponse",
   "Lifecycle",
+  "ManifestStore",
   "Request",
   "Response",
   "Router",

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -1,0 +1,760 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import mm from 'mm';
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+import { ManifestStore } from '../../src/loader/manifest.ts';
+import type { StartupManifest } from '../../src/loader/manifest.ts';
+
+let tmpDir: string;
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egg-manifest-test-'));
+}
+
+function setupBaseDir(options?: {
+  lockfile?: 'pnpm' | 'npm' | 'yarn' | 'none';
+  configFiles?: Record<string, string>;
+}): string {
+  const baseDir = createTmpDir();
+  const lockfile = options?.lockfile ?? 'pnpm';
+  if (lockfile === 'pnpm') {
+    fs.writeFileSync(path.join(baseDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  } else if (lockfile === 'npm') {
+    fs.writeFileSync(path.join(baseDir, 'package-lock.json'), '{"lockfileVersion": 3}');
+  } else if (lockfile === 'yarn') {
+    fs.writeFileSync(path.join(baseDir, 'yarn.lock'), '# yarn lockfile v1\n');
+  }
+
+  const configDir = path.join(baseDir, 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  if (options?.configFiles) {
+    for (const [name, content] of Object.entries(options.configFiles)) {
+      fs.writeFileSync(path.join(configDir, name), content);
+    }
+  } else {
+    fs.writeFileSync(path.join(configDir, 'config.default.ts'), 'export default {};\n');
+  }
+
+  return baseDir;
+}
+
+async function generateAndWrite(baseDir: string, overrides?: Partial<StartupManifest>): Promise<StartupManifest> {
+  const manifest = ManifestStore.generate({
+    baseDir,
+    serverEnv: 'prod',
+    serverScope: '',
+    typescriptEnabled: true,
+  });
+  Object.assign(manifest, overrides);
+  await ManifestStore.write(baseDir, manifest);
+  return manifest;
+}
+
+describe('ManifestStore', () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    mm.restore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('generate()', () => {
+    it('should generate manifest with correct structure', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+
+        assert.equal(manifest.version, 1);
+        assert.ok(manifest.generatedAt);
+        assert.ok(new Date(manifest.generatedAt).getTime() > 0);
+        assert.equal(manifest.invalidation.serverEnv, 'prod');
+        assert.equal(manifest.invalidation.serverScope, '');
+        assert.equal(manifest.invalidation.baseDir, baseDir);
+        assert.equal(manifest.invalidation.typescriptEnabled, true);
+        assert.ok(manifest.invalidation.lockfileFingerprint);
+        assert.ok(manifest.invalidation.configFingerprint);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should default optional fields to empty', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: false,
+        });
+
+        assert.deepStrictEqual(manifest.tegg, { moduleReferences: [], moduleDescriptors: [] });
+        assert.deepStrictEqual(manifest.resolveCache, {});
+        assert.deepStrictEqual(manifest.fileDiscovery, {});
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should preserve provided tegg, resolveCache, fileDiscovery', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const tegg = {
+          moduleReferences: [{ name: 'mod', path: '/tmp/mod' }],
+          moduleDescriptors: [{ name: 'mod', unitPath: '/tmp/mod', decoratedFiles: ['a.ts'] }],
+        };
+        const resolveCache = { '/foo/bar': '/resolved/bar', '/foo/missing': null };
+        const fileDiscovery = { '/app/service': ['user.ts', 'post.ts'] };
+
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+          tegg,
+          resolveCache,
+          fileDiscovery,
+        });
+
+        assert.deepStrictEqual(manifest.tegg, tegg);
+        assert.deepStrictEqual(manifest.resolveCache, resolveCache);
+        assert.deepStrictEqual(manifest.fileDiscovery, fileDiscovery);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should detect pnpm lockfile', () => {
+      const baseDir = setupBaseDir({ lockfile: 'pnpm' });
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        assert.ok(manifest.invalidation.lockfileFingerprint.startsWith('pnpm-lock.yaml:'));
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should detect npm lockfile', () => {
+      const baseDir = setupBaseDir({ lockfile: 'npm' });
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        assert.ok(manifest.invalidation.lockfileFingerprint.startsWith('package-lock.json:'));
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should detect yarn lockfile', () => {
+      const baseDir = setupBaseDir({ lockfile: 'yarn' });
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        assert.ok(manifest.invalidation.lockfileFingerprint.startsWith('yarn.lock:'));
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return empty lockfile fingerprint when no lockfile', () => {
+      const baseDir = setupBaseDir({ lockfile: 'none' });
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        assert.equal(manifest.invalidation.lockfileFingerprint, '');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should produce deterministic config fingerprint', () => {
+      const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
+      try {
+        const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+        const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+        assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('write() and clean()', () => {
+    it('should create .egg/ directory and write manifest', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        await ManifestStore.write(baseDir, manifest);
+
+        const manifestPath = path.join(baseDir, '.egg', 'manifest.json');
+        assert.ok(fs.existsSync(manifestPath));
+
+        const written = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        assert.equal(written.version, 1);
+        assert.equal(written.invalidation.baseDir, baseDir);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should overwrite existing manifest', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+        await ManifestStore.write(baseDir, m1);
+
+        const m2 = ManifestStore.generate({ baseDir, serverEnv: 'test', serverScope: '', typescriptEnabled: true });
+        await ManifestStore.write(baseDir, m2);
+
+        const written = JSON.parse(fs.readFileSync(path.join(baseDir, '.egg', 'manifest.json'), 'utf-8'));
+        assert.equal(written.invalidation.serverEnv, 'test');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should clean manifest file', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir);
+        assert.ok(fs.existsSync(path.join(baseDir, '.egg', 'manifest.json')));
+
+        ManifestStore.clean(baseDir);
+        assert.ok(!fs.existsSync(path.join(baseDir, '.egg', 'manifest.json')));
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should not throw when cleaning non-existent manifest', () => {
+      assert.doesNotThrow(() => {
+        ManifestStore.clean(tmpDir);
+      });
+    });
+  });
+
+  describe('load()', () => {
+    it('should load a valid manifest', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir);
+
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.ok(store);
+        assert.equal(store.data.version, 1);
+        assert.equal(store.data.invalidation.baseDir, baseDir);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null when manifest file does not exist', () => {
+      const store = ManifestStore.load(tmpDir, 'prod', '');
+      assert.equal(store, null);
+    });
+
+    it('should return null for invalid JSON', async () => {
+      const eggDir = path.join(tmpDir, '.egg');
+      fs.mkdirSync(eggDir, { recursive: true });
+      fs.writeFileSync(path.join(eggDir, 'manifest.json'), 'not json{{{');
+
+      const store = ManifestStore.load(tmpDir, 'prod', '');
+      assert.equal(store, null);
+    });
+
+    it('should return null when version mismatches', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, { version: 999 });
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should load manifest even when baseDir differs from generation', async () => {
+      const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
+      try {
+        await generateAndWrite(baseDir);
+
+        // Create a second directory with identical lockfile + config (simulating build→deploy)
+        const otherDir = createTmpDir();
+        try {
+          // Copy lockfile and config so fingerprints match
+          fs.copyFileSync(path.join(baseDir, 'pnpm-lock.yaml'), path.join(otherDir, 'pnpm-lock.yaml'));
+          const configDir = path.join(otherDir, 'config');
+          fs.mkdirSync(configDir, { recursive: true });
+          fs.copyFileSync(path.join(baseDir, 'config', 'a.ts'), path.join(configDir, 'a.ts'));
+          // Copy manifest
+          const eggDir = path.join(otherDir, '.egg');
+          fs.mkdirSync(eggDir, { recursive: true });
+          fs.copyFileSync(path.join(baseDir, '.egg', 'manifest.json'), path.join(eggDir, 'manifest.json'));
+          // Load should succeed — baseDir is not validated
+          const store = ManifestStore.load(otherDir, 'prod', '');
+          assert.ok(store);
+        } finally {
+          fs.rmSync(otherDir, { recursive: true, force: true });
+        }
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null when serverEnv mismatches', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir);
+        const store = ManifestStore.load(baseDir, 'test', '');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null when serverScope mismatches', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: 'scopeA',
+          typescriptEnabled: true,
+        });
+        await ManifestStore.write(baseDir, manifest);
+
+        const store = ManifestStore.load(baseDir, 'prod', 'scopeB');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null when lockfile changes', async () => {
+      const baseDir = setupBaseDir({ lockfile: 'pnpm' });
+      try {
+        await generateAndWrite(baseDir);
+
+        // Modify lockfile to change its mtime and size
+        fs.writeFileSync(path.join(baseDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\nmodified: true\n');
+
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null when config directory changes', async () => {
+      const baseDir = setupBaseDir({ configFiles: { 'config.default.ts': 'export default {};' } });
+      try {
+        await generateAndWrite(baseDir);
+
+        // Add a new config file
+        fs.writeFileSync(path.join(baseDir, 'config', 'config.prod.ts'), 'export default { port: 8080 };');
+
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null in local env by default', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir);
+        // Re-generate with local env so invalidation matches
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'local',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        await ManifestStore.write(baseDir, manifest);
+
+        const store = ManifestStore.load(baseDir, 'local', '');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should load in local env when EGG_MANIFEST=true', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'local',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        await ManifestStore.write(baseDir, manifest);
+
+        mm(process.env, 'EGG_MANIFEST', 'true');
+        const store = ManifestStore.load(baseDir, 'local', '');
+        assert.ok(store);
+        assert.equal(store.data.invalidation.serverEnv, 'local');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('query APIs', () => {
+    it('getResolveCache() should return cached path', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, {
+          resolveCache: { '/app/config/plugin': '/resolved/plugin.ts' },
+        });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getResolveCache('/app/config/plugin'), '/resolved/plugin.ts');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('getResolveCache() should return null for null-cached entry', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, {
+          resolveCache: { '/app/missing': null },
+        });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getResolveCache('/app/missing'), null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('getResolveCache() should return undefined for uncached entry', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, { resolveCache: {} });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getResolveCache('/not/in/cache'), undefined);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('getFileDiscovery() should return cached file list', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, {
+          fileDiscovery: { '/app/service': ['user.ts', 'post.ts'] },
+        });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.deepStrictEqual(store.getFileDiscovery('/app/service'), ['user.ts', 'post.ts']);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('getFileDiscovery() should return undefined for uncached directory', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, { fileDiscovery: {} });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getFileDiscovery('/not/cached'), undefined);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('tegg getter should return tegg data', async () => {
+      const baseDir = setupBaseDir();
+      const tegg = {
+        moduleReferences: [{ name: 'myModule', path: '/tmp/myModule' }],
+        moduleDescriptors: [],
+      };
+      try {
+        await generateAndWrite(baseDir, { tegg });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.deepStrictEqual(store.tegg, tegg);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fingerprint stability', () => {
+    it('should produce same fingerprint for unchanged file', () => {
+      const filePath = path.join(tmpDir, 'test.txt');
+      fs.writeFileSync(filePath, 'hello');
+
+      // Access statFingerprint via generate's lockfile detection
+      // Instead, test via generate() which uses the fingerprint internally
+      const m1 = ManifestStore.generate({
+        baseDir: tmpDir,
+        serverEnv: 'prod',
+        serverScope: '',
+        typescriptEnabled: true,
+      });
+      const m2 = ManifestStore.generate({
+        baseDir: tmpDir,
+        serverEnv: 'prod',
+        serverScope: '',
+        typescriptEnabled: true,
+      });
+      // Config fingerprint should be stable (no config dir = deterministic empty hash)
+      assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+    });
+
+    it('should change config fingerprint when file is added', async () => {
+      const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
+      try {
+        const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+
+        // Wait a tiny bit to ensure mtime differs
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        fs.writeFileSync(path.join(baseDir, 'config', 'b.ts'), 'const b = 2;');
+
+        const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+        assert.notEqual(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should change config fingerprint when file is deleted', async () => {
+      const baseDir = setupBaseDir({ configFiles: { 'a.ts': '1', 'b.ts': '2' } });
+      try {
+        const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+        fs.unlinkSync(path.join(baseDir, 'config', 'b.ts'));
+        const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+        assert.notEqual(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should produce deterministic fingerprint for non-existent config directory', () => {
+      // tmpDir has no config/ subdirectory
+      const m1 = ManifestStore.generate({
+        baseDir: tmpDir,
+        serverEnv: 'prod',
+        serverScope: '',
+        typescriptEnabled: true,
+      });
+      const m2 = ManifestStore.generate({
+        baseDir: tmpDir,
+        serverEnv: 'prod',
+        serverScope: '',
+        typescriptEnabled: true,
+      });
+      assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+    });
+
+    it('should handle symlink cycles without infinite recursion', () => {
+      const baseDir = setupBaseDir({ configFiles: { 'a.ts': '1' } });
+      try {
+        const configDir = path.join(baseDir, 'config');
+        // Create a symlink cycle: config/loop -> config/
+        try {
+          fs.symlinkSync(configDir, path.join(configDir, 'loop'));
+        } catch {
+          // Symlinks may not be supported (Windows without admin)
+          return;
+        }
+
+        // Should not hang or throw
+        const manifest = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        assert.ok(manifest.invalidation.configFingerprint);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('end-to-end: generate → write → load', () => {
+    it('should round-trip manifest data correctly', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        const resolveCache = { '/some/path': '/resolved/path', '/missing': null };
+        const fileDiscovery = { '/app/controller': ['home.ts', 'user.ts'] };
+        const tegg = {
+          moduleReferences: [{ name: 'foo', path: '/tmp/foo', optional: true }],
+          moduleDescriptors: [{ name: 'foo', unitPath: '/tmp/foo', decoratedFiles: ['service.ts'] }],
+        };
+
+        const original = ManifestStore.generate({
+          baseDir,
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+          resolveCache,
+          fileDiscovery,
+          tegg,
+        });
+        await ManifestStore.write(baseDir, original);
+
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.ok(store);
+        assert.deepStrictEqual(store.data.resolveCache, resolveCache);
+        assert.deepStrictEqual(store.data.fileDiscovery, fileDiscovery);
+        assert.deepStrictEqual(store.data.tegg, tegg);
+        assert.equal(store.data.version, original.version);
+        assert.equal(store.data.generatedAt, original.generatedAt);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should invalidate after lockfile modification', async () => {
+      const baseDir = setupBaseDir({ lockfile: 'pnpm' });
+      try {
+        await generateAndWrite(baseDir);
+        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+
+        // Modify lockfile
+        fs.appendFileSync(path.join(baseDir, 'pnpm-lock.yaml'), '\n# modified');
+        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should invalidate after config file modification', async () => {
+      const baseDir = setupBaseDir({ configFiles: { 'config.default.ts': 'export default {};' } });
+      try {
+        await generateAndWrite(baseDir);
+        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        fs.writeFileSync(path.join(baseDir, 'config', 'config.prod.ts'), 'export default { port: 3000 };');
+        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should remain valid when nothing changes', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir);
+        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('E2E: generate manifest → app uses cached data', () => {
+    it('should use resolveCache and skip importResolve on second load', async () => {
+      const { createApp } = await import('../helper.ts');
+
+      // First load: no manifest, collects data
+      const app1 = createApp('nothing');
+      await app1.loader.loadPlugin();
+      await app1.loader.loadConfig();
+
+      // Collect some resolve results
+      assert.ok(Object.keys(app1.loader.resolveCacheCollector).length >= 0);
+
+      // Generate and write manifest with the collected data
+      const manifest = app1.loader.generateManifest();
+      await ManifestStore.write(app1.baseDir, manifest);
+
+      try {
+        // Second load: manifest exists, should use cached data
+        const app2 = createApp('nothing');
+        assert.ok(app2.loader.manifest, 'manifest should be loaded');
+
+        // Verify resolveModule uses cache
+        for (const [filepath, resolved] of Object.entries(manifest.resolveCache)) {
+          const result = app2.loader.resolveModule(filepath);
+          assert.equal(result, resolved ?? undefined, `resolveModule('${filepath}') should return cached value`);
+        }
+
+        // Verify no new entries were added to the collector (cache was used)
+        assert.equal(
+          Object.keys(app2.loader.resolveCacheCollector).length,
+          0,
+          'should not collect new resolve results when manifest is used',
+        );
+      } finally {
+        ManifestStore.clean(app1.baseDir);
+      }
+    });
+
+    it('should use fileDiscovery cache in FileLoader', async () => {
+      const { createApp } = await import('../helper.ts');
+      const { FileLoader } = await import('../../src/loader/file_loader.ts');
+
+      const app = createApp('nothing');
+      await app.loader.loadPlugin();
+      await app.loader.loadConfig();
+
+      // Create a manifest with pre-computed file discovery
+      const testDir = path.join(app.baseDir, 'app', 'service');
+      const manifest = app.loader.generateManifest();
+      manifest.fileDiscovery[testDir] = ['foo.ts', 'bar.ts'];
+      await ManifestStore.write(app.baseDir, manifest);
+
+      try {
+        const app2 = createApp('nothing');
+        assert.ok(app2.loader.manifest);
+
+        // FileLoader should use cached files instead of globby
+        const target = {};
+        new FileLoader({
+          directory: testDir,
+          target,
+          manifest: app2.loader.manifest,
+          fileDiscoveryCollector: app2.loader.fileDiscoveryCollector,
+        });
+
+        // getFileDiscovery should return the cached list
+        const cached = app2.loader.manifest.getFileDiscovery(testDir);
+        assert.deepStrictEqual(cached, ['foo.ts', 'bar.ts']);
+
+        // Verify the collector was NOT populated (cache was used)
+        assert.equal(app2.loader.fileDiscoveryCollector[testDir], undefined);
+      } finally {
+        ManifestStore.clean(app.baseDir);
+      }
+    });
+  });
+});

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -259,23 +259,19 @@ describe('ManifestStore', () => {
       }
     });
 
-    it('should load manifest even when baseDir differs from generation', async () => {
-      const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
+    it('should load manifest even when stored baseDir differs from actual path', async () => {
+      const baseDir = setupBaseDir();
       try {
         await generateAndWrite(baseDir);
-        const otherDir = createTmpDir();
-        try {
-          fs.copyFileSync(path.join(baseDir, 'pnpm-lock.yaml'), path.join(otherDir, 'pnpm-lock.yaml'));
-          const configDir = path.join(otherDir, 'config');
-          fs.mkdirSync(configDir, { recursive: true });
-          fs.copyFileSync(path.join(baseDir, 'config', 'a.ts'), path.join(configDir, 'a.ts'));
-          const eggDir = path.join(otherDir, '.egg');
-          fs.mkdirSync(eggDir, { recursive: true });
-          fs.copyFileSync(path.join(baseDir, '.egg', 'manifest.json'), path.join(eggDir, 'manifest.json'));
-          assert.ok(ManifestStore.load(otherDir, 'prod', ''));
-        } finally {
-          fs.rmSync(otherDir, { recursive: true, force: true });
-        }
+        // Tamper the stored baseDir to simulate build→deploy path change
+        const manifestPath = path.join(baseDir, '.egg', 'manifest.json');
+        const data = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        data.invalidation.baseDir = '/some/build/path';
+        fs.writeFileSync(manifestPath, JSON.stringify(data));
+        // Should still load — baseDir is not validated
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.ok(store);
+        assert.equal(store.data.invalidation.baseDir, '/some/build/path');
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -1,58 +1,14 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import mm from 'mm';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 import { ManifestStore } from '../../src/loader/manifest.ts';
-import type { StartupManifest } from '../../src/loader/manifest.ts';
+import { createTmpDir, setupBaseDir, generateAndWrite } from './manifest_helper.ts';
 
 let tmpDir: string;
-
-function createTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'egg-manifest-test-'));
-}
-
-function setupBaseDir(options?: {
-  lockfile?: 'pnpm' | 'npm' | 'yarn' | 'none';
-  configFiles?: Record<string, string>;
-}): string {
-  const baseDir = createTmpDir();
-  const lockfile = options?.lockfile ?? 'pnpm';
-  if (lockfile === 'pnpm') {
-    fs.writeFileSync(path.join(baseDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
-  } else if (lockfile === 'npm') {
-    fs.writeFileSync(path.join(baseDir, 'package-lock.json'), '{"lockfileVersion": 3}');
-  } else if (lockfile === 'yarn') {
-    fs.writeFileSync(path.join(baseDir, 'yarn.lock'), '# yarn lockfile v1\n');
-  }
-
-  const configDir = path.join(baseDir, 'config');
-  fs.mkdirSync(configDir, { recursive: true });
-  if (options?.configFiles) {
-    for (const [name, content] of Object.entries(options.configFiles)) {
-      fs.writeFileSync(path.join(configDir, name), content);
-    }
-  } else {
-    fs.writeFileSync(path.join(configDir, 'config.default.ts'), 'export default {};\n');
-  }
-
-  return baseDir;
-}
-
-async function generateAndWrite(baseDir: string, overrides?: Partial<StartupManifest>): Promise<StartupManifest> {
-  const manifest = ManifestStore.generate({
-    baseDir,
-    serverEnv: 'prod',
-    serverScope: '',
-    typescriptEnabled: true,
-  });
-  Object.assign(manifest, overrides);
-  await ManifestStore.write(baseDir, manifest);
-  return manifest;
-}
 
 describe('ManifestStore', () => {
   beforeEach(() => {
@@ -271,7 +227,6 @@ describe('ManifestStore', () => {
       const baseDir = setupBaseDir();
       try {
         await generateAndWrite(baseDir);
-
         const store = ManifestStore.load(baseDir, 'prod', '');
         assert.ok(store);
         assert.equal(store.data.version, 1);
@@ -286,11 +241,10 @@ describe('ManifestStore', () => {
       assert.equal(store, null);
     });
 
-    it('should return null for invalid JSON', async () => {
+    it('should return null for invalid JSON', () => {
       const eggDir = path.join(tmpDir, '.egg');
       fs.mkdirSync(eggDir, { recursive: true });
       fs.writeFileSync(path.join(eggDir, 'manifest.json'), 'not json{{{');
-
       const store = ManifestStore.load(tmpDir, 'prod', '');
       assert.equal(store, null);
     });
@@ -299,8 +253,7 @@ describe('ManifestStore', () => {
       const baseDir = setupBaseDir();
       try {
         await generateAndWrite(baseDir, { version: 999 });
-        const store = ManifestStore.load(baseDir, 'prod', '');
-        assert.equal(store, null);
+        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }
@@ -310,22 +263,16 @@ describe('ManifestStore', () => {
       const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
       try {
         await generateAndWrite(baseDir);
-
-        // Create a second directory with identical lockfile + config (simulating build→deploy)
         const otherDir = createTmpDir();
         try {
-          // Copy lockfile and config so fingerprints match
           fs.copyFileSync(path.join(baseDir, 'pnpm-lock.yaml'), path.join(otherDir, 'pnpm-lock.yaml'));
           const configDir = path.join(otherDir, 'config');
           fs.mkdirSync(configDir, { recursive: true });
           fs.copyFileSync(path.join(baseDir, 'config', 'a.ts'), path.join(configDir, 'a.ts'));
-          // Copy manifest
           const eggDir = path.join(otherDir, '.egg');
           fs.mkdirSync(eggDir, { recursive: true });
           fs.copyFileSync(path.join(baseDir, '.egg', 'manifest.json'), path.join(eggDir, 'manifest.json'));
-          // Load should succeed — baseDir is not validated
-          const store = ManifestStore.load(otherDir, 'prod', '');
-          assert.ok(store);
+          assert.ok(ManifestStore.load(otherDir, 'prod', ''));
         } finally {
           fs.rmSync(otherDir, { recursive: true, force: true });
         }
@@ -338,8 +285,7 @@ describe('ManifestStore', () => {
       const baseDir = setupBaseDir();
       try {
         await generateAndWrite(baseDir);
-        const store = ManifestStore.load(baseDir, 'test', '');
-        assert.equal(store, null);
+        assert.equal(ManifestStore.load(baseDir, 'test', ''), null);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }
@@ -355,9 +301,7 @@ describe('ManifestStore', () => {
           typescriptEnabled: true,
         });
         await ManifestStore.write(baseDir, manifest);
-
-        const store = ManifestStore.load(baseDir, 'prod', 'scopeB');
-        assert.equal(store, null);
+        assert.equal(ManifestStore.load(baseDir, 'prod', 'scopeB'), null);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }
@@ -367,12 +311,8 @@ describe('ManifestStore', () => {
       const baseDir = setupBaseDir({ lockfile: 'pnpm' });
       try {
         await generateAndWrite(baseDir);
-
-        // Modify lockfile to change its mtime and size
         fs.writeFileSync(path.join(baseDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\nmodified: true\n');
-
-        const store = ManifestStore.load(baseDir, 'prod', '');
-        assert.equal(store, null);
+        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }
@@ -382,12 +322,8 @@ describe('ManifestStore', () => {
       const baseDir = setupBaseDir({ configFiles: { 'config.default.ts': 'export default {};' } });
       try {
         await generateAndWrite(baseDir);
-
-        // Add a new config file
         fs.writeFileSync(path.join(baseDir, 'config', 'config.prod.ts'), 'export default { port: 8080 };');
-
-        const store = ManifestStore.load(baseDir, 'prod', '');
-        assert.equal(store, null);
+        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }
@@ -396,8 +332,6 @@ describe('ManifestStore', () => {
     it('should return null in local env by default', async () => {
       const baseDir = setupBaseDir();
       try {
-        await generateAndWrite(baseDir);
-        // Re-generate with local env so invalidation matches
         const manifest = ManifestStore.generate({
           baseDir,
           serverEnv: 'local',
@@ -405,9 +339,7 @@ describe('ManifestStore', () => {
           typescriptEnabled: true,
         });
         await ManifestStore.write(baseDir, manifest);
-
-        const store = ManifestStore.load(baseDir, 'local', '');
-        assert.equal(store, null);
+        assert.equal(ManifestStore.load(baseDir, 'local', ''), null);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }
@@ -423,337 +355,12 @@ describe('ManifestStore', () => {
           typescriptEnabled: true,
         });
         await ManifestStore.write(baseDir, manifest);
-
         mm(process.env, 'EGG_MANIFEST', 'true');
         const store = ManifestStore.load(baseDir, 'local', '');
         assert.ok(store);
         assert.equal(store.data.invalidation.serverEnv, 'local');
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-  });
-
-  describe('query APIs', () => {
-    it('getResolveCache() should return cached path', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        await generateAndWrite(baseDir, {
-          resolveCache: { '/app/config/plugin': '/resolved/plugin.ts' },
-        });
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.equal(store.getResolveCache('/app/config/plugin'), '/resolved/plugin.ts');
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('getResolveCache() should return null for null-cached entry', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        await generateAndWrite(baseDir, {
-          resolveCache: { '/app/missing': null },
-        });
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.equal(store.getResolveCache('/app/missing'), null);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('getResolveCache() should return undefined for uncached entry', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        await generateAndWrite(baseDir, { resolveCache: {} });
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.equal(store.getResolveCache('/not/in/cache'), undefined);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('getFileDiscovery() should return cached file list', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        await generateAndWrite(baseDir, {
-          fileDiscovery: { '/app/service': ['user.ts', 'post.ts'] },
-        });
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.deepStrictEqual(store.getFileDiscovery('/app/service'), ['user.ts', 'post.ts']);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('getFileDiscovery() should return undefined for uncached directory', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        await generateAndWrite(baseDir, { fileDiscovery: {} });
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.equal(store.getFileDiscovery('/not/cached'), undefined);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('tegg getter should return tegg data', async () => {
-      const baseDir = setupBaseDir();
-      const tegg = {
-        moduleReferences: [{ name: 'myModule', path: '/tmp/myModule' }],
-        moduleDescriptors: [],
-      };
-      try {
-        await generateAndWrite(baseDir, { tegg });
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.deepStrictEqual(store.tegg, tegg);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-  });
-
-  describe('fingerprint stability', () => {
-    it('should produce same fingerprint for unchanged file', () => {
-      const filePath = path.join(tmpDir, 'test.txt');
-      fs.writeFileSync(filePath, 'hello');
-
-      // Access statFingerprint via generate's lockfile detection
-      // Instead, test via generate() which uses the fingerprint internally
-      const m1 = ManifestStore.generate({
-        baseDir: tmpDir,
-        serverEnv: 'prod',
-        serverScope: '',
-        typescriptEnabled: true,
-      });
-      const m2 = ManifestStore.generate({
-        baseDir: tmpDir,
-        serverEnv: 'prod',
-        serverScope: '',
-        typescriptEnabled: true,
-      });
-      // Config fingerprint should be stable (no config dir = deterministic empty hash)
-      assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
-    });
-
-    it('should change config fingerprint when file is added', async () => {
-      const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
-      try {
-        const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
-
-        // Wait a tiny bit to ensure mtime differs
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        fs.writeFileSync(path.join(baseDir, 'config', 'b.ts'), 'const b = 2;');
-
-        const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
-        assert.notEqual(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should change config fingerprint when file is deleted', async () => {
-      const baseDir = setupBaseDir({ configFiles: { 'a.ts': '1', 'b.ts': '2' } });
-      try {
-        const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
-        fs.unlinkSync(path.join(baseDir, 'config', 'b.ts'));
-        const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
-        assert.notEqual(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should produce deterministic fingerprint for non-existent config directory', () => {
-      // tmpDir has no config/ subdirectory
-      const m1 = ManifestStore.generate({
-        baseDir: tmpDir,
-        serverEnv: 'prod',
-        serverScope: '',
-        typescriptEnabled: true,
-      });
-      const m2 = ManifestStore.generate({
-        baseDir: tmpDir,
-        serverEnv: 'prod',
-        serverScope: '',
-        typescriptEnabled: true,
-      });
-      assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
-    });
-
-    it('should handle symlink cycles without infinite recursion', () => {
-      const baseDir = setupBaseDir({ configFiles: { 'a.ts': '1' } });
-      try {
-        const configDir = path.join(baseDir, 'config');
-        // Create a symlink cycle: config/loop -> config/
-        try {
-          fs.symlinkSync(configDir, path.join(configDir, 'loop'));
-        } catch {
-          // Symlinks may not be supported (Windows without admin)
-          return;
-        }
-
-        // Should not hang or throw
-        const manifest = ManifestStore.generate({
-          baseDir,
-          serverEnv: 'prod',
-          serverScope: '',
-          typescriptEnabled: true,
-        });
-        assert.ok(manifest.invalidation.configFingerprint);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-  });
-
-  describe('end-to-end: generate → write → load', () => {
-    it('should round-trip manifest data correctly', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        const resolveCache = { '/some/path': '/resolved/path', '/missing': null };
-        const fileDiscovery = { '/app/controller': ['home.ts', 'user.ts'] };
-        const tegg = {
-          moduleReferences: [{ name: 'foo', path: '/tmp/foo', optional: true }],
-          moduleDescriptors: [{ name: 'foo', unitPath: '/tmp/foo', decoratedFiles: ['service.ts'] }],
-        };
-
-        const original = ManifestStore.generate({
-          baseDir,
-          serverEnv: 'prod',
-          serverScope: '',
-          typescriptEnabled: true,
-          resolveCache,
-          fileDiscovery,
-          tegg,
-        });
-        await ManifestStore.write(baseDir, original);
-
-        const store = ManifestStore.load(baseDir, 'prod', '')!;
-        assert.ok(store);
-        assert.deepStrictEqual(store.data.resolveCache, resolveCache);
-        assert.deepStrictEqual(store.data.fileDiscovery, fileDiscovery);
-        assert.deepStrictEqual(store.data.tegg, tegg);
-        assert.equal(store.data.version, original.version);
-        assert.equal(store.data.generatedAt, original.generatedAt);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should invalidate after lockfile modification', async () => {
-      const baseDir = setupBaseDir({ lockfile: 'pnpm' });
-      try {
-        await generateAndWrite(baseDir);
-        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
-
-        // Modify lockfile
-        fs.appendFileSync(path.join(baseDir, 'pnpm-lock.yaml'), '\n# modified');
-        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should invalidate after config file modification', async () => {
-      const baseDir = setupBaseDir({ configFiles: { 'config.default.ts': 'export default {};' } });
-      try {
-        await generateAndWrite(baseDir);
-        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
-
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        fs.writeFileSync(path.join(baseDir, 'config', 'config.prod.ts'), 'export default { port: 3000 };');
-        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-
-    it('should remain valid when nothing changes', async () => {
-      const baseDir = setupBaseDir();
-      try {
-        await generateAndWrite(baseDir);
-        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
-        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
-        assert.ok(ManifestStore.load(baseDir, 'prod', ''));
-      } finally {
-        fs.rmSync(baseDir, { recursive: true, force: true });
-      }
-    });
-  });
-
-  describe('E2E: generate manifest → app uses cached data', () => {
-    it('should use resolveCache and skip importResolve on second load', async () => {
-      const { createApp } = await import('../helper.ts');
-
-      // First load: no manifest, collects data
-      const app1 = createApp('nothing');
-      await app1.loader.loadPlugin();
-      await app1.loader.loadConfig();
-
-      // Collect some resolve results
-      assert.ok(Object.keys(app1.loader.resolveCacheCollector).length >= 0);
-
-      // Generate and write manifest with the collected data
-      const manifest = app1.loader.generateManifest();
-      await ManifestStore.write(app1.baseDir, manifest);
-
-      try {
-        // Second load: manifest exists, should use cached data
-        const app2 = createApp('nothing');
-        assert.ok(app2.loader.manifest, 'manifest should be loaded');
-
-        // Verify resolveModule uses cache
-        for (const [filepath, resolved] of Object.entries(manifest.resolveCache)) {
-          const result = app2.loader.resolveModule(filepath);
-          assert.equal(result, resolved ?? undefined, `resolveModule('${filepath}') should return cached value`);
-        }
-
-        // Verify no new entries were added to the collector (cache was used)
-        assert.equal(
-          Object.keys(app2.loader.resolveCacheCollector).length,
-          0,
-          'should not collect new resolve results when manifest is used',
-        );
-      } finally {
-        ManifestStore.clean(app1.baseDir);
-      }
-    });
-
-    it('should use fileDiscovery cache in FileLoader', async () => {
-      const { createApp } = await import('../helper.ts');
-      const { FileLoader } = await import('../../src/loader/file_loader.ts');
-
-      const app = createApp('nothing');
-      await app.loader.loadPlugin();
-      await app.loader.loadConfig();
-
-      // Create a manifest with pre-computed file discovery
-      const testDir = path.join(app.baseDir, 'app', 'service');
-      const manifest = app.loader.generateManifest();
-      manifest.fileDiscovery[testDir] = ['foo.ts', 'bar.ts'];
-      await ManifestStore.write(app.baseDir, manifest);
-
-      try {
-        const app2 = createApp('nothing');
-        assert.ok(app2.loader.manifest);
-
-        // FileLoader should use cached files instead of globby
-        const target = {};
-        new FileLoader({
-          directory: testDir,
-          target,
-          manifest: app2.loader.manifest,
-          fileDiscoveryCollector: app2.loader.fileDiscoveryCollector,
-        });
-
-        // getFileDiscovery should return the cached list
-        const cached = app2.loader.manifest.getFileDiscovery(testDir);
-        assert.deepStrictEqual(cached, ['foo.ts', 'bar.ts']);
-
-        // Verify the collector was NOT populated (cache was used)
-        assert.equal(app2.loader.fileDiscoveryCollector[testDir], undefined);
-      } finally {
-        ManifestStore.clean(app.baseDir);
       }
     });
   });

--- a/packages/core/test/loader/manifest_fingerprint.test.ts
+++ b/packages/core/test/loader/manifest_fingerprint.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+import { ManifestStore } from '../../src/loader/manifest.ts';
+import { createTmpDir, setupBaseDir } from './manifest_helper.ts';
+
+let tmpDir: string;
+
+describe('ManifestStore fingerprint stability', () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should produce same fingerprint for unchanged file', () => {
+    fs.writeFileSync(path.join(tmpDir, 'test.txt'), 'hello');
+    const m1 = ManifestStore.generate({ baseDir: tmpDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+    const m2 = ManifestStore.generate({ baseDir: tmpDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+    assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+  });
+
+  it('should change config fingerprint when file is added', async () => {
+    const baseDir = setupBaseDir({ configFiles: { 'a.ts': 'const a = 1;' } });
+    try {
+      const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      fs.writeFileSync(path.join(baseDir, 'config', 'b.ts'), 'const b = 2;');
+      const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+      assert.notEqual(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should change config fingerprint when file is deleted', () => {
+    const baseDir = setupBaseDir({ configFiles: { 'a.ts': '1', 'b.ts': '2' } });
+    try {
+      const m1 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+      fs.unlinkSync(path.join(baseDir, 'config', 'b.ts'));
+      const m2 = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+      assert.notEqual(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should produce deterministic fingerprint for non-existent config directory', () => {
+    const m1 = ManifestStore.generate({ baseDir: tmpDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+    const m2 = ManifestStore.generate({ baseDir: tmpDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+    assert.equal(m1.invalidation.configFingerprint, m2.invalidation.configFingerprint);
+  });
+
+  it('should handle symlink cycles without infinite recursion', () => {
+    const baseDir = setupBaseDir({ configFiles: { 'a.ts': '1' } });
+    try {
+      const configDir = path.join(baseDir, 'config');
+      try {
+        fs.symlinkSync(configDir, path.join(configDir, 'loop'));
+      } catch {
+        return; // Symlinks may not be supported
+      }
+      const manifest = ManifestStore.generate({ baseDir, serverEnv: 'prod', serverScope: '', typescriptEnabled: true });
+      assert.ok(manifest.invalidation.configFingerprint);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/test/loader/manifest_helper.ts
+++ b/packages/core/test/loader/manifest_helper.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ManifestStore } from '../../src/loader/manifest.ts';
+import type { StartupManifest } from '../../src/loader/manifest.ts';
+
+export function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'egg-manifest-test-'));
+}
+
+export function setupBaseDir(options?: {
+  lockfile?: 'pnpm' | 'npm' | 'yarn' | 'none';
+  configFiles?: Record<string, string>;
+}): string {
+  const baseDir = createTmpDir();
+  const lockfile = options?.lockfile ?? 'pnpm';
+  if (lockfile === 'pnpm') {
+    fs.writeFileSync(path.join(baseDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  } else if (lockfile === 'npm') {
+    fs.writeFileSync(path.join(baseDir, 'package-lock.json'), '{"lockfileVersion": 3}');
+  } else if (lockfile === 'yarn') {
+    fs.writeFileSync(path.join(baseDir, 'yarn.lock'), '# yarn lockfile v1\n');
+  }
+
+  const configDir = path.join(baseDir, 'config');
+  fs.mkdirSync(configDir, { recursive: true });
+  if (options?.configFiles) {
+    for (const [name, content] of Object.entries(options.configFiles)) {
+      fs.writeFileSync(path.join(configDir, name), content);
+    }
+  } else {
+    fs.writeFileSync(path.join(configDir, 'config.default.ts'), 'export default {};\n');
+  }
+
+  return baseDir;
+}
+
+export async function generateAndWrite(
+  baseDir: string,
+  overrides?: Partial<StartupManifest>,
+): Promise<StartupManifest> {
+  const manifest = ManifestStore.generate({
+    baseDir,
+    serverEnv: 'prod',
+    serverScope: '',
+    typescriptEnabled: true,
+  });
+  Object.assign(manifest, overrides);
+  await ManifestStore.write(baseDir, manifest);
+  return manifest;
+}

--- a/packages/core/test/loader/manifest_query.test.ts
+++ b/packages/core/test/loader/manifest_query.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+import { ManifestStore } from '../../src/loader/manifest.ts';
+import { createTmpDir, setupBaseDir, generateAndWrite } from './manifest_helper.ts';
+
+let tmpDir: string;
+
+describe('ManifestStore query APIs', () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('getResolveCache()', () => {
+    it('should return cached path', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, {
+          resolveCache: { '/app/config/plugin': '/resolved/plugin.ts' },
+        });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getResolveCache('/app/config/plugin'), '/resolved/plugin.ts');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return null for null-cached entry', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, {
+          resolveCache: { '/app/missing': null },
+        });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getResolveCache('/app/missing'), null);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return undefined for uncached entry', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, { resolveCache: {} });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getResolveCache('/not/in/cache'), undefined);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('getFileDiscovery()', () => {
+    it('should return cached file list', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, {
+          fileDiscovery: { '/app/service': ['user.ts', 'post.ts'] },
+        });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.deepStrictEqual(store.getFileDiscovery('/app/service'), ['user.ts', 'post.ts']);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return undefined for uncached directory', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        await generateAndWrite(baseDir, { fileDiscovery: {} });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.equal(store.getFileDiscovery('/not/cached'), undefined);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('tegg getter', () => {
+    it('should return tegg data', async () => {
+      const baseDir = setupBaseDir();
+      const tegg = {
+        moduleReferences: [{ name: 'myModule', path: '/tmp/myModule' }],
+        moduleDescriptors: [],
+      };
+      try {
+        await generateAndWrite(baseDir, { tegg });
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        assert.deepStrictEqual(store.tegg, tegg);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/packages/core/test/loader/manifest_roundtrip.test.ts
+++ b/packages/core/test/loader/manifest_roundtrip.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+import { ManifestStore } from '../../src/loader/manifest.ts';
+import { createTmpDir, setupBaseDir, generateAndWrite } from './manifest_helper.ts';
+
+let tmpDir: string;
+
+describe('ManifestStore roundtrip: generate → write → load', () => {
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should round-trip manifest data correctly', async () => {
+    const baseDir = setupBaseDir();
+    try {
+      const resolveCache = { '/some/path': '/resolved/path', '/missing': null };
+      const fileDiscovery = { '/app/controller': ['home.ts', 'user.ts'] };
+      const tegg = {
+        moduleReferences: [{ name: 'foo', path: '/tmp/foo', optional: true }],
+        moduleDescriptors: [{ name: 'foo', unitPath: '/tmp/foo', decoratedFiles: ['service.ts'] }],
+      };
+
+      const original = ManifestStore.generate({
+        baseDir,
+        serverEnv: 'prod',
+        serverScope: '',
+        typescriptEnabled: true,
+        resolveCache,
+        fileDiscovery,
+        tegg,
+      });
+      await ManifestStore.write(baseDir, original);
+
+      const store = ManifestStore.load(baseDir, 'prod', '')!;
+      assert.ok(store);
+      assert.deepStrictEqual(store.data.resolveCache, resolveCache);
+      assert.deepStrictEqual(store.data.fileDiscovery, fileDiscovery);
+      assert.deepStrictEqual(store.data.tegg, tegg);
+      assert.equal(store.data.version, original.version);
+      assert.equal(store.data.generatedAt, original.generatedAt);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should invalidate after lockfile modification', async () => {
+    const baseDir = setupBaseDir({ lockfile: 'pnpm' });
+    try {
+      await generateAndWrite(baseDir);
+      assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+
+      fs.appendFileSync(path.join(baseDir, 'pnpm-lock.yaml'), '\n# modified');
+      assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should invalidate after config file modification', async () => {
+    const baseDir = setupBaseDir({ configFiles: { 'config.default.ts': 'export default {};' } });
+    try {
+      await generateAndWrite(baseDir);
+      assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      fs.writeFileSync(path.join(baseDir, 'config', 'config.prod.ts'), 'export default { port: 3000 };');
+      assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should remain valid when nothing changes', async () => {
+    const baseDir = setupBaseDir();
+    try {
+      await generateAndWrite(baseDir);
+      assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+      assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+      assert.ok(ManifestStore.load(baseDir, 'prod', ''));
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -215,7 +215,7 @@ export class EggApplicationCore extends EggCore {
 
       // single process mode will close agent before app close
       if (this.type === 'application' && this.options.mode === 'single') {
-        await this.agent!.close();
+        await this.agent?.close();
       }
 
       for (const logger of this.loggers.values()) {

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { performance } from 'node:perf_hooks';
 
 import { Cookies as ContextCookies } from '@eggjs/cookies';
-import { EggCore, Router } from '@eggjs/core';
+import { EggCore, Router, ManifestStore } from '@eggjs/core';
 import type { EggCoreOptions, Next, MiddlewareFunc as EggCoreMiddlewareFunc, ILifecycleBoot } from '@eggjs/core';
 import { utils as eggUtils } from '@eggjs/core';
 import { extend } from '@eggjs/extend2';
@@ -190,6 +190,7 @@ export class EggApplicationCore extends EggCore {
         const dumpStartTime = Date.now();
         this.dumpConfig();
         this.dumpTiming();
+        this.dumpManifest();
         this.coreLogger.info('[egg] dump config after ready, %sms', Date.now() - dumpStartTime);
       }),
     );
@@ -530,6 +531,28 @@ export class EggApplicationCore extends EggCore {
       }
     } catch (err: any) {
       this.coreLogger.warn(`[egg] dumpTiming error: ${err.message}`);
+    }
+  }
+
+  /**
+   * Generate and save startup manifest for faster subsequent startups.
+   * Only generates when no valid manifest exists (avoids overwriting during manifest-accelerated starts).
+   * Tegg data is collected by the tegg plugin via `loader.teggManifestCollector`.
+   * @private
+   */
+  dumpManifest(): void {
+    try {
+      // Skip if we already loaded from a valid manifest
+      if (this.loader.manifest) {
+        return;
+      }
+
+      const manifest = this.loader.generateManifest(this.loader.teggManifestCollector);
+      ManifestStore.write(this.baseDir, manifest).catch((err: Error) => {
+        this.coreLogger.warn(`[egg] dumpManifest write error: ${err.message}`);
+      });
+    } catch (err: any) {
+      this.coreLogger.warn(`[egg] dumpManifest error: ${err.message}`);
     }
   }
 

--- a/packages/egg/src/lib/loader/AppWorkerLoader.ts
+++ b/packages/egg/src/lib/loader/AppWorkerLoader.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { EggApplicationLoader } from './EggApplicationLoader.ts';
 
 /**
@@ -30,12 +32,6 @@ export class AppWorkerLoader extends EggApplicationLoader {
 
     // app > plugin
     await this.loadCustomApp();
-
-    // In metadataOnly mode, loadCustomApp triggers loadMetadata and marks ready.
-    // Skip the remaining phases (service/middleware/controller/router) since
-    // they do real module evaluation and are not needed for manifest generation.
-    if (this.options.metadataOnly) return;
-
     // app > plugin
     await this.loadService();
     // app > plugin > core
@@ -43,6 +39,11 @@ export class AppWorkerLoader extends EggApplicationLoader {
     // app
     await this.loadController();
     // app
-    await this.loadRouter(); // Depend on controllers
+    if (this.options.metadataOnly) {
+      // Resolve router path to collect metadata, but don't execute it
+      this.resolveModule(path.join(this.options.baseDir, 'app/router'));
+    } else {
+      await this.loadRouter(); // Depend on controllers
+    }
   }
 }

--- a/packages/egg/src/lib/loader/AppWorkerLoader.ts
+++ b/packages/egg/src/lib/loader/AppWorkerLoader.ts
@@ -30,6 +30,12 @@ export class AppWorkerLoader extends EggApplicationLoader {
 
     // app > plugin
     await this.loadCustomApp();
+
+    // In metadataOnly mode, loadCustomApp triggers loadMetadata and marks ready.
+    // Skip the remaining phases (service/middleware/controller/router) since
+    // they do real module evaluation and are not needed for manifest generation.
+    if (this.options.metadataOnly) return;
+
     // app > plugin
     await this.loadService();
     // app > plugin > core

--- a/packages/egg/src/lib/start.ts
+++ b/packages/egg/src/lib/start.ts
@@ -17,6 +17,8 @@ export interface StartEggOptions {
   mode?: 'single';
   env?: string;
   plugins?: EggPlugin;
+  /** Skip lifecycle hooks, only trigger loadMetadata for manifest generation */
+  metadataOnly?: boolean;
 }
 
 export interface SingleModeApplication extends Application {
@@ -53,18 +55,27 @@ export async function startEgg(options: StartEggOptions = {}): Promise<SingleMod
     ApplicationClass = framework.Application;
   }
 
-  const agent = new AgentClass({
-    ...options,
-  }) as SingleModeAgent;
-  await agent.ready();
+  // In metadataOnly mode, skip agent entirely — only app metadata is needed
+  let agent: SingleModeAgent | undefined;
+  if (!options.metadataOnly) {
+    agent = new AgentClass({
+      ...options,
+    }) as SingleModeAgent;
+    await agent.ready();
+  }
+
   const application = new ApplicationClass({
     ...options,
   }) as SingleModeApplication;
-  application.agent = agent;
-  agent.application = application;
+  if (agent) {
+    application.agent = agent;
+    agent.application = application;
+  }
   await application.ready();
 
-  // emit egg-ready message in agent and application
-  application.messenger.broadcast('egg-ready');
+  if (!options.metadataOnly) {
+    // emit egg-ready message in agent and application
+    application.messenger.broadcast('egg-ready');
+  }
   return application;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3652,6 +3652,9 @@ importers:
 
   tools/egg-bin:
     dependencies:
+      '@eggjs/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@eggjs/tegg-vitest':
         specifier: workspace:*
         version: link:../../tegg/core/vitest

--- a/tegg/core/loader/src/LoaderFactory.ts
+++ b/tegg/core/loader/src/LoaderFactory.ts
@@ -10,6 +10,18 @@ import {
 
 export type LoaderCreator = (unitPath: string) => Loader;
 
+export interface ManifestModuleDescriptor {
+  name: string;
+  unitPath: string;
+  optional?: boolean;
+  /** Files containing decorated classes, relative to unitPath */
+  decoratedFiles: string[];
+}
+
+export interface LoadAppManifest {
+  moduleDescriptors: ManifestModuleDescriptor[];
+}
+
 export class LoaderFactory {
   private static loaderCreatorMap: Map<EggLoadUnitTypeLike, LoaderCreator> = new Map();
 
@@ -25,14 +37,37 @@ export class LoaderFactory {
     this.loaderCreatorMap.set(type, creator);
   }
 
-  static async loadApp(moduleReferences: readonly ModuleReference[]): Promise<ModuleDescriptor[]> {
+  static async loadApp(
+    moduleReferences: readonly ModuleReference[],
+    manifest?: LoadAppManifest,
+  ): Promise<ModuleDescriptor[]> {
     const result: ModuleDescriptor[] = [];
     const multiInstanceClazzList: EggProtoImplClass[] = [];
+
+    const manifestMap = new Map<string, ManifestModuleDescriptor>();
+    if (manifest?.moduleDescriptors) {
+      for (const desc of manifest.moduleDescriptors) {
+        manifestMap.set(desc.unitPath, desc);
+      }
+    }
+
+    // Lazy-load ModuleLoader once if manifest is used (avoid repeated dynamic imports)
+    let ModuleLoaderClass: (typeof import('./impl/ModuleLoader.ts'))['ModuleLoader'] | undefined;
+    if (manifestMap.size > 0) {
+      ModuleLoaderClass = (await import('./impl/ModuleLoader.ts')).ModuleLoader;
+    }
+
     for (const moduleReference of moduleReferences) {
-      const loader = LoaderFactory.createLoader(
-        moduleReference.path,
-        moduleReference.loaderType || EggLoadUnitType.MODULE,
-      );
+      const manifestDesc = manifestMap.get(moduleReference.path);
+      const loaderType = moduleReference.loaderType || EggLoadUnitType.MODULE;
+
+      let loader: Loader;
+      if (manifestDesc && ModuleLoaderClass && loaderType === EggLoadUnitType.MODULE) {
+        loader = new ModuleLoaderClass(moduleReference.path, manifestDesc.decoratedFiles);
+      } else {
+        loader = LoaderFactory.createLoader(moduleReference.path, loaderType);
+      }
+
       const res: ModuleDescriptor = {
         name: moduleReference.name,
         unitPath: moduleReference.path,

--- a/tegg/core/loader/src/impl/ModuleLoader.ts
+++ b/tegg/core/loader/src/impl/ModuleLoader.ts
@@ -12,9 +12,12 @@ const debug = debuglog('egg/tegg/loader/impl/ModuleLoader');
 export class ModuleLoader implements Loader {
   private readonly moduleDir: string;
   private protoClazzList: EggProtoImplClass[];
+  /** Pre-computed file list from manifest (only decorated files) */
+  private readonly precomputedFiles?: string[];
 
-  constructor(moduleDir: string) {
+  constructor(moduleDir: string, precomputedFiles?: string[]) {
     this.moduleDir = moduleDir;
+    this.precomputedFiles = precomputedFiles;
   }
 
   async load(): Promise<EggProtoImplClass[]> {
@@ -23,10 +26,17 @@ export class ModuleLoader implements Loader {
       return this.protoClazzList;
     }
     const protoClassList: EggProtoImplClass[] = [];
-    const filePattern = LoaderUtil.filePattern();
 
-    const files = await globby(filePattern, { cwd: this.moduleDir });
-    debug('load files: %o, filePattern: %o, moduleDir: %o', files, filePattern, this.moduleDir);
+    let files: string[];
+    if (this.precomputedFiles) {
+      files = this.precomputedFiles;
+      debug('load from manifest, files: %o, moduleDir: %o', files, this.moduleDir);
+    } else {
+      const filePattern = LoaderUtil.filePattern();
+      files = await globby(filePattern, { cwd: this.moduleDir });
+      debug('load files: %o, filePattern: %o, moduleDir: %o', files, filePattern, this.moduleDir);
+    }
+
     for (const file of files) {
       const realPath = path.join(this.moduleDir, file);
       const fileClazzList = await LoaderUtil.loadFile(realPath);

--- a/tegg/core/metadata/src/model/ModuleDescriptor.ts
+++ b/tegg/core/metadata/src/model/ModuleDescriptor.ts
@@ -66,4 +66,19 @@ export class ModuleDescriptorDumper {
     await fs.mkdir(path.dirname(dumpPath), { recursive: true });
     await fs.writeFile(dumpPath, ModuleDescriptorDumper.stringifyDescriptor(desc));
   }
+
+  /**
+   * Extract decorated file paths (relative to unitPath) from a ModuleDescriptor.
+   * Used for manifest generation to record which files contain egg prototypes.
+   */
+  static getDecoratedFiles(desc: ModuleDescriptor): string[] {
+    const fileSet = new Set<string>();
+    for (const clazz of [...desc.clazzList, ...desc.multiInstanceClazzList]) {
+      const filePath = PrototypeUtil.getFilePath(clazz);
+      if (filePath) {
+        fileSet.add(path.relative(desc.unitPath, filePath));
+      }
+    }
+    return Array.from(fileSet);
+  }
 }

--- a/tegg/plugin/config/src/app.ts
+++ b/tegg/plugin/config/src/app.ts
@@ -21,24 +21,35 @@ export default class App implements ILifecycleBoot {
 
   configWillLoad(): void {
     const { readModuleOptions } = this.app.config.tegg;
-    // Auto-exclude outDir (e.g. dist/) from module scanning to avoid
-    // duplicate modules when both source and compiled output exist
-    const outDir = this.app.loader.outDir;
-    if (outDir) {
-      const extraFilePattern = readModuleOptions.extraFilePattern || [];
-      const excludePattern = `!**/${outDir}`;
-      if (!extraFilePattern.includes(excludePattern)) {
-        readModuleOptions.extraFilePattern = [...extraFilePattern, excludePattern];
-      }
-    }
-    const moduleScanner = new ModuleScanner(this.app.baseDir, readModuleOptions);
-    let moduleReferences = moduleScanner.loadModuleReferences();
 
-    // When outDir is configured and compiled output exists, rewrite module paths
-    // from source (e.g. app/port/) to compiled output (e.g. dist/app/port/)
-    // so that LoaderUtil can find .js files in production mode
-    if (outDir) {
-      moduleReferences = this.#rewriteModulePaths(moduleReferences, outDir);
+    // Try to use manifest for module references (skip expensive globby scan)
+    const manifest = this.app.loader.manifest;
+    const manifestTegg = manifest?.tegg;
+
+    let moduleReferences: readonly ModuleReference[];
+    if (manifestTegg?.moduleReferences?.length) {
+      moduleReferences = manifestTegg.moduleReferences;
+      debug('load moduleReferences from manifest: %o', moduleReferences);
+    } else {
+      // Auto-exclude outDir (e.g. dist/) from module scanning to avoid
+      // duplicate modules when both source and compiled output exist
+      const outDir = this.app.loader.outDir;
+      if (outDir) {
+        const extraFilePattern = readModuleOptions.extraFilePattern || [];
+        const excludePattern = `!**/${outDir}`;
+        if (!extraFilePattern.includes(excludePattern)) {
+          readModuleOptions.extraFilePattern = [...extraFilePattern, excludePattern];
+        }
+      }
+      const moduleScanner = new ModuleScanner(this.app.baseDir, readModuleOptions);
+      moduleReferences = moduleScanner.loadModuleReferences();
+
+      // When outDir is configured and compiled output exists, rewrite module paths
+      // from source (e.g. app/port/) to compiled output (e.g. dist/app/port/)
+      // so that LoaderUtil can find .js files in production mode
+      if (outDir) {
+        moduleReferences = this.#rewriteModulePaths(moduleReferences, outDir);
+      }
     }
 
     this.app.moduleReferences = moduleReferences;

--- a/tegg/plugin/config/src/app.ts
+++ b/tegg/plugin/config/src/app.ts
@@ -20,6 +20,16 @@ export default class App implements ILifecycleBoot {
   }
 
   configWillLoad(): void {
+    this.#scanModuleReferences();
+    this.#loadModuleConfigs();
+  }
+
+  async loadMetadata(): Promise<void> {
+    this.#scanModuleReferences();
+    this.#loadModuleConfigs();
+  }
+
+  #scanModuleReferences(): void {
     const { readModuleOptions } = this.app.config.tegg;
 
     // Try to use manifest for module references (skip expensive globby scan)
@@ -44,9 +54,6 @@ export default class App implements ILifecycleBoot {
       const moduleScanner = new ModuleScanner(this.app.baseDir, readModuleOptions);
       moduleReferences = moduleScanner.loadModuleReferences();
 
-      // When outDir is configured and compiled output exists, rewrite module paths
-      // from source (e.g. app/port/) to compiled output (e.g. dist/app/port/)
-      // so that LoaderUtil can find .js files in production mode
       if (outDir) {
         moduleReferences = this.#rewriteModulePaths(moduleReferences, outDir);
       }
@@ -54,7 +61,9 @@ export default class App implements ILifecycleBoot {
 
     this.app.moduleReferences = moduleReferences;
     debug('load moduleReferences: %o', this.app.moduleReferences);
+  }
 
+  #loadModuleConfigs(): void {
     this.app.moduleConfigs = {};
     for (const reference of this.app.moduleReferences) {
       const absoluteRef: ModuleReference = {

--- a/tegg/plugin/tegg/src/app.ts
+++ b/tegg/plugin/tegg/src/app.ts
@@ -3,12 +3,14 @@ import './lib/AppLoadUnit.ts';
 import './lib/AppLoadUnitInstance.ts';
 import './lib/EggCompatibleObject.ts';
 import { LoadUnitMultiInstanceProtoHook } from '@eggjs/metadata';
+import { LoaderFactory } from '@eggjs/tegg-loader';
 import type { Application, ILifecycleBoot } from 'egg';
 
 import { CompatibleUtil } from './lib/CompatibleUtil.ts';
 import { ConfigSourceLoadUnitHook } from './lib/ConfigSourceLoadUnitHook.ts';
 import { EggContextCompatibleHook } from './lib/EggContextCompatibleHook.ts';
 import { EggContextHandler } from './lib/EggContextHandler.ts';
+import { EggModuleLoader } from './lib/EggModuleLoader.ts';
 import { EggQualifierProtoHook } from './lib/EggQualifierProtoHook.ts';
 import { ModuleHandler } from './lib/ModuleHandler.ts';
 import { hijackRunInBackground } from './lib/run_in_background.ts';
@@ -52,6 +54,15 @@ export default class TeggAppBoot implements ILifecycleBoot {
     await this.app.moduleHandler.init();
     this.compatibleHook = new EggContextCompatibleHook(this.app.moduleHandler);
     this.app.eggContextLifecycleUtil.registerLifecycle(this.compatibleHook);
+  }
+
+  async loadMetadata(): Promise<void> {
+    if (!this.app.moduleReferences) return;
+    const moduleDescriptors = await LoaderFactory.loadApp(this.app.moduleReferences);
+    this.app.loader.teggManifestCollector = EggModuleLoader.buildTeggManifestData(
+      this.app.moduleReferences,
+      moduleDescriptors,
+    );
   }
 
   async beforeClose(): Promise<void> {

--- a/tegg/plugin/tegg/src/lib/EggModuleLoader.ts
+++ b/tegg/plugin/tegg/src/lib/EggModuleLoader.ts
@@ -1,6 +1,7 @@
 import { EggLoadUnitType, LoadUnitFactory, GlobalGraph, ModuleDescriptorDumper } from '@eggjs/metadata';
-import type { GlobalGraphBuildHook } from '@eggjs/metadata';
+import type { GlobalGraphBuildHook, ModuleDescriptor } from '@eggjs/metadata';
 import { LoaderFactory } from '@eggjs/tegg-loader';
+import type { LoadAppManifest } from '@eggjs/tegg-loader';
 import type { Application } from 'egg';
 
 import { EggAppLoader } from './EggAppLoader.ts';
@@ -18,13 +19,13 @@ export class EggModuleLoader {
     this.pendingBuildHooks.push(hook);
   }
 
-  private async loadApp() {
+  private async loadApp(): Promise<void> {
     const loader = new EggAppLoader(this.app);
     const loadUnit = await LoadUnitFactory.createLoadUnit(this.app.baseDir, EggLoadUnitType.APP, loader);
     this.app.moduleHandler.loadUnits.push(loadUnit);
   }
 
-  private async buildAppGraph() {
+  private async buildAppGraph(): Promise<GlobalGraph> {
     for (const plugin of Object.values(this.app.plugins)) {
       if (!plugin.enable) continue;
       const modulePlugin = this.app.moduleReferences.find((t) => t.path === plugin.path);
@@ -32,11 +33,26 @@ export class EggModuleLoader {
         modulePlugin.optional = false;
       }
     }
-    const moduleDescriptors = await LoaderFactory.loadApp(this.app.moduleReferences);
+
+    // Pass manifest data to LoaderFactory if available
+    const manifest = this.app.loader.manifest;
+    const manifestTegg = manifest?.tegg;
+    let loadAppManifest: LoadAppManifest | undefined;
+    if (manifestTegg?.moduleDescriptors?.length) {
+      loadAppManifest = {
+        moduleDescriptors: manifestTegg.moduleDescriptors,
+      };
+    }
+
+    const moduleDescriptors = await LoaderFactory.loadApp(this.app.moduleReferences, loadAppManifest);
+
+    // Dump module descriptors and collect manifest data
+    this.#collectTeggManifest(moduleDescriptors);
+
     for (const moduleDescriptor of moduleDescriptors) {
       ModuleDescriptorDumper.dump(moduleDescriptor, {
         dumpDir: this.app.baseDir,
-      }).catch((e) => {
+      }).catch((e: Error) => {
         e.message = 'dump module descriptor failed: ' + e.message;
         this.app.logger.warn(e);
       });
@@ -45,7 +61,30 @@ export class EggModuleLoader {
     return graph;
   }
 
-  private async loadModule() {
+  /**
+   * Collect tegg manifest data for the egg core manifest generation.
+   * Populates loader.teggManifestCollector with moduleReferences and decoratedFiles.
+   */
+  #collectTeggManifest(moduleDescriptors: ModuleDescriptor[]): void {
+    // Skip collection if we loaded from a valid manifest (no need to regenerate)
+    if (this.app.loader.manifest) return;
+
+    this.app.loader.teggManifestCollector = {
+      moduleReferences: [...this.app.moduleReferences].map((ref) => ({
+        name: ref.name,
+        path: ref.path,
+        optional: ref.optional,
+      })),
+      moduleDescriptors: moduleDescriptors.map((desc) => ({
+        name: desc.name,
+        unitPath: desc.unitPath,
+        optional: desc.optional,
+        decoratedFiles: ModuleDescriptorDumper.getDecoratedFiles(desc),
+      })),
+    };
+  }
+
+  private async loadModule(): Promise<void> {
     this.globalGraph.build();
     this.globalGraph.sort();
     const moduleConfigList = this.globalGraph.moduleConfigList;

--- a/tegg/plugin/tegg/src/lib/EggModuleLoader.ts
+++ b/tegg/plugin/tegg/src/lib/EggModuleLoader.ts
@@ -2,6 +2,7 @@ import { EggLoadUnitType, LoadUnitFactory, GlobalGraph, ModuleDescriptorDumper }
 import type { GlobalGraphBuildHook, ModuleDescriptor } from '@eggjs/metadata';
 import { LoaderFactory } from '@eggjs/tegg-loader';
 import type { LoadAppManifest } from '@eggjs/tegg-loader';
+import type { ModuleReference } from '@eggjs/tegg-types';
 import type { Application } from 'egg';
 
 import { EggAppLoader } from './EggAppLoader.ts';
@@ -62,15 +63,18 @@ export class EggModuleLoader {
   }
 
   /**
-   * Collect tegg manifest data for the egg core manifest generation.
-   * Populates loader.teggManifestCollector with moduleReferences and decoratedFiles.
+   * Build tegg manifest data from module references and descriptors.
+   * Shared by both normal startup (#collectTeggManifest) and metadataOnly mode (loadMetadata hook).
    */
-  #collectTeggManifest(moduleDescriptors: ModuleDescriptor[]): void {
-    // Skip collection if we loaded from a valid manifest (no need to regenerate)
-    if (this.app.loader.manifest) return;
-
-    this.app.loader.teggManifestCollector = {
-      moduleReferences: [...this.app.moduleReferences].map((ref) => ({
+  static buildTeggManifestData(
+    moduleReferences: readonly ModuleReference[],
+    moduleDescriptors: readonly ModuleDescriptor[],
+  ): {
+    moduleReferences: Array<{ name: string; path: string; optional?: boolean }>;
+    moduleDescriptors: Array<{ name: string; unitPath: string; optional?: boolean; decoratedFiles: string[] }>;
+  } {
+    return {
+      moduleReferences: moduleReferences.map((ref) => ({
         name: ref.name,
         path: ref.path,
         optional: ref.optional,
@@ -82,6 +86,14 @@ export class EggModuleLoader {
         decoratedFiles: ModuleDescriptorDumper.getDecoratedFiles(desc),
       })),
     };
+  }
+
+  #collectTeggManifest(moduleDescriptors: ModuleDescriptor[]): void {
+    if (this.app.loader.manifest) return;
+    this.app.loader.teggManifestCollector = EggModuleLoader.buildTeggManifestData(
+      this.app.moduleReferences,
+      moduleDescriptors,
+    );
   }
 
   private async loadModule(): Promise<void> {

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -30,8 +30,8 @@
     "./baseCommand": "./src/baseCommand.ts",
     "./commands/cov": "./src/commands/cov.ts",
     "./commands/dev": "./src/commands/dev.ts",
-    "./commands/test": "./src/commands/test.ts",
     "./commands/manifest": "./src/commands/manifest.ts",
+    "./commands/test": "./src/commands/test.ts",
     "./types": "./src/types.ts",
     "./utils": "./src/utils.ts",
     "./package.json": "./package.json"
@@ -43,8 +43,8 @@
       "./baseCommand": "./dist/baseCommand.js",
       "./commands/cov": "./dist/commands/cov.js",
       "./commands/dev": "./dist/commands/dev.js",
-      "./commands/test": "./dist/commands/test.js",
       "./commands/manifest": "./dist/commands/manifest.js",
+      "./commands/test": "./dist/commands/test.js",
       "./types": "./dist/types.js",
       "./utils": "./dist/utils.js",
       "./package.json": "./package.json"

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -31,6 +31,7 @@
     "./commands/cov": "./src/commands/cov.ts",
     "./commands/dev": "./src/commands/dev.ts",
     "./commands/test": "./src/commands/test.ts",
+    "./commands/manifest": "./src/commands/manifest.ts",
     "./types": "./src/types.ts",
     "./utils": "./src/utils.ts",
     "./package.json": "./package.json"
@@ -43,6 +44,7 @@
       "./commands/cov": "./dist/commands/cov.js",
       "./commands/dev": "./dist/commands/dev.js",
       "./commands/test": "./dist/commands/test.js",
+      "./commands/manifest": "./dist/commands/manifest.js",
       "./types": "./dist/types.js",
       "./utils": "./dist/utils.js",
       "./package.json": "./package.json"
@@ -56,6 +58,7 @@
     "ci": "npm run cov"
   },
   "dependencies": {
+    "@eggjs/core": "workspace:*",
     "@eggjs/tegg-vitest": "workspace:*",
     "@eggjs/utils": "workspace:*",
     "@oclif/core": "catalog:",

--- a/tools/egg-bin/scripts/manifest-generate.mjs
+++ b/tools/egg-bin/scripts/manifest-generate.mjs
@@ -1,0 +1,43 @@
+import { debuglog } from 'node:util';
+
+import { importModule } from '@eggjs/utils';
+
+const debug = debuglog('egg/bin/scripts/manifest-generate');
+
+async function main() {
+  debug('argv: %o', process.argv);
+  const options = JSON.parse(process.argv[2]);
+  debug('manifest generate options: %o', options);
+
+  process.env.EGG_SERVER_ENV = options.env ?? 'prod';
+
+  const egg = await importModule(options.framework || 'egg');
+  const { ManifestStore } = await importModule('@eggjs/core');
+
+  // startEgg with metadataOnly: skips lifecycle hooks, only triggers loadMetadata
+  const app = await egg.startEgg({
+    baseDir: options.baseDir,
+    mode: 'single',
+    metadataOnly: true,
+  });
+
+  const manifest = app.loader.generateManifest(app.loader.teggManifestCollector);
+  await ManifestStore.write(options.baseDir, manifest);
+
+  debug(
+    'manifest generated, resolveCache: %d, fileDiscovery: %d, tegg: %o',
+    Object.keys(manifest.resolveCache).length,
+    Object.keys(manifest.fileDiscovery).length,
+    manifest.tegg
+      ? {
+          moduleReferences: manifest.tegg.moduleReferences.length,
+          moduleDescriptors: manifest.tegg.moduleDescriptors.length,
+        }
+      : 'none',
+  );
+
+  await app.close();
+  process.exit(0);
+}
+
+void main();

--- a/tools/egg-bin/src/baseCommand.ts
+++ b/tools/egg-bin/src/baseCommand.ts
@@ -315,6 +315,19 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     return `--require "${modulePath}"`;
   }
 
+  protected async buildRequireExecArgv(): Promise<string[]> {
+    const requires = await this.formatRequires();
+    const execArgv: string[] = [];
+    for (const r of requires) {
+      const module = this.formatImportModule(r);
+      const splitIndex = module.indexOf(' ');
+      if (splitIndex !== -1) {
+        execArgv.push(module.slice(0, splitIndex), module.slice(splitIndex + 2, -1));
+      }
+    }
+    return execArgv;
+  }
+
   protected addNodeOptions(options: string) {
     if (this.env.NODE_OPTIONS) {
       if (!this.env.NODE_OPTIONS.includes(options)) {

--- a/tools/egg-bin/src/commands/dev.ts
+++ b/tools/egg-bin/src/commands/dev.ts
@@ -41,19 +41,7 @@ export default class Dev<T extends typeof Dev> extends BaseCommand<T> {
     const serverBin = getSourceFilename(`../scripts/start-cluster.${ext}`);
     const eggStartOptions = await this.formatEggStartOptions();
     const args = [JSON.stringify(eggStartOptions)];
-    const requires = await this.formatRequires();
-    const execArgv: string[] = [];
-    for (const r of requires) {
-      const module = this.formatImportModule(r);
-
-      // Remove the quotes from the path
-      // --require "module path" -> ['--require', 'module path']
-      // --import "module path" -> ['--import', 'module path']
-      const splitIndex = module.indexOf(' ');
-      if (splitIndex !== -1) {
-        execArgv.push(module.slice(0, splitIndex), module.slice(splitIndex + 2, -1));
-      }
-    }
+    const execArgv = await this.buildRequireExecArgv();
     await this.forkNode(serverBin, args, { execArgv });
   }
 

--- a/tools/egg-bin/src/commands/manifest.ts
+++ b/tools/egg-bin/src/commands/manifest.ts
@@ -1,0 +1,106 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { debuglog } from 'node:util';
+
+import { ManifestStore } from '@eggjs/core';
+import { Args, Flags } from '@oclif/core';
+
+import { BaseCommand } from '../baseCommand.ts';
+
+const debug = debuglog('egg/bin/commands/manifest');
+
+export default class Manifest<T extends typeof Manifest> extends BaseCommand<T> {
+  static override description = 'Generate, validate, or clean the startup manifest for faster cold starts';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> generate',
+    '<%= config.bin %> <%= command.id %> validate',
+    '<%= config.bin %> <%= command.id %> clean',
+  ];
+
+  static override flags = {
+    framework: Flags.string({
+      description: 'specify framework, default is "egg"',
+    }),
+    env: Flags.string({
+      description: 'server environment, default is "prod"',
+      default: 'prod',
+    }),
+  };
+
+  static override args = {
+    action: Args.string({
+      description: 'action to perform: generate, validate, or clean',
+      required: true,
+      options: ['generate', 'validate', 'clean'],
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(Manifest);
+    const baseDir = path.resolve(flags.base ?? process.cwd());
+    const action = args.action as 'generate' | 'validate' | 'clean';
+
+    debug('manifest %s, baseDir: %s', action, baseDir);
+
+    switch (action) {
+      case 'generate':
+        await this.generate(baseDir, flags);
+        break;
+      case 'validate':
+        this.validate(baseDir, flags);
+        break;
+      case 'clean':
+        ManifestStore.clean(baseDir);
+        this.log('Manifest cleaned at: %s', baseDir);
+        break;
+    }
+  }
+
+  private async generate(baseDir: string, flags: Record<string, any>): Promise<void> {
+    this.log('Generating startup manifest...');
+    this.log('  baseDir: %s', baseDir);
+
+    const env = flags.env ?? 'prod';
+    const manifest = ManifestStore.generate({
+      baseDir,
+      serverEnv: env,
+      serverScope: '',
+      typescriptEnabled: true,
+      resolveCache: {},
+      fileDiscovery: {},
+    });
+
+    await ManifestStore.write(baseDir, manifest);
+    this.log('Manifest generated at: %s', path.join(baseDir, '.egg', 'manifest.json'));
+    this.log('Note: For full manifest data, start the app once with EGG_SERVER_ENV=%s', env);
+    this.log('The app will auto-generate a complete manifest on first startup.');
+  }
+
+  private validate(baseDir: string, flags: Record<string, any>): void {
+    const manifestPath = path.join(baseDir, '.egg', 'manifest.json');
+
+    if (!fs.existsSync(manifestPath)) {
+      this.log('No manifest found at: %s', manifestPath);
+      this.exit(1);
+    }
+
+    const env = flags.env ?? 'prod';
+    const store = ManifestStore.load(baseDir, env, '');
+    if (store) {
+      this.log('Manifest is valid');
+      this.log('  version: %d', store.data.version);
+      this.log('  generated: %s', store.data.generatedAt);
+      this.log('  env: %s', store.data.invalidation.serverEnv);
+      this.log('  resolveCache entries: %d', Object.keys(store.data.resolveCache).length);
+      this.log('  fileDiscovery entries: %d', Object.keys(store.data.fileDiscovery).length);
+      if (store.data.tegg) {
+        this.log('  tegg moduleReferences: %d', store.data.tegg.moduleReferences.length);
+        this.log('  tegg moduleDescriptors: %d', store.data.tegg.moduleDescriptors.length);
+      }
+    } else {
+      this.log('Manifest is invalid or outdated');
+      this.exit(1);
+    }
+  }
+}

--- a/tools/egg-bin/src/commands/manifest.ts
+++ b/tools/egg-bin/src/commands/manifest.ts
@@ -6,6 +6,7 @@ import { ManifestStore } from '@eggjs/core';
 import { Args, Flags } from '@oclif/core';
 
 import { BaseCommand } from '../baseCommand.ts';
+import { getSourceFilename } from '../utils.ts';
 
 const debug = debuglog('egg/bin/commands/manifest');
 
@@ -61,20 +62,19 @@ export default class Manifest<T extends typeof Manifest> extends BaseCommand<T> 
     this.log('Generating startup manifest...');
     this.log('  baseDir: %s', baseDir);
 
-    const env = flags.env ?? 'prod';
-    const manifest = ManifestStore.generate({
-      baseDir,
-      serverEnv: env,
-      serverScope: '',
-      typescriptEnabled: true,
-      resolveCache: {},
-      fileDiscovery: {},
-    });
+    const ext = this.isESM ? 'mjs' : 'cjs';
+    const scriptFile = getSourceFilename(`../scripts/manifest-generate.${ext}`);
+    const args = [
+      JSON.stringify({
+        baseDir,
+        framework: flags.framework,
+        env: flags.env ?? 'prod',
+      }),
+    ];
 
-    await ManifestStore.write(baseDir, manifest);
+    const execArgv = await this.buildRequireExecArgv();
+    await this.forkNode(scriptFile, args, { execArgv });
     this.log('Manifest generated at: %s', path.join(baseDir, '.egg', 'manifest.json'));
-    this.log('Note: For full manifest data, start the app once with EGG_SERVER_ENV=%s', env);
-    this.log('The app will auto-generate a complete manifest on first startup.');
   }
 
   private validate(baseDir: string, flags: Record<string, any>): void {

--- a/tools/egg-bin/tsdown.config.ts
+++ b/tools/egg-bin/tsdown.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   unused: {
     level: 'error',
     // @vitest/coverage-v8 is loaded by vitest at runtime as a coverage provider, not directly imported
-    ignore: ['utility', '@vitest/coverage-v8'],
+    // @eggjs/core is used by manifest command and scripts/manifest-generate.mjs
+    ignore: ['utility', '@vitest/coverage-v8', '@eggjs/core'],
   },
   copy: [
     {


### PR DESCRIPTION
## Summary

WIP: 通过静态化启动时的文件 I/O metadata 来优化 Egg/tegg 框架冷启动性能。

- 新增 `ManifestStore` 类，将 resolveModule 路径、globby 文件发现结果、tegg 模块描述符缓存到 `.egg/manifest.json`
- 启动时通过 stat-based fingerprint（mtime+size）校验 manifest 有效性，跳过昂贵的文件扫描
- tegg 层：`ModuleLoader` 接受预计算的 decorated files 列表，跳过 70-80% 的 `import()` 调用
- tegg config 插件：有 manifest 时跳过深度 `globby.sync('**/package.json')` 扫描
- egg-bin：新增 `manifest generate|validate|clean` CLI 命令
- 首次启动自动生成 manifest（ready hook 中的 `dumpManifest`）

### 主要优化点

| 层 | 消除的 I/O | 预期加速 |
|---|-----------|---------|
| tegg 模块扫描 | 每模块 globby + 70-80% import() | 40-60% |
| egg core resolveModule | 数百次 fs.existsSync | 30-50% |
| egg core FileLoader | 4-7 次 globby.sync | 10-20% |

## TODO

- [ ] 性能基准测试（有/无 manifest 对比）
- [ ] 更完整的 egg-bin manifest generate（通过完整 app boot 收集数据）
- [ ] 单元测试覆盖 ManifestStore

## Test plan

- [x] `@eggjs/core` 351 tests passed
- [x] `egg` 352 tests passed
- [x] tegg plugin/loader/metadata 72 tests passed
- [x] 所有修改包 typecheck 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)