### PR TITLE
fix(ci): remove test sharding to reduce runner usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,12 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         node: ['20', '22', '24']
-        # 1-based index
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
 
-    name: Test (${{ matrix.os }}, ${{ matrix.node }}, ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: Test (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
 
     concurrency:
-      group: test-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }}, ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+      group: test-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }})
       cancel-in-progress: true
 
     steps:
@@ -170,7 +167,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm run ci --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: pnpm run ci
 
       - name: Run example tests
         if: ${{ matrix.node != '20' && matrix.os != 'windows-latest' }}
@@ -190,15 +187,12 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
         node: ['24']
-        # 0-based index
-        shardIndex: [0, 1, 2]
-        shardTotal: [3]
 
-    name: Test bin (${{ matrix.os }}, ${{ matrix.node }}, ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    name: Test bin (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
 
     concurrency:
-      group: test-egg-bin-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }}, ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+      group: test-egg-bin-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }})
       cancel-in-progress: true
 
     steps:
@@ -221,10 +215,6 @@ jobs:
         run: |
           pnpm build --workspace ./tools/egg-bin
           pnpm run --filter ./tools/egg-bin ci
-        env:
-          # https://github.com/jamiebuilds/ci-parallel-vars
-          CI_NODE_INDEX: ${{ matrix.shardIndex }}
-          CI_NODE_TOTAL: ${{ matrix.shardTotal }}
 
       - name: Code Coverage
         # skip on windows, it will hangup on codecov https://github.com/codecov/codecov-action/issues/1787


### PR DESCRIPTION
## Summary
- Remove `shardIndex`/`shardTotal` matrix from `test` and `test-egg-bin` jobs
- Each platform/node combo now runs all tests in a single job instead of splitting into 3 shards
- Total CI jobs reduced from 37 to 14 (~62% reduction)

## Test plan
- [ ] CI passes on all platforms (ubuntu, macos, windows)
- [ ] egg-bin tests pass without `CI_NODE_INDEX`/`CI_NODE_TOTAL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI workflow by removing test sharding configuration from the testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->