### PR TITLE
feat(egg): skip loadRouter in metadataOnly mode

### DIFF
--- a/packages/egg/src/lib/loader/AppWorkerLoader.ts
+++ b/packages/egg/src/lib/loader/AppWorkerLoader.ts
@@ -37,6 +37,8 @@ export class AppWorkerLoader extends EggApplicationLoader {
     // app
     await this.loadController();
     // app
-    await this.loadRouter(); // Depend on controllers
+    if (!this.options.metadataOnly) {
+      await this.loadRouter(); // Depend on controllers
+    }
   }
 }

--- a/packages/egg/test/fixtures/apps/metadata-only-app/app.js
+++ b/packages/egg/test/fixtures/apps/metadata-only-app/app.js
@@ -1,0 +1,38 @@
+module.exports = class MetadataOnlyBoot {
+  constructor(app) {
+    this.app = app;
+    app.bootLog = [];
+  }
+
+  configWillLoad() {
+    this.app.bootLog.push('configWillLoad');
+  }
+
+  configDidLoad() {
+    this.app.bootLog.push('configDidLoad');
+  }
+
+  async didLoad() {
+    this.app.bootLog.push('didLoad');
+  }
+
+  async willReady() {
+    this.app.bootLog.push('willReady');
+  }
+
+  async didReady() {
+    this.app.bootLog.push('didReady');
+  }
+
+  async serverDidReady() {
+    this.app.bootLog.push('serverDidReady');
+  }
+
+  async beforeClose() {
+    this.app.bootLog.push('beforeClose');
+  }
+
+  async loadMetadata() {
+    this.app.bootLog.push('loadMetadata');
+  }
+};

--- a/packages/egg/test/fixtures/apps/metadata-only-app/app/controller/home.js
+++ b/packages/egg/test/fixtures/apps/metadata-only-app/app/controller/home.js
@@ -1,0 +1,3 @@
+module.exports = async function () {
+  this.body = 'hello';
+};

--- a/packages/egg/test/fixtures/apps/metadata-only-app/app/router.js
+++ b/packages/egg/test/fixtures/apps/metadata-only-app/app/router.js
@@ -1,0 +1,3 @@
+module.exports = (app) => {
+  app.get('/', app.controller.home);
+};

--- a/packages/egg/test/fixtures/apps/metadata-only-app/package.json
+++ b/packages/egg/test/fixtures/apps/metadata-only-app/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "metadata-only-app"
+}

--- a/packages/egg/test/start.test.ts
+++ b/packages/egg/test/start.test.ts
@@ -1,66 +1,58 @@
-import { describe } from 'vitest';
+import { strict as assert } from 'node:assert';
 
-// import utils from '../utils';
-// import assert from 'assert';
-// import path from 'path';
+import { describe, it, afterAll, beforeAll } from 'vitest';
 
-// let app;
+import { singleProcessApp, type SingleModeApplication } from './utils.ts';
 
-describe.skip('test/lib/start.test.js', () => {
-  //   afterEach(() => app.close());
-  //   describe('start', () => {
-  //     it('should dump config and plugins', async () => {
-  //       app = await utils.singleProcessApp('apps/demo');
-  //       const baseDir = utils.getFilepath('apps/demo');
-  //       let json = require(path.join(baseDir, 'run/agent_config.json'));
-  //       assert(/\d+\.\d+\.\d+/.test(json.plugins.onerror.version));
-  //       assert(json.config.name === 'demo');
-  //       assert(json.config.tips === 'hello egg');
-  //       json = require(path.join(baseDir, 'run/application_config.json'));
-  //       checkApp(json);
-  //       const dumpped = app.dumpConfigToObject();
-  //       checkApp(dumpped.config);
-  //       function checkApp(json) {
-  //         assert(/\d+\.\d+\.\d+/.test(json.plugins.onerror.version));
-  //         assert(json.config.name === 'demo');
-  //         // should dump dynamic config
-  //         assert(json.config.tips === 'hello egg started');
-  //       }
-  //     });
-  //     it('should request work', async () => {
-  //       app = await utils.singleProcessApp('apps/demo');
-  //       await app.httpRequest().get('/protocol')
-  //         .expect(200)
-  //         .expect('http');
-  //       await app.httpRequest().get('/class-controller')
-  //         .expect(200)
-  //         .expect('this is bar!');
-  //     });
-  //     it('should env work', async () => {
-  //       app = await utils.singleProcessApp('apps/demo', { env: 'prod' });
-  //       assert(app.config.env === 'prod');
-  //     });
-  //   });
-  //   describe('custom framework work', () => {
-  //     it('should work with options.framework', async () => {
-  //       app = await utils.singleProcessApp('apps/demo', { framework: path.join(__dirname, '../fixtures/custom-egg') });
-  //       assert(app.customEgg);
-  //       await app.httpRequest().get('/protocol')
-  //         .expect(200)
-  //         .expect('http');
-  //       await app.httpRequest().get('/class-controller')
-  //         .expect(200)
-  //         .expect('this is bar!');
-  //     });
-  //     it('should work with package.egg.framework', async () => {
-  //       app = await utils.singleProcessApp('apps/custom-framework-demo');
-  //       assert(app.customEgg);
-  //       await app.httpRequest().get('/protocol')
-  //         .expect(200)
-  //         .expect('http');
-  //       await app.httpRequest().get('/class-controller')
-  //         .expect(200)
-  //         .expect('this is bar!');
-  //     });
-  //   });
+describe('test/start.test.ts', () => {
+  describe('metadataOnly mode', () => {
+    let app: SingleModeApplication;
+
+    beforeAll(async () => {
+      app = await singleProcessApp('apps/metadata-only-app', { metadataOnly: true });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('should only call loadMetadata, not normal lifecycle hooks', () => {
+      assert.deepStrictEqual(app.bootLog, ['loadMetadata']);
+    });
+
+    it('should skip loadRouter — no routes registered', () => {
+      assert.strictEqual(app.router.stack.length, 0);
+    });
+
+    it('should not create agent', () => {
+      assert.strictEqual(app.agent, undefined);
+    });
+  });
+
+  describe('normal mode (baseline)', () => {
+    let app: SingleModeApplication;
+
+    beforeAll(async () => {
+      app = await singleProcessApp('apps/metadata-only-app');
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('should call normal lifecycle hooks, not loadMetadata', () => {
+      assert(app.bootLog.includes('configDidLoad'));
+      assert(app.bootLog.includes('didLoad'));
+      assert(app.bootLog.includes('willReady'));
+      assert(!app.bootLog.includes('loadMetadata'));
+    });
+
+    it('should register routes', () => {
+      assert(app.router.stack.length > 0);
+    });
+
+    it('should create agent', () => {
+      assert(app.agent);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `AppWorkerLoader.load()` 在 `metadataOnly` 模式下跳过 `loadRouter()`，避免不必要的路由注册
- 为 `egg-bin manifest generate` 命令的 metadata-only 启动服务
- 新增 6 个测试用例覆盖 metadataOnly 和正常模式对比

## Context

PR #5842 manifest 系列的第三部分。lifecycle 层的 `loadMetadata` / `triggerLoadMetadata` / `metadataOnly` flag 已在 #5844 和 #5846 中合入，本 PR 补全 AppWorkerLoader 侧的守卫。

## Test plan

- [x] metadataOnly 模式：仅调用 `loadMetadata`，跳过正常生命周期钩子
- [x] metadataOnly 模式：`router.stack` 为空（loadRouter 被跳过）
- [x] metadataOnly 模式：不创建 agent
- [x] 正常模式：生命周期钩子正常触发，路由正常注册
- [x] `pnpm --filter=egg run test test/start.test.ts` 6/6 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata-only initialization mode that conditionally skips router registration during app startup, enabling metadata extraction without full application initialization.

* **Tests**
  * Added test coverage for metadata-only startup mode, verifying correct lifecycle behavior and router initialization is prevented.
  * Added test suite for standard initialization mode to validate baseline functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->