### PR TITLE
feat: add Node.js V8 startup snapshot support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,12 +264,59 @@ jobs:
         with:
           use_oidc: true
 
+  test-snapshot:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22', '24']
+
+    name: Test snapshot (ubuntu, ${{ matrix.node }})
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: test-snapshot-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-${{ matrix.node }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Run snapshot tests
+        run: |
+          pnpm run --filter=./tools/scripts test -- snapshot.test.ts
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+
+      - name: Upload snapshot blob on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-blob-${{ matrix.node }}
+          path: tools/scripts/test/fixtures/snapshot-app/*.blob
+          retention-days: 3
+
   done:
     runs-on: ubuntu-latest
     needs:
       - test
       - test-egg-bin
       - test-egg-scripts
+      - test-snapshot
       - typecheck
     steps:
       - run: exit 1

--- a/docs/snapshot-design.md
+++ b/docs/snapshot-design.md
@@ -1,0 +1,506 @@
+# Egg.js V8 Startup Snapshot Design
+
+## Overview and Goals
+
+Node.js V8 startup snapshots (`--build-snapshot` / `--snapshot-blob`) allow serializing the V8 heap after initialization, then restoring it on subsequent starts. This eliminates module loading, parsing, compilation, and initialization work -- dramatically reducing cold-start time.
+
+**Goals for Egg.js snapshot support:**
+
+1. Support single-process mode snapshot build and restore via `egg-scripts`
+2. Pre-compute as much initialization as possible: module require cache, config parsing, plugin loading, middleware chain setup, controller/service class loading, tegg metadata (GlobalGraph)
+3. Defer runtime-dependent resources: `server.listen()`, DB connections, file watchers, timers, loggers (file handles), `AsyncLocalStorage`
+4. Keep changes modular -- each package owns its own snapshot awareness
+5. **No bundling required** -- run egg's full loader during snapshot build, capture post-loader state
+
+## Node.js Snapshot API Summary
+
+### Key APIs
+
+| API                                                       | Purpose                                                             |
+| --------------------------------------------------------- | ------------------------------------------------------------------- |
+| `v8.startupSnapshot.isBuildingSnapshot()`                 | Returns `true` during snapshot build phase                          |
+| `v8.startupSnapshot.addSerializeCallback(fn, data)`       | Cleanup before snapshot is taken (close handles, release resources) |
+| `v8.startupSnapshot.addDeserializeCallback(fn, data)`     | Restore after snapshot loads (reopen handles, reinitialize)         |
+| `v8.startupSnapshot.setDeserializeMainFunction(fn, data)` | Set the entry point for deserialized app (called once)              |
+| `--build-snapshot`                                        | CLI flag to build snapshot blob                                     |
+| `--snapshot-blob=path`                                    | CLI flag to load snapshot blob                                      |
+| `--build-snapshot-config=path`                            | JSON config for snapshot build (builder script, withoutCodeCache)   |
+
+### Critical Limitations
+
+1. **Single entry file required**: `--build-snapshot` loads one script. However, that script can dynamically `import()` other modules -- full bundling is NOT needed. Egg's loader runs normally during snapshot build, and the entire post-load state is captured in the heap. See "Bundling Decision" section below.
+2. **No open handles at snapshot time**: Sockets, timers (`setTimeout`/`setInterval`), file descriptors, file watchers must be cleaned up before serialization.
+3. **No `AsyncLocalStorage`**: Cannot be serialized -- must be deferred to deserialize callback (already handled in `@eggjs/koa`).
+4. **`process.env` and `process.argv` refresh**: These are updated to runtime values during deserialization -- config that reads `process.env` at build time will be stale unless re-read.
+5. **Cannot re-snapshot**: A deserialized app cannot build another snapshot.
+6. **Built-in module subset**: Not all Node.js built-in modules serialize correctly. Known safe: `fs`, `path`, `util`, `url`, `assert`, `buffer`, `crypto`, `zlib`. Potentially problematic: `http` (if server created), `net`, `dgram`.
+
+### Lifecycle
+
+```
+BUILD PHASE:
+  1. node --snapshot-blob snap.blob --build-snapshot entry.js
+  2. entry.js executes: loads modules, builds app state
+  3. addSerializeCallback()s run: cleanup handles
+  4. V8 serializes heap to snap.blob
+  5. Process exits
+
+RESTORE PHASE:
+  1. node --snapshot-blob snap.blob [optional-entry.js]
+  2. V8 deserializes heap from snap.blob
+  3. process.env / process.argv refreshed to runtime values
+  4. addDeserializeCallback()s run: restore resources
+  5. setDeserializeMainFunction() callback runs: start app
+```
+
+## Architecture
+
+### What Gets Captured in the Snapshot
+
+These are **I/O-heavy or compute-heavy** operations that happen once and produce deterministic results:
+
+| Component               | What's Captured                                                         | Package              |
+| ----------------------- | ----------------------------------------------------------------------- | -------------------- |
+| Module require cache    | All `require()`/`import()` calls for framework, plugins, app code       | Node.js built-in     |
+| Plugin resolution       | Plugin paths, ordering (`loader.orderPlugins`)                          | `@eggjs/core`        |
+| Config parsing          | Merged config from all layers (plugin + framework + app + env-specific) | `@eggjs/core`        |
+| Extend loading          | Application/Request/Response/Context/Helper extensions                  | `@eggjs/core`        |
+| Middleware classes      | Middleware factory functions loaded from disk                           | `packages/egg`       |
+| Controller classes      | Controller classes loaded and bound                                     | `packages/egg`       |
+| Service classes         | Service class definitions (lazy-instantiated per request)               | `packages/egg`       |
+| Router definition       | Route table compiled from `app/router.ts`                               | `packages/egg`       |
+| Tegg GlobalGraph        | Module descriptors, dependency graph, topological sort                  | `tegg/core/metadata` |
+| Tegg prototype metadata | Decorator metadata, inject mappings, qualifier resolutions              | `tegg/core/metadata` |
+
+### What Must Be Deferred to Runtime
+
+These resources are either **environment-dependent** or **non-serializable**:
+
+| Resource                             | Why Deferred                            | Restore Strategy                                   |
+| ------------------------------------ | --------------------------------------- | -------------------------------------------------- |
+| `AsyncLocalStorage`                  | Cannot serialize                        | `addDeserializeCallback` (already in `@eggjs/koa`) |
+| Loggers (file handles)               | Open FDs                                | Re-create in deserialize callback                  |
+| `server.listen()`                    | Network socket                          | Called in `setDeserializeMainFunction`             |
+| Agent keepalive timer                | `setInterval`                           | Re-create in deserialize callback                  |
+| `process.on('unhandledRejection')`   | Process listener                        | Re-register in deserialize callback                |
+| Timeout timer (`#setupTimeoutTimer`) | `setTimeout`                            | Skip or re-create at runtime                       |
+| `cluster-client` connections         | Network socket                          | Defer creation to runtime                          |
+| `process.env` reads                  | Values change between build and runtime | Re-read config env overrides in deserialize        |
+| DB/Redis connections                 | Network handles                         | Plugins defer connections to `serverDidReady`      |
+| File watchers (development plugin)   | FD handles                              | Not relevant in prod                               |
+| `egg-ready` messenger event          | Tied to runtime lifecycle               | Fire in deserialize main function                  |
+
+### Bundling Decision
+
+**Full single-file bundling of egg is NOT feasible.** Egg relies on runtime filesystem scanning (`globby.sync`) and dynamic `import()` for controllers, services, plugins, and config files. A bundler cannot follow these dynamic patterns.
+
+**Approach: Run egg's full loader during snapshot build.** The `snapshot-build.mjs` entry script calls `startEgg()` which runs the entire loader (filesystem scanning, dynamic imports, plugin resolution, config merging, etc.). The resulting fully-initialized app state is captured in the V8 heap snapshot. On restore, the loader does NOT run again -- everything is already in memory.
+
+This means:
+
+- No utoo/esbuild bundle step needed
+- The snapshot build machine needs the full app source and `node_modules`
+- The snapshot blob captures all loaded modules in the V8 heap
+- utoo bundling is an **optional optimization** to speed up module resolution during the build phase itself
+
+### Architecture Diagram
+
+```
+                    BUILD TIME                          RUNTIME
+                    ==========                          =======
+
+  ┌──────────────────────┐
+  │  User App (source)   │
+  │  + node_modules      │
+  │  + config/           │
+  │  + app/              │
+  └──────────┬───────────┘
+             │
+             ▼
+  ┌───────────────────────┐
+  │  snapshot-build.mjs   │
+  │                       │
+  │  1. startEgg(options) │  ← Full loader runs: filesystem scan,
+  │     ├─ new Agent()    │    dynamic imports, plugin resolution,
+  │     │  └─ loadConfig  │    config merging, etc.
+  │     │  └─ load        │
+  │     ├─ new Application│
+  │     │  └─ loadConfig  │
+  │     │  └─ load        │
+  │     │    ├─ extends   │
+  │     │    ├─ services  │
+  │     │    ├─ middleware │
+  │     │    ├─ controller │
+  │     │    └─ router    │
+  │     └─ await ready()  │
+  │                       │
+  │  2. Serialize cleanup:│
+  │     ├─ Close loggers  │
+  │     ├─ Clear timers   │
+  │     ├─ Null ALS       │
+  │     └─ Close messenger│
+  │                       │
+  │  3. Set main function:│
+  │     → restore & listen│
+  └───────────┬───────────┘
+              │
+    node --build-snapshot
+              │
+              ▼
+       snapshot.blob          ← Contains entire V8 heap:
+              │                  all modules, config, metadata,
+    node --snapshot-blob         middleware chain, router, etc.
+              │
+              ▼
+  ┌──────────────────┐
+  │  Deserialize     │        ← NO loader runs, NO filesystem scan,
+  │                  │          NO dynamic imports
+  │  1. Restore ALS  │
+  │  2. Reopen logs  │
+  │  3. Re-read env  │
+  │  4. Restart timer│
+  │  5. http.listen()│
+  │  6. egg-ready    │
+  └──────────────────┘
+```
+
+## Module-by-Module Changes
+
+### 1. `packages/koa` -- AsyncLocalStorage Deferral
+
+**Status: ALREADY DONE**
+
+The `@eggjs/koa` package already has snapshot support (similar to koajs/koa#1946):
+
+- `ctxStorage` set to `null` during `isBuildingSnapshot()`
+- `addDeserializeCallback` restores `ctxStorage` with `getAsyncLocalStorage()`
+- `callback()` already handles `ctxStorage === null` gracefully
+- Type: `ctxStorage: AsyncLocalStorage<Context> | null`
+
+**No changes needed.**
+
+### 2. `packages/egg` -- Core Framework Snapshot Awareness
+
+**Files to modify:**
+
+#### `packages/egg/src/lib/egg.ts` (EggApplicationCore)
+
+Add snapshot awareness to the constructor and load process:
+
+- **Loggers**: During snapshot build, create loggers normally but register a serialize callback to close all log file handles, and a deserialize callback to re-create them.
+- **Timeout timer** (`#setupTimeoutTimer`): Skip during snapshot build (no timeout needed for build phase). Re-register on deserialize.
+- **`process.on('unhandledRejection')`**: Register in deserialize callback instead of during load.
+- **Config env re-read**: Add a deserialize callback that re-reads `process.env.EGG_APP_CONFIG` and merges runtime env overrides.
+
+Add a new method:
+
+```typescript
+/**
+ * Register snapshot serialize/deserialize callbacks.
+ * Called at end of load() when isBuildingSnapshot() is true.
+ */
+protected registerSnapshotCallbacks(): void {
+  const v8 = require('node:v8');
+
+  // Serialize: cleanup non-serializable resources
+  v8.startupSnapshot.addSerializeCallback((app) => {
+    // Close all loggers (file handles)
+    for (const logger of app.loggers.values()) {
+      logger.close();
+    }
+    // Clear timeout timer (if any)
+    // Close messenger
+    app.messenger.close();
+  }, this);
+
+  // Deserialize: restore resources
+  v8.startupSnapshot.addDeserializeCallback((app) => {
+    // Re-create loggers with runtime config
+    app.#loggers = createLoggers(app);
+    // Re-register unhandledRejection handler
+    process.on('unhandledRejection', app._unhandledRejectionHandler);
+    // Re-create messenger
+    app.messenger = createMessenger(app);
+    // Re-read env config overrides
+    app.#reloadEnvConfig();
+  }, this);
+}
+```
+
+#### `packages/egg/src/lib/agent.ts` (Agent)
+
+- **`#agentAliveHandler` setInterval**: Must be cleared in serialize callback and re-created in deserialize callback.
+
+#### `packages/egg/src/lib/application.ts` (Application)
+
+- **`#bindEvents`**: The `cookieLimitExceed` and `server` event listeners are set up during `load()`. These are EventEmitter listeners (serializable), but the `server` event should fire at runtime. No change needed -- listeners survive snapshot.
+- **`onServer`**: Called at runtime when server is created. No change needed.
+
+#### `packages/egg/src/lib/start.ts` (startEgg)
+
+Add a new export for snapshot-aware startup:
+
+```typescript
+/**
+ * Build snapshot: initialize app fully, then register snapshot callbacks.
+ * Called by snapshot-builder.mjs during --build-snapshot.
+ */
+export async function buildSnapshot(options: StartEggOptions): Promise<SingleModeApplication> {
+  const app = await startEgg(options);
+  app.registerSnapshotCallbacks();
+  app.agent.registerSnapshotCallbacks();
+  return app;
+}
+```
+
+### 3. `packages/core` -- Lifecycle and Loader
+
+#### `packages/core/src/lifecycle.ts`
+
+- **`#initReady` / `loadReady` / `bootReady`**: These are `Ready` instances used during startup. After `ready()` resolves, they are inert. They should survive snapshot fine.
+- **Timing**: Timing data from build phase should be discarded on restore. Add deserialize callback to reset timing.
+
+#### `packages/core/src/loader/egg_loader.ts`
+
+- **`process.env` reads**: `getServerEnv()` reads `process.env.EGG_SERVER_ENV` and `process.env.NODE_ENV`. These values are baked into the snapshot at build time. If the runtime env differs, config will be wrong.
+  - **Solution**: In the deserialize callback, allow an env override mechanism. For the initial POC, require that build-time and runtime env match (document this constraint). Future: add env-aware config reload.
+
+- **File system reads**: All `fs.existsSync`, `readJSONSync`, `readJSON` calls happen during `loadConfig()` and `load()`. These complete before snapshot is taken. No issue.
+
+### 4. `tools/scripts` -- egg-scripts Commands
+
+#### New command: `snapshot-build`
+
+Add `tools/scripts/src/commands/snapshot-build.ts`:
+
+```
+egg-scripts snapshot-build [--baseDir] [--framework] [--env]
+```
+
+This command:
+
+1. Runs `utoo bundle` to produce a single-file bundle of the app
+2. Spawns `node --snapshot-blob snapshot.blob --build-snapshot scripts/snapshot-builder.mjs`
+3. Outputs `snapshot.blob` in the app directory
+
+#### New script: `scripts/snapshot-builder.mjs`
+
+The snapshot build entry point:
+
+```javascript
+import v8 from 'node:v8';
+
+// Import the bundled app (single file)
+const options = JSON.parse(process.argv[2]);
+const framework = await import(options.framework);
+const buildSnapshot = framework.buildSnapshot ?? framework.default?.buildSnapshot;
+
+const app = await buildSnapshot({
+  baseDir: options.baseDir,
+  framework: options.framework,
+  env: options.env,
+  mode: 'single',
+});
+
+// Set the main function for restore
+v8.startupSnapshot.setDeserializeMainFunction((app) => {
+  const http = require('node:http');
+  const port = process.env.PORT || 7001;
+  const server = http.createServer(app.callback());
+  app.emit('server', server);
+  server.listen(port, () => {
+    console.log(`Server started on port ${port}`);
+    if (process.send) {
+      process.send({ action: 'egg-ready', data: { port } });
+    }
+  });
+  app.messenger.broadcast('egg-ready');
+}, app);
+```
+
+#### Modified command: `start` with `--snapshot` flag
+
+Add `--snapshot` flag to `tools/scripts/src/commands/start.ts`:
+
+```
+egg-scripts start --single --snapshot [--snapshot-blob=snapshot.blob]
+```
+
+When `--snapshot` is set:
+
+- Uses `scripts/start-snapshot.mjs` instead of `start-single.mjs`
+- Passes `--snapshot-blob=snapshot.blob` to the node process
+- No additional entry script needed (main function is in the snapshot)
+
+#### New script: `scripts/start-snapshot.mjs`
+
+Minimal -- just launches node with `--snapshot-blob`:
+
+```javascript
+// This script is spawned by egg-scripts start --snapshot
+// Node.js automatically runs setDeserializeMainFunction from the snapshot
+// Nothing needed here -- the snapshot blob contains the entry point
+```
+
+Actually, since `setDeserializeMainFunction` is in the snapshot, the start command just needs to spawn:
+
+```bash
+node --snapshot-blob snapshot.blob
+```
+
+### 5. `tegg/` -- Metadata Pre-computation
+
+#### `tegg/plugin/tegg/src/app.ts` (TeggAppBoot)
+
+The tegg plugin's startup flow in `didLoad()`:
+
+1. `EggModuleLoader.load()` → scans filesystem, dynamic imports, builds GlobalGraph
+2. `LoadUnitInstanceFactory.createLoadUnitInstance()` → instantiates singletons
+
+For snapshot:
+
+- **Step 1** completes during snapshot build. GlobalGraph, module descriptors, prototype metadata all live in memory and are serializable (plain objects, Maps, Sets).
+- **Step 2** creates singleton instances. These are also in-heap objects that should survive snapshot, **unless** they hold non-serializable resources (DB connections, etc.).
+
+**Key change**: Singletons that connect to external services (Redis, DB) typically do so in `@LifecycleInit` or `serverDidReady`. If they create connections during `didLoad`/`willReady`, those connections must be closed in serialize callback and reopened in deserialize callback.
+
+**Approach**: Add snapshot hooks to `ModuleHandler`:
+
+```typescript
+if (v8.startupSnapshot?.isBuildingSnapshot?.()) {
+  v8.startupSnapshot.addSerializeCallback(() => {
+    // Close any singleton connections
+    // GlobalGraph and metadata stay in memory (serializable)
+  });
+  v8.startupSnapshot.addDeserializeCallback(() => {
+    // Re-initialize singletons that need runtime resources
+    // Re-register lifecycle hooks if needed
+  });
+}
+```
+
+### 6. Bundling (NOT required)
+
+**Key finding**: Full single-file bundling of egg is **not feasible** because egg relies on runtime filesystem scanning (`globby.sync`) and dynamic `import()` for controllers, services, plugins, and config. A bundler cannot follow these dynamic patterns.
+
+**Instead**: The `snapshot-build.mjs` entry script is a small (~30 line) file that calls `startEgg()`. Egg's full loader runs during the snapshot build phase, dynamically importing all modules from disk. The V8 snapshot captures the entire heap including all loaded modules, so no bundling is needed.
+
+**Optional optimization**: utoo could bundle static framework dependencies (egg, core, koa, plugins) into a single file to speed up the initial module resolution during the snapshot build phase itself. But this is an optimization, not a requirement. See `docs/utoo-bundling.md` for details.
+
+## Snapshot Build Flow
+
+```
+1. Developer runs: eggctl build-snapshot --env prod
+
+2. egg-scripts:
+   a. Resolves baseDir, framework, env
+   b. Spawns: node --snapshot-blob snapshot.blob \
+                   --build-snapshot snapshot-build.mjs \
+                   -- '{"baseDir":"...","framework":"...","env":"prod"}'
+   (No bundling step -- egg's full loader runs during snapshot build)
+
+3. snapshot-build.mjs:
+   a. Imports framework (egg) via dynamic import
+   b. Calls startEgg(options) — full loader runs:
+      - Filesystem scanning (globby), dynamic imports
+      - Creates Agent, loads config + plugins
+      - Creates Application, loads config + plugins + extends + services + middleware + controllers + router
+      - Tegg: scans modules, builds GlobalGraph, instantiates singletons
+      - Awaits ready()
+   c. Creates HTTP server (no listen) and wires app.callback()
+   d. Registers serialize callbacks (cleanup handles: loggers, timers, messenger)
+   e. Registers deserialize callbacks (restore: ALS, loggers, messenger)
+   f. Calls setDeserializeMainFunction (the runtime entry that calls server.listen)
+
+4. Node.js:
+   a. Runs serialize callbacks
+   b. Serializes entire V8 heap to snapshot.blob (includes all loaded modules)
+   c. Exits
+```
+
+## Snapshot Restore/Startup Flow
+
+```
+1. Production start: eggctl start --snapshot-blob snapshot.blob
+
+2. egg-scripts:
+   a. Spawns: node --snapshot-blob snapshot.blob
+   b. Sets runtime env vars: PORT, EGG_SERVER_TITLE, etc.
+
+3. Node.js:
+   a. Deserializes V8 heap from snapshot.blob
+      (NO loader runs, NO filesystem scan, NO dynamic imports)
+   b. Refreshes process.env and process.argv to runtime values
+   c. Runs deserialize callbacks (in order registered):
+      - Koa: restores AsyncLocalStorage
+      - Egg: re-creates loggers, messenger, re-reads env config
+      - Agent: re-creates keepalive timer
+      - Tegg: re-initializes runtime resources
+   d. Runs setDeserializeMainFunction:
+      - Reads PORT from process.env (runtime value, not build-time)
+      - Calls server.listen(port)
+      - Emits 'server' event
+      - Broadcasts 'egg-ready'
+
+4. Server is ready to accept requests
+   (Startup time: ~10-50ms instead of ~500-2000ms)
+```
+
+## Constraints and Limitations
+
+1. **Single process mode only**: Snapshots work with `--single` mode. Cluster mode (master + workers) is not supported because each worker would need its own snapshot, and the master process manages worker lifecycle.
+
+2. **Build env must match runtime env**: The config loaded during snapshot build is for a specific `EGG_SERVER_ENV`. Running a `prod`-built snapshot with `unittest` env will not work correctly. (Future: add env-aware config reload.)
+
+3. **Full source required at build time**: The snapshot build machine needs the full app source and `node_modules` because egg's loader runs during the build. The snapshot blob is self-contained for runtime.
+
+4. **Plugin compatibility**: Plugins that create non-serializable resources during `configDidLoad`/`didLoad`/`willReady` (before `serverDidReady`) must be made snapshot-aware. Most well-behaved plugins defer connections to `serverDidReady`.
+
+5. **No hot reload**: Snapshot contains compiled code. Code changes require rebuilding the snapshot.
+
+6. **Snapshot size**: The blob may be 50-200MB depending on app complexity. This is a one-time cost and still faster than parsing/compiling from source.
+
+## PR Split Plan
+
+### PR 1: `packages/koa` snapshot support
+
+**Status: ALREADY DONE** -- `@eggjs/koa` already has snapshot awareness.
+
+### PR 2: `packages/egg` snapshot awareness
+
+- Add `v8.startupSnapshot` integration to `EggApplicationCore`
+- Add serialize/deserialize callbacks for loggers, timers, messenger
+- Add `buildSnapshot()` export to `start.ts`
+- Add `registerSnapshotCallbacks()` to `EggApplicationCore`, `Agent`, `Application`
+- Tests: unit tests verifying callbacks are registered during `isBuildingSnapshot()`
+
+### PR 3: `tools/scripts` snapshot commands
+
+- Add `snapshot-build` command
+- Add `--snapshot` flag to `start` command
+- Add `scripts/snapshot-builder.mjs` and `scripts/start-snapshot.mjs`
+- Update `stop` command to find snapshot processes
+- Tests: E2E tests with a fixture app
+
+### PR 4: `tegg/` snapshot support
+
+- Add snapshot hooks to `TeggAppBoot` / `ModuleHandler`
+- Ensure GlobalGraph and metadata survive serialization
+- Handle singleton lifecycle across snapshot boundary
+- Tests: tegg-plugin tests with snapshot build/restore
+
+### PR 5: E2E tests and CI
+
+- GitHub Actions workflow for snapshot build + start + verify
+- Benchmark: measure startup time with and without snapshot
+- Integration test with a realistic egg app (controllers, services, plugins)
+
+## Open Questions
+
+1. **Config reload on restore**: Should we fully reload config from disk on deserialize, or just merge `process.env` overrides? Full reload is safer but negates some snapshot benefits.
+
+2. **Tegg singleton lifecycle**: How to handle singletons that need `@LifecycleInit` re-execution on restore? Need to identify which lifecycle hooks should re-run.
+
+3. **Bundle strategy for plugins**: Should plugins be bundled into the main entry, or loaded as separate chunks? Single bundle is simpler but may hit esbuild limitations with dynamic imports.
+
+4. **Snapshot portability**: Should we support building on CI and deploying to different machines? This requires `--build-snapshot-config` with `withoutCodeCache: true` for cross-platform compatibility.

--- a/docs/snapshot-test-plan.md
+++ b/docs/snapshot-test-plan.md
@@ -1,0 +1,408 @@
+# Egg.js Startup Snapshot - Test Plan
+
+## Overview
+
+This document describes the test strategy for the Node.js V8 startup snapshot feature in Egg.js. The snapshot feature allows pre-compiling the framework into a V8 snapshot blob, drastically reducing cold-start time for production deployments.
+
+### Feature Flow
+
+```
+Build Phase:    bundle app → node --build-snapshot build-snapshot.mjs → egg-snapshot.blob
+Runtime Phase:  node --snapshot-blob=egg-snapshot.blob → app starts with pre-compiled framework
+```
+
+### Dependencies
+
+- Node.js >= 22 (V8 startup snapshot support)
+- `--build-snapshot` / `--snapshot-blob` Node.js flags
+- Single process mode (`--single` flag in egg-scripts)
+
+---
+
+## 1. Unit Tests
+
+### 1.1 egg-scripts: Single Mode Start/Stop
+
+**File:** `tools/scripts/test/start-single.test.ts`
+
+| #   | Test Case                   | Description                                                                          |
+| --- | --------------------------- | ------------------------------------------------------------------------------------ |
+| 1   | Start app in single mode    | `eggctl start --single --port=<port>` starts successfully, sends `egg-ready` message |
+| 2   | Serve HTTP requests         | App started in single mode responds to HTTP requests correctly                       |
+| 3   | Graceful shutdown (SIGTERM) | Sending SIGTERM to single-mode process triggers graceful shutdown                    |
+| 4   | Graceful shutdown (SIGINT)  | Sending SIGINT to single-mode process triggers graceful shutdown                     |
+| 5   | Port configuration          | `--port` flag is respected in single mode                                            |
+| 6   | Daemon mode with single     | `--single --daemon` starts in background, detaches correctly                         |
+| 7   | Workers flag ignored        | `--workers` flag is silently ignored in single mode                                  |
+| 8   | Custom framework            | Single mode works with custom framework path                                         |
+
+**Test Pattern:**
+
+```typescript
+// Uses coffee to spawn eggctl process, detect-port for dynamic ports,
+// urllib to verify HTTP responses
+import coffee from 'coffee';
+import { detectPort } from 'detect-port';
+import { request } from 'urllib';
+
+it('should start app in single mode', async () => {
+  const port = await detectPort();
+  await coffee
+    .fork(eggBin, ['start', '--single', `--port=${port}`, fixturePath])
+    .expect('stdout', /single process mode/)
+    .expect('code', 0)
+    .end();
+  const result = await request(`http://127.0.0.1:${port}`);
+  assert.equal(result.status, 200);
+});
+```
+
+### 1.2 egg-scripts: Snapshot Build Command
+
+**File:** `tools/scripts/test/snapshot-build.test.ts`
+
+| #   | Test Case                    | Description                                                               |
+| --- | ---------------------------- | ------------------------------------------------------------------------- |
+| 1   | Build snapshot blob          | `eggctl start --single --build-snapshot` creates `egg-snapshot.blob` file |
+| 2   | Snapshot blob is valid       | Generated blob file is non-empty and has expected binary header           |
+| 3   | Build requires --single      | `--build-snapshot` without `--single` exits with error                    |
+| 4   | Build exits after completion | Process exits with code 0 after building snapshot (does not start server) |
+| 5   | Custom blob path             | `--snapshot-blob=custom.blob --build-snapshot` writes to specified path   |
+
+### 1.3 egg Lifecycle: Metadata-Only Mode
+
+**File:** `packages/egg/test/snapshot-lifecycle.test.ts`
+
+| #   | Test Case                 | Description                                                                                     |
+| --- | ------------------------- | ----------------------------------------------------------------------------------------------- |
+| 1   | Metadata-only loading     | When `snapshotMode: 'build'` is set, framework loads plugins/config but does not start services |
+| 2   | Serializable state        | After metadata-only loading, framework state can be captured by V8 snapshot                     |
+| 3   | No server listening       | In snapshot build mode, no HTTP server is created                                               |
+| 4   | Restore completes startup | After snapshot restore, remaining lifecycle phases execute and app becomes ready                |
+
+### 1.4 Koa: Snapshot Serialize/Deserialize Round-Trip
+
+**File:** `packages/koa/test/snapshot.test.ts`
+
+| #   | Test Case                    | Description                                                              |
+| --- | ---------------------------- | ------------------------------------------------------------------------ |
+| 1   | Koa app survives snapshot    | Koa instance created before snapshot can handle requests after restore   |
+| 2   | Middleware chain preserved   | Middleware registered before snapshot fires correctly after restore      |
+| 3   | Context extensions preserved | Custom context properties survive snapshot round-trip                    |
+| 4   | No active handles leak       | Koa app in snapshot mode doesn't hold active handles that block snapshot |
+
+---
+
+## 2. Integration Tests
+
+### 2.1 Full Snapshot Workflow
+
+**File:** `tools/scripts/test/snapshot-integration.test.ts`
+
+These tests use the `helloworld-typescript` example or a dedicated fixture app.
+
+| #   | Test Case                        | Description                                                                |
+| --- | -------------------------------- | -------------------------------------------------------------------------- |
+| 1   | Build snapshot of example app    | Build snapshot blob from helloworld-typescript, verify blob file created   |
+| 2   | Start app from snapshot          | Start app using `--snapshot-blob=egg-snapshot.blob`, verify it serves HTTP |
+| 3   | Response correctness             | App started from snapshot returns same response as cold-started app        |
+| 4   | Graceful shutdown from snapshot  | App started from snapshot handles SIGTERM gracefully                       |
+| 5   | Startup time comparison          | Snapshot startup is measurably faster than cold start (>30% improvement)   |
+| 6   | Multiple restarts from same blob | Same snapshot blob can be used to start the app multiple times             |
+
+**Test Pattern:**
+
+```typescript
+describe('snapshot integration', () => {
+  const fixturePath = path.join(__dirname, 'fixtures/snapshot-app');
+  let blobPath: string;
+
+  beforeAll(async () => {
+    blobPath = path.join(fixturePath, 'egg-snapshot.blob');
+    // Step 1: Build the snapshot
+    await coffee
+      .fork(eggBin, ['start', '--single', '--build-snapshot', fixturePath])
+      .expect('code', 0)
+      .end();
+    assert(await exists(blobPath), 'snapshot blob should be created');
+  });
+
+  afterAll(async () => {
+    await cleanup(fixturePath);
+    await fs.rm(blobPath, { force: true });
+  });
+
+  it('should start from snapshot and serve requests', async () => {
+    const port = await detectPort();
+    // Start with snapshot
+    const child = spawn('node', [
+      `--snapshot-blob=${blobPath}`,
+      startSingleBin,
+      JSON.stringify({ baseDir: fixturePath, port, framework: 'egg' }),
+    ]);
+
+    // Wait for ready
+    await waitForReady(child);
+
+    const result = await request(`http://127.0.0.1:${port}`);
+    assert.equal(result.status, 200);
+
+    // Cleanup
+    child.kill('SIGTERM');
+  });
+
+  it('should start faster from snapshot than cold start', async () => {
+    const port1 = await detectPort();
+    const port2 = await detectPort(port1 + 1);
+
+    // Cold start timing
+    const coldStart = Date.now();
+    const cold = await startAndWait(fixturePath, port1, { snapshot: false });
+    const coldTime = Date.now() - coldStart;
+    cold.kill('SIGTERM');
+
+    // Snapshot start timing
+    const snapStart = Date.now();
+    const snap = await startAndWait(fixturePath, port2, { snapshot: blobPath });
+    const snapTime = Date.now() - snapStart;
+    snap.kill('SIGTERM');
+
+    console.log(`Cold start: ${coldTime}ms, Snapshot start: ${snapTime}ms`);
+    console.log(`Speedup: ${((1 - snapTime / coldTime) * 100).toFixed(1)}%`);
+
+    // Snapshot should be at least 30% faster
+    assert(snapTime < coldTime * 0.7,
+      `Snapshot (${snapTime}ms) should be >30% faster than cold (${coldTime}ms)`);
+  });
+});
+```
+
+### 2.2 Snapshot Fixture App
+
+Create a minimal fixture app at `tools/scripts/test/fixtures/snapshot-app/` that:
+
+- Has a simple controller returning JSON with timestamp
+- Has minimal config (port, keys)
+- Uses the egg framework from workspace
+- Can be built into a snapshot and started from it
+
+**Structure:**
+
+```
+tools/scripts/test/fixtures/snapshot-app/
+  ├── app/
+  │   ├── controller/
+  │   │   └── home.ts
+  │   └── router.ts
+  ├── config/
+  │   └── config.default.ts
+  └── package.json
+```
+
+---
+
+## 3. E2E Tests for CI
+
+### 3.1 GitHub Actions Workflow
+
+**File:** `.github/workflows/ci.yml` (new job added)
+
+Add a `test-snapshot` job to the existing CI workflow:
+
+```yaml
+test-snapshot:
+  name: Test snapshot (ubuntu, ${{ matrix.node }})
+  runs-on: ubuntu-latest
+  strategy:
+    fail-fast: false
+    matrix:
+      node: ['22', '24']
+
+  concurrency:
+    group: test-snapshot-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-${{ matrix.node }}
+    cancel-in-progress: true
+
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      with:
+        node-version: ${{ matrix.node }}
+        cache: 'pnpm'
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Build all packages
+      run: pnpm build
+
+    - name: Run snapshot tests
+      run: |
+        pnpm run --filter=./tools/scripts test -- --testPathPattern=snapshot
+      env:
+        NODE_OPTIONS: '--max-old-space-size=4096'
+
+    - name: Upload snapshot blob (for debugging)
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: snapshot-blob-${{ matrix.node }}
+        path: tools/scripts/test/fixtures/snapshot-app/egg-snapshot.blob
+        retention-days: 3
+```
+
+### 3.2 Design Decisions
+
+**Why add to `ci.yml` instead of a separate workflow?**
+
+- The existing CI already has dedicated jobs for `test-egg-scripts` which is the closest related test suite
+- Adding a `test-snapshot` job keeps all CI in one workflow with the shared `done` gate job
+- Snapshot tests only need Node.js 22+ (no need for Node 20 matrix entry)
+- No external services (Redis/MySQL) needed — simpler than E2E
+
+**Why Ubuntu-only?**
+
+- V8 snapshot blobs are platform-specific (cannot cross-compile)
+- Snapshot support is most stable on Linux
+- macOS/Windows support can be added later once Linux is proven
+- This matches `test-egg-scripts` which is also Ubuntu-only
+
+**Why Node.js 22 and 24?**
+
+- Node.js 22 is the minimum version with stable startup snapshot support
+- Node.js 24 tests forward compatibility
+- Node.js 20 does not have mature snapshot support
+
+### 3.3 `done` Job Update
+
+The `done` job must include `test-snapshot` in its `needs` array:
+
+```yaml
+done:
+  runs-on: ubuntu-latest
+  needs:
+    - test
+    - test-egg-bin
+    - test-egg-scripts
+    - test-snapshot    # <-- add this
+    - typecheck
+```
+
+---
+
+## 4. Test Utilities
+
+### 4.1 Helper Functions
+
+Add to `tools/scripts/test/utils.ts`:
+
+```typescript
+/**
+ * Wait for a child process to emit 'egg-ready' via IPC message.
+ * Times out after `timeoutMs` (default 30s).
+ */
+export function waitForReady(child: ChildProcess, timeoutMs = 30000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for egg-ready after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on('message', (msg: any) => {
+      if (msg?.action === 'egg-ready') {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`Process exited with code ${code}`));
+      }
+    });
+  });
+}
+
+/**
+ * Measure startup time: spawn process and wait for egg-ready.
+ * Returns elapsed milliseconds and the ChildProcess.
+ */
+export async function measureStartup(
+  eggBin: string,
+  args: string[],
+  options: SpawnOptions,
+): Promise<{ elapsed: number; child: ChildProcess }> {
+  const start = Date.now();
+  const child = spawn('node', args, { ...options, stdio: ['ignore', 'pipe', 'pipe', 'ipc'] });
+  await waitForReady(child);
+  return { elapsed: Date.now() - start, child };
+}
+```
+
+---
+
+## 5. Test Matrix Summary
+
+| Category             | File                                              | Tests  | Node.js | OS     | Services |
+| -------------------- | ------------------------------------------------- | ------ | ------- | ------ | -------- |
+| Unit: single mode    | `tools/scripts/test/start-single.test.ts`         | 8      | 22, 24  | ubuntu | none     |
+| Unit: snapshot build | `tools/scripts/test/snapshot-build.test.ts`       | 5      | 22, 24  | ubuntu | none     |
+| Unit: lifecycle      | `packages/egg/test/snapshot-lifecycle.test.ts`    | 4      | 22, 24  | all    | none     |
+| Unit: koa snapshot   | `packages/koa/test/snapshot.test.ts`              | 4      | 22, 24  | all    | none     |
+| Integration          | `tools/scripts/test/snapshot-integration.test.ts` | 6      | 22, 24  | ubuntu | none     |
+| **Total**            |                                                   | **27** |         |        |          |
+
+---
+
+## 6. Implementation Order
+
+1. **Phase 1 (now):** Write this test plan, design CI workflow
+2. **Phase 2 (after tasks #3, #4 complete):** Implement snapshot-build and start-single unit tests
+3. **Phase 3 (after tasks #5, #6 complete):** Implement lifecycle and koa snapshot unit tests
+4. **Phase 4 (all tasks done):** Implement integration tests with timing comparison
+5. **Phase 5:** Add `test-snapshot` job to CI workflow
+
+---
+
+## 7. Fixture App Requirements
+
+The snapshot test fixture app needs to be:
+
+- **Minimal:** Only a home controller returning JSON, to isolate snapshot behavior
+- **Self-contained:** No database, Redis, or external service dependencies
+- **Deterministic:** Response includes a marker proving the snapshot was used (e.g., a build timestamp baked into the snapshot vs. runtime timestamp)
+- **Fast:** Small dependency tree to keep snapshot build times reasonable in CI
+
+Example controller:
+
+```typescript
+// app/controller/home.ts
+import { Controller } from 'egg';
+
+export default class HomeController extends Controller {
+  async index(): Promise<void> {
+    this.ctx.body = {
+      message: 'Hello from Egg.js',
+      pid: process.pid,
+      uptime: process.uptime(),
+    };
+  }
+}
+```
+
+---
+
+## 8. Risk and Mitigation
+
+| Risk                                    | Impact                                           | Mitigation                                                    |
+| --------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
+| Snapshot blob is platform-specific      | CI tests pass on Linux but fail locally on macOS | Document platform limitation; don't commit blobs              |
+| V8 snapshot API is experimental         | API may change between Node.js versions          | Pin minimum Node.js 22; test on 22 and 24                     |
+| Timing tests are flaky                  | CI machines have variable performance            | Use relative comparison (>30% faster) not absolute thresholds |
+| Snapshot build takes too long           | CI timeout                                       | Set generous timeout (120s); cache if needed                  |
+| Snapshot incompatible with some plugins | Plugins with native bindings may fail            | Test with minimal plugin set first; document limitations      |

--- a/docs/utoo-bundling.md
+++ b/docs/utoo-bundling.md
@@ -1,0 +1,346 @@
+# Utoo Bundling for Egg Projects
+
+## Overview of Utoo
+
+[Utoo](https://github.com/utooland/utoo) (`ut` CLI, v1.0.8) is a unified frontend toolchain with three core components:
+
+1. **Package Manager** (`ut install`) - Rust-based npm-compatible dependency resolver
+2. **Bundler** (`@utoo/pack` / `up build`) - Powered by **Turbopack** (from Next.js/Vercel)
+3. **Web Version** (`@utoo/web`) - WASM-based browser variant
+
+The bundler is the relevant piece for snapshot construction. It uses Turbopack as its core engine, with SWC for TypeScript/JavaScript transformation and NAPI bindings to Node.js.
+
+### CLI Usage
+
+```bash
+# Install @utoo/pack-cli (bundler CLI)
+ut x @utoo/pack-cli -- build --help
+
+# Build a project
+ut x @utoo/pack-cli -- build -p ./my-project
+
+# Or use the `up` alias
+up build
+up build --webpack  # webpack.config.js compatibility mode
+```
+
+### Configuration (`utoopack.json`)
+
+```json
+{
+  "entry": [{ "import": "./src/index.ts", "name": "main" }],
+  "target": "node 22.18",
+  "output": { "path": "./dist", "clean": true },
+  "sourceMaps": true,
+  "optimization": {
+    "moduleIds": "named",
+    "minify": false,
+    "treeShaking": true
+  },
+  "externals": {
+    "some-native-addon": "commonjs some-native-addon"
+  },
+  "define": {
+    "process.env.NODE_ENV": "\"production\""
+  }
+}
+```
+
+### Key Capabilities
+
+| Feature                  | Support                           |
+| ------------------------ | --------------------------------- |
+| TypeScript/TSX           | Yes (via SWC)                     |
+| ESM output               | Yes                               |
+| CommonJS output          | Yes                               |
+| Node.js target           | Yes (`target: "node X.Y"`)        |
+| Tree-shaking             | Yes                               |
+| Code splitting           | Partial                           |
+| Externals                | Yes (commonjs/esm format control) |
+| Source maps              | Yes                               |
+| Webpack compat mode      | Yes (`--webpack` flag)            |
+| Dynamic `require()`      | Limited - static analysis only    |
+| `globby.sync()` patterns | Not supported at bundle time      |
+| Native addons (.node)    | Must be marked as externals       |
+
+---
+
+## Egg Framework Loading Architecture
+
+### How Egg Loads at Runtime
+
+Egg uses a **convention-based, dynamic loading** pattern. The `EggLoader` class (in `@eggjs/core`) discovers and loads files at runtime:
+
+```
+1. loadPlugin()      - Read config/plugin.ts, resolve plugin paths from node_modules
+2. loadConfig()      - Merge config.default + config.{env} from plugins → framework → app
+3. loadExtend()      - Merge app/extend/(context|request|response|application|helper).ts
+4. loadCustomLoader() - User-defined custom loaders
+5. loadService()     - Discover app/service/**/*.ts via globby
+6. loadMiddleware()  - Discover app/middleware/**/*.ts via globby
+7. loadController()  - Discover app/controller/**/*.ts via globby
+8. loadRouter()      - Import app/router.ts and call with app instance
+```
+
+### Critical Dynamic Patterns
+
+#### 1. File Discovery via `globby.sync()`
+
+```typescript
+// packages/core/src/loader/file_loader.ts:196
+const filepaths = globby.sync(files, { cwd: directory });
+```
+
+Controllers, services, and middlewares are discovered by scanning directories at runtime. No static imports exist.
+
+#### 2. Dynamic Import via `importModule()`
+
+```typescript
+// packages/core/src/utils/index.ts:86
+const obj = await importModule(filepath, { importDefaultOnly: true });
+```
+
+Every discovered file is imported dynamically. The bundler cannot trace these imports.
+
+#### 3. Plugin Resolution from `node_modules`
+
+```typescript
+// packages/egg/src/config/plugin.ts
+export default {
+  onerror: { enable: true, package: '@eggjs/onerror' },
+  session: { enable: true, package: '@eggjs/session' },
+  // 13+ built-in plugins...
+};
+```
+
+Plugins resolved dynamically from `node_modules` at startup, each providing their own controllers/services/config/extends.
+
+#### 4. Config as Functions
+
+```typescript
+// Config files can export functions
+export default (appInfo) => ({
+  keys: appInfo.name + '_secret',
+});
+```
+
+Config loading executes functions with runtime app info - not statically analyzable.
+
+#### 5. Multi-Process Architecture
+
+```typescript
+// packages/egg/src/lib/start.ts
+const agent = new AgentClass({ ...options });
+await agent.ready();
+const application = new ApplicationClass({ ...options });
+```
+
+Agent and Application run separately with different loaders (`AgentWorkerLoader` vs `AppWorkerLoader`).
+
+---
+
+## Bundling Analysis
+
+### What Can Be Bundled
+
+1. **Framework code** - `egg`, `@eggjs/core`, `@eggjs/koa`, `@eggjs/utils` - all are static imports
+2. **Plugin packages** - `@eggjs/onerror`, `@eggjs/session`, etc. - statically importable
+3. **Third-party dependencies** - lodash, utility, etc.
+
+### What Cannot Be Bundled (without transformation)
+
+1. **App code** (controllers, services, middleware) - discovered via globby at runtime
+2. **Config files** - loaded dynamically with `importModule()`, executed as functions
+3. **Extend files** - loaded dynamically, merged into prototypes
+4. **Router file** - dynamically imported and called
+5. **Plugin ordering** - computed at runtime via sequencify algorithm
+6. **Native addons** - must remain external
+
+### Root Cause
+
+The fundamental issue is that Egg's loader uses **runtime file system scanning** (`globby.sync`) followed by **dynamic imports** (`importModule`). A bundler performs **static analysis** of import/require statements - it cannot follow these patterns.
+
+---
+
+## Integration Strategy for Snapshot Workflow
+
+### Approach: Two-Phase Bundle
+
+Rather than trying to bundle the entire egg app into a single file (which fights against Egg's architecture), we should use a **two-phase approach**:
+
+#### Phase 1: Bundle Framework Dependencies
+
+Use utoo to bundle all **framework and plugin code** into a single file that can be snapshot-ted:
+
+```json
+{
+  "entry": [{ "import": "./snapshot-entry.ts", "name": "egg-snapshot" }],
+  "target": "node 22.18",
+  "output": { "path": "./dist", "clean": true },
+  "optimization": { "minify": false, "treeShaking": false },
+  "externals": {}
+}
+```
+
+Where `snapshot-entry.ts` explicitly imports all framework code:
+
+```typescript
+// snapshot-entry.ts - Pre-import everything for snapshot
+import 'egg';
+import '@eggjs/core';
+import '@eggjs/koa';
+import '@eggjs/utils';
+// All built-in plugins
+import '@eggjs/onerror';
+import '@eggjs/session';
+import '@eggjs/security';
+// ... etc
+```
+
+**Benefit**: All framework code in a single file = faster `--build-snapshot` construction.
+
+#### Phase 2: App Code Loaded Normally
+
+App-specific code (controllers, services, middleware, config) is loaded normally via Egg's existing loader at runtime. This code is typically small and app-specific.
+
+### Alternative Approach: Snapshot-Aware Loader
+
+Instead of bundling, create a **snapshot-aware loader** that:
+
+1. **At build time**: Run the normal Egg loader, collect the file manifest (which files were loaded, in what order, with what exports)
+2. **Serialize the manifest**: Write a static module map
+3. **At snapshot construction**: Load everything using the pre-computed manifest (no globby needed)
+4. **At runtime restore**: Skip the loading phase entirely, use the pre-initialized state from snapshot
+
+This avoids bundling entirely and works with Egg's existing architecture:
+
+```typescript
+// snapshot-build.ts
+const app = await startEgg({ baseDir: '/app' });
+// All files are loaded, all plugins resolved, all configs merged
+// Now construct the V8 snapshot from this state
+```
+
+### Recommended Approach: Hybrid
+
+1. **Use utoo to bundle framework deps** into a pre-loaded module (Phase 1)
+2. **Use snapshot-aware loader** for app code (Phase 2 alternative)
+3. **Construct V8 snapshot** after both framework and app code are loaded
+
+This maximizes snapshot coverage while respecting Egg's dynamic loading patterns.
+
+---
+
+## Known Issues and Workarounds
+
+### Issue 1: `globby` at Bundle Time
+
+**Problem**: Bundler can't resolve `globby.sync()` calls.
+**Workaround**: Don't bundle the loader. Instead, pre-run the loader and snapshot the result.
+
+### Issue 2: Plugin Inter-Dependencies
+
+**Problem**: Plugins have complex dependency ordering computed by `sequencify()`.
+**Workaround**: Pre-compute plugin order at build time, serialize as static data.
+
+### Issue 3: Config Merging
+
+**Problem**: Configs are deep-merged from multiple sources with env-specific overrides.
+**Workaround**: Pre-merge all configs at build time for the target environment.
+
+### Issue 4: Prototype Extensions
+
+**Problem**: `app/extend/*.ts` files mutate `Context.prototype`, `Application.prototype`, etc.
+**Workaround**: Pre-apply all extensions at build time, include in snapshot.
+
+### Issue 5: Native Addons
+
+**Problem**: Some plugins may use native addons (e.g., `better-sqlite3`).
+**Workaround**: Mark as externals in utoo config. These cannot be snapshot-ted anyway.
+
+### Issue 6: `tsconfig-paths` Runtime Registration
+
+**Problem**: Egg registers `tsconfig-paths` at runtime for TypeScript path resolution.
+**Workaround**: In bundled mode, all paths are already resolved - skip this step.
+
+---
+
+## Utoo Configuration for Egg Framework Bundle
+
+### Minimal Config (`utoopack.json`)
+
+```json
+{
+  "entry": [
+    {
+      "import": "./snapshot-entry.ts",
+      "name": "egg-framework"
+    }
+  ],
+  "target": "node 22.18",
+  "output": {
+    "path": "./dist/snapshot",
+    "clean": true
+  },
+  "sourceMaps": false,
+  "optimization": {
+    "moduleIds": "named",
+    "minify": false,
+    "treeShaking": false
+  },
+  "externals": {
+    "fsevents": "commonjs fsevents",
+    "cpu-features": "commonjs cpu-features"
+  }
+}
+```
+
+**Important settings**:
+
+- `treeShaking: false` - Egg uses many patterns that look unused but are accessed dynamically
+- `minify: false` - Snapshot construction doesn't benefit from minification
+- `target: "node 22.18"` - Match Egg's minimum Node.js requirement
+- Externalize native addons that can't be bundled
+
+### Snapshot Entry File
+
+```typescript
+// snapshot-entry.ts
+// Framework core
+export * from 'egg';
+
+// Built-in plugins (pre-import to include in bundle)
+import '@eggjs/onerror';
+import '@eggjs/session';
+import '@eggjs/security';
+import '@eggjs/static';
+import '@eggjs/development';
+import '@eggjs/watcher';
+import '@eggjs/schedule';
+import '@eggjs/multipart';
+import '@eggjs/i18n';
+import '@eggjs/view';
+import '@eggjs/logrotator';
+import '@eggjs/tracer';
+
+// Key framework dependencies
+import '@eggjs/core';
+import '@eggjs/koa';
+import '@eggjs/router';
+import '@eggjs/utils';
+import '@eggjs/cookies';
+```
+
+---
+
+## Summary
+
+| Aspect                                 | Feasibility      | Notes                                                             |
+| -------------------------------------- | ---------------- | ----------------------------------------------------------------- |
+| Bundle framework code with utoo        | **High**         | Static imports, well-defined dependency tree                      |
+| Bundle app code (controllers/services) | **Low**          | Dynamic loading via globby + importModule                         |
+| Bundle plugin code                     | **Medium**       | Can pre-import but plugin loading logic is dynamic                |
+| Bundle configs                         | **Low**          | Functions, env-specific, deep-merged at runtime                   |
+| Full single-file bundle                | **Not feasible** | Egg's architecture fundamentally relies on runtime file discovery |
+
+**Recommendation**: Use utoo to bundle framework dependencies for faster snapshot construction, but rely on the snapshot-aware loader (not bundling) for app-specific code. The V8 snapshot should capture the fully-initialized application state after all dynamic loading completes.

--- a/packages/core/src/egg.ts
+++ b/packages/core/src/egg.ts
@@ -31,6 +31,12 @@ export interface EggCoreOptions {
   plugins?: any;
   serverScope?: string;
   env?: string;
+  /**
+   * When true, the application loads metadata only (plugins, configs, extensions,
+   * services, controllers) without starting servers, timers, or connections.
+   * Used for V8 startup snapshot construction.
+   */
+  snapshot?: boolean;
 }
 
 export type EggCoreInitOptions = Partial<EggCoreOptions>;
@@ -189,6 +195,7 @@ export class EggCore extends KoaApplication {
       baseDir: options.baseDir,
       app: this,
       logger: this.console,
+      snapshot: options.snapshot,
     });
     this.lifecycle.on('error', (err) => this.emit('error', err));
     this.lifecycle.on('ready_timeout', (id) => this.emit('ready_timeout', id));

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -62,6 +62,12 @@ export interface LifecycleOptions {
   baseDir: string;
   app: EggCore;
   logger: EggConsoleLogger;
+  /**
+   * When true, the lifecycle stops after didLoad phase completes.
+   * willReady, didReady, and serverDidReady hooks are NOT called.
+   * Used for V8 startup snapshot construction.
+   */
+  snapshot?: boolean;
 }
 
 export type FunWithFullPath = Fun & { fullPath?: string };
@@ -110,7 +116,9 @@ export class Lifecycle extends EventEmitter {
     });
 
     this.ready((err) => {
-      this.triggerDidReady(err);
+      if (!this.options.snapshot) {
+        this.triggerDidReady(err);
+      }
       debug('app ready');
       this.timing.end(`${this.options.app.type} Start`);
     });
@@ -340,6 +348,10 @@ export class Lifecycle extends EventEmitter {
       debug('trigger didLoad end');
       if (err) {
         this.ready(err);
+      } else if (this.options.snapshot) {
+        // In snapshot mode, stop after didLoad — skip willReady/didReady/serverDidReady
+        debug('snapshot mode: skipping willReady, marking ready after didLoad');
+        this.ready(true);
       } else {
         this.triggerWillReady();
       }

--- a/packages/egg/src/index.ts
+++ b/packages/egg/src/index.ts
@@ -41,6 +41,9 @@ export type {
 
 export * from './lib/start.ts';
 
+// export snapshot utilities
+export * from './lib/snapshot.ts';
+
 // export singleton
 export { Singleton, type SingletonCreateMethod, type SingletonOptions } from '@eggjs/core';
 

--- a/packages/egg/src/lib/agent.ts
+++ b/packages/egg/src/lib/agent.ts
@@ -1,3 +1,5 @@
+import v8 from 'node:v8';
+
 import type { EggLogger } from 'egg-logger';
 
 import { EggApplicationCore, type EggApplicationCoreOptions } from './egg.ts';
@@ -8,7 +10,7 @@ import { AgentWorkerLoader } from './loader/index.ts';
  * @augments EggApplicationCore
  */
 export class Agent extends EggApplicationCore {
-  readonly #agentAliveHandler: NodeJS.Timeout;
+  #agentAliveHandler?: NodeJS.Timeout;
 
   /**
    * @class
@@ -20,17 +22,41 @@ export class Agent extends EggApplicationCore {
       type: 'agent',
     });
 
-    // keep agent alive even it doesn't have any io tasks
-    this.#agentAliveHandler = setInterval(
-      () => {
-        this.coreLogger.info('[]');
-      },
-      24 * 60 * 60 * 1000,
-    );
+    if (!this.options.snapshot) {
+      // keep agent alive even it doesn't have any io tasks
+      this.#agentAliveHandler = setInterval(
+        () => {
+          this.coreLogger.info('[]');
+        },
+        24 * 60 * 60 * 1000,
+      );
+    }
   }
 
   protected override customEggLoader(): typeof AgentWorkerLoader {
     return AgentWorkerLoader;
+  }
+
+  override registerSnapshotCallbacks(): void {
+    super.registerSnapshotCallbacks();
+
+    v8.startupSnapshot.addSerializeCallback(() => {
+      // Clear the keepalive interval before snapshot
+      if (this.#agentAliveHandler) {
+        clearInterval(this.#agentAliveHandler);
+        this.#agentAliveHandler = undefined;
+      }
+    });
+
+    v8.startupSnapshot.addDeserializeCallback(() => {
+      // Re-create keepalive interval after restore
+      this.#agentAliveHandler = setInterval(
+        () => {
+          this.coreLogger.info('[]');
+        },
+        24 * 60 * 60 * 1000,
+      );
+    });
   }
 
   _wrapMessenger(): void {
@@ -52,7 +78,9 @@ export class Agent extends EggApplicationCore {
   }
 
   async close(): Promise<void> {
-    clearInterval(this.#agentAliveHandler);
+    if (this.#agentAliveHandler) {
+      clearInterval(this.#agentAliveHandler);
+    }
     await super.close();
   }
 }

--- a/packages/egg/src/lib/application.ts
+++ b/packages/egg/src/lib/application.ts
@@ -69,7 +69,9 @@ export class Application extends EggApplicationCore {
   protected async load(): Promise<void> {
     await super.load();
     this.#warnConfusedConfig();
-    this.#bindEvents();
+    if (!this.options.snapshot) {
+      this.#bindEvents();
+    }
   }
 
   #responseRaw(socket: Socket, raw?: any): void {

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -5,6 +5,7 @@ import http, { type IncomingMessage, type ServerResponse } from 'node:http';
 import inspector from 'node:inspector';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
+import v8 from 'node:v8';
 
 import { Cookies as ContextCookies } from '@eggjs/cookies';
 import { EggCore, Router } from '@eggjs/core';
@@ -42,6 +43,12 @@ export interface EggApplicationCoreOptions extends Omit<EggCoreOptions, 'baseDir
   mode?: 'cluster' | 'single';
   clusterPort?: number;
   baseDir?: string;
+  /**
+   * When true, the application loads metadata only (plugins, configs, extensions,
+   * services, controllers) without starting servers, timers, or connections.
+   * Used for V8 startup snapshot construction.
+   */
+  snapshot?: boolean;
 }
 
 export { Request, Response };
@@ -132,7 +139,7 @@ export class EggApplicationCore extends EggCore {
   #loggers?: EggLoggers;
   #clusterClients: any[] = [];
 
-  readonly messenger: IMessenger;
+  messenger: IMessenger;
   agent?: Agent;
   application?: Application;
   declare loader: EggApplicationLoader;
@@ -160,11 +167,13 @@ export class EggApplicationCore extends EggCore {
      */
     this.messenger = createMessenger(this);
 
-    // trigger `serverDidReady` hook when all the app workers
-    // and agent worker are ready
-    this.messenger.once('egg-ready', () => {
-      this.lifecycle.triggerServerDidReady();
-    });
+    if (!this.options.snapshot) {
+      // trigger `serverDidReady` hook when all the app workers
+      // and agent worker are ready
+      this.messenger.once('egg-ready', () => {
+        this.lifecycle.triggerServerDidReady();
+      });
+    }
     this.lifecycle.registerBeforeStart(async () => {
       await this.load();
     }, 'load files');
@@ -183,46 +192,51 @@ export class EggApplicationCore extends EggCore {
 
   protected async load(): Promise<void> {
     await this.loadConfig();
-    // dump config after ready, ensure all the modifications during start will be recorded
-    // make sure dumpConfig is the last ready callback
-    this.ready(() =>
-      process.nextTick(() => {
-        const dumpStartTime = Date.now();
-        this.dumpConfig();
-        this.dumpTiming();
-        this.coreLogger.info('[egg] dump config after ready, %sms', Date.now() - dumpStartTime);
-      }),
-    );
-    this.#setupTimeoutTimer();
+
+    if (!this.options.snapshot) {
+      // dump config after ready, ensure all the modifications during start will be recorded
+      // make sure dumpConfig is the last ready callback
+      this.ready(() =>
+        process.nextTick(() => {
+          const dumpStartTime = Date.now();
+          this.dumpConfig();
+          this.dumpTiming();
+          this.coreLogger.info('[egg] dump config after ready, %sms', Date.now() - dumpStartTime);
+        }),
+      );
+      this.#setupTimeoutTimer();
+    }
 
     this.console.info('[egg] App root: %s', this.baseDir);
     this.console.info('[egg] All *.log files save on %j', this.config.logger.dir);
     assert(this.config.logger.dir, 'logger.dir is required');
     this.console.info('[egg] Loaded enabled plugin %j', this.loader.orderPlugins);
 
-    // Listen the error that promise had not catch, then log it in common-error
-    this._unhandledRejectionHandler = this._unhandledRejectionHandler.bind(this);
-    process.on('unhandledRejection', this._unhandledRejectionHandler);
+    if (!this.options.snapshot) {
+      // Listen the error that promise had not catch, then log it in common-error
+      this._unhandledRejectionHandler = this._unhandledRejectionHandler.bind(this);
+      process.on('unhandledRejection', this._unhandledRejectionHandler);
 
-    // register close function
-    this.lifecycle.registerBeforeClose(async () => {
-      // close all cluster clients
-      for (const clusterClient of this.#clusterClients) {
-        await closeClusterClient(clusterClient);
-      }
-      this.#clusterClients = [];
+      // register close function
+      this.lifecycle.registerBeforeClose(async () => {
+        // close all cluster clients
+        for (const clusterClient of this.#clusterClients) {
+          await closeClusterClient(clusterClient);
+        }
+        this.#clusterClients = [];
 
-      // single process mode will close agent before app close
-      if (this.type === 'application' && this.options.mode === 'single') {
-        await this.agent!.close();
-      }
+        // single process mode will close agent before app close
+        if (this.type === 'application' && this.options.mode === 'single') {
+          await this.agent!.close();
+        }
 
-      for (const logger of this.loggers.values()) {
-        logger.close();
-      }
-      this.messenger.close();
-      process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
-    });
+        for (const logger of this.loggers.values()) {
+          logger.close();
+        }
+        this.messenger.close();
+        process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
+      });
+    }
 
     await this.loader.load();
   }
@@ -531,6 +545,60 @@ export class EggApplicationCore extends EggCore {
     } catch (err: any) {
       this.coreLogger.warn(`[egg] dumpTiming error: ${err.message}`);
     }
+  }
+
+  /**
+   * Register V8 startup snapshot serialize/deserialize callbacks.
+   *
+   * Serialize: close loggers (file handles), close messenger, remove process listeners.
+   * Deserialize: re-create loggers (lazy), re-create messenger, re-register listeners.
+   *
+   * Call this after the application is ready but before the snapshot is taken.
+   */
+  registerSnapshotCallbacks(): void {
+    v8.startupSnapshot.addSerializeCallback(() => {
+      // Close all loggers (they hold file handles)
+      if (this.#loggers) {
+        for (const logger of this.#loggers.values()) {
+          logger.close();
+        }
+        this.#loggers = undefined;
+      }
+      // Close messenger
+      this.messenger.close();
+      // Remove process listeners
+      process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
+    });
+
+    v8.startupSnapshot.addDeserializeCallback(() => {
+      // Re-create messenger (loggers are lazily created via get loggers())
+      this.messenger = createMessenger(this);
+      this.messenger.once('egg-ready', () => {
+        this.lifecycle.triggerServerDidReady();
+      });
+      // Re-register process listener
+      this._unhandledRejectionHandler = this._unhandledRejectionHandler.bind(this);
+      process.on('unhandledRejection', this._unhandledRejectionHandler);
+
+      // Patch HttpClient prototype chain with the real urllib.
+      // During snapshot build, urllib was replaced with a stub to avoid
+      // WebAssembly/undici initialization. Now in a normal Node.js context,
+      // load the real urllib and fix the prototype chain so that:
+      // 1. super() in egg's HttpClient calls real urllib.HttpClient constructor
+      // 2. Instance methods from urllib.HttpClient are available on instances
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { createRequire } = require('node:module');
+        const req = createRequire(path.join(this.baseDir, 'package.json'));
+        const urllib = req('urllib');
+        if (urllib.HttpClient && this.HttpClient) {
+          Object.setPrototypeOf(this.HttpClient.prototype, urllib.HttpClient.prototype);
+          Object.setPrototypeOf(this.HttpClient, urllib.HttpClient);
+        }
+      } catch (err: any) {
+        this.console.error('[egg] Failed to patch HttpClient from urllib: %s', err.message);
+      }
+    });
   }
 
   protected override customEggPaths(): string[] {

--- a/packages/egg/src/lib/snapshot.ts
+++ b/packages/egg/src/lib/snapshot.ts
@@ -1,0 +1,77 @@
+import v8 from 'node:v8';
+
+import type { Application } from './application.ts';
+import { startEggForSnapshot, type SnapshotEggOptions, type SingleModeApplication } from './start.ts';
+
+/**
+ * Build a V8 startup snapshot of an egg application.
+ *
+ * Call this from the snapshot entry script passed to
+ * `node --snapshot-blob=snapshot.blob --build-snapshot snapshot_entry.js`.
+ *
+ * It loads all metadata (plugins, configs, extensions, services, controllers,
+ * router, tegg modules) without creating servers, timers, or connections,
+ * then registers serialize/deserialize callbacks with the V8 snapshot API.
+ *
+ * Example snapshot entry script:
+ * ```ts
+ * import { buildSnapshot } from 'egg';
+ * await buildSnapshot({ baseDir: __dirname });
+ * ```
+ *
+ * Example restoring from snapshot:
+ * ```ts
+ * import { restoreSnapshot } from 'egg';
+ * const app = restoreSnapshot();
+ * // app is fully loaded with metadata, ready for server creation
+ * ```
+ */
+export async function buildSnapshot(options: SnapshotEggOptions = {}): Promise<void> {
+  const app = await startEggForSnapshot(options);
+
+  // Register snapshot callbacks on agent and application.
+  // These handle cleanup of non-serializable resources (file handles, timers)
+  // before snapshot and restoration after deserialize.
+  if (app.agent && typeof app.agent.registerSnapshotCallbacks === 'function') {
+    app.agent.registerSnapshotCallbacks();
+  }
+  app.registerSnapshotCallbacks();
+
+  v8.startupSnapshot.setDeserializeMainFunction(
+    (snapshotData: SnapshotData) => {
+      // This function runs when restoring from snapshot.
+      // The application object is available via snapshotData.
+      // Users should call restoreSnapshot() to get it.
+      globalThis.__egg_snapshot_app = snapshotData.app;
+    },
+    { app } as SnapshotData,
+  );
+}
+
+/**
+ * Restore an egg application from a V8 startup snapshot.
+ *
+ * Returns the Application instance that was captured during snapshot
+ * construction. The application has all metadata pre-loaded (plugins,
+ * configs, extensions, services, controllers, router). Loggers and
+ * messenger have been automatically re-created by the deserialize callbacks.
+ */
+export function restoreSnapshot(): Application {
+  const app = globalThis.__egg_snapshot_app;
+  if (!app) {
+    throw new Error(
+      'No egg application found in snapshot. ' +
+        'Ensure the process was started from a snapshot built with buildSnapshot().',
+    );
+  }
+  return app as Application;
+}
+
+interface SnapshotData {
+  app: SingleModeApplication;
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __egg_snapshot_app: unknown;
+}

--- a/packages/egg/src/lib/start.ts
+++ b/packages/egg/src/lib/start.ts
@@ -19,6 +19,15 @@ export interface StartEggOptions {
   plugins?: EggPlugin;
 }
 
+export interface SnapshotEggOptions {
+  /** specify framework that can be absolute path or npm package */
+  framework?: string;
+  /** directory of application, default to `process.cwd()` */
+  baseDir?: string;
+  env?: string;
+  plugins?: EggPlugin;
+}
+
 export interface SingleModeApplication extends Application {
   agent: SingleModeAgent;
 }
@@ -66,5 +75,56 @@ export async function startEgg(options: StartEggOptions = {}): Promise<SingleMod
 
   // emit egg-ready message in agent and application
   application.messenger.broadcast('egg-ready');
+  return application;
+}
+
+/**
+ * Load egg application metadata for V8 startup snapshot construction.
+ *
+ * This runs the loading phases (configWillLoad, configDidLoad, didLoad) but
+ * stops before willReady/didReady/serverDidReady. No servers, timers,
+ * file watchers, or connections are created.
+ *
+ * The returned application has all metadata loaded: plugins, configs,
+ * extensions, services, controllers, router, and (if present) tegg modules.
+ */
+export async function startEggForSnapshot(options: SnapshotEggOptions = {}): Promise<SingleModeApplication> {
+  options.baseDir = options.baseDir ?? process.cwd();
+
+  // get framework from options or package.json
+  if (!options.framework) {
+    try {
+      const pkg = await readJSON(path.join(options.baseDir, 'package.json'));
+      options.framework = pkg.egg.framework;
+    } catch {
+      // ignore
+    }
+  }
+  let AgentClass = Agent;
+  let ApplicationClass = Application;
+  if (options.framework) {
+    const framework = await importModule(options.framework, {
+      paths: [options.baseDir],
+    });
+    AgentClass = framework.Agent;
+    ApplicationClass = framework.Application;
+  }
+
+  const agent = new AgentClass({
+    ...options,
+    mode: 'single',
+    snapshot: true,
+  }) as SingleModeAgent;
+  await agent.ready();
+
+  const application = new ApplicationClass({
+    ...options,
+    mode: 'single',
+    snapshot: true,
+  }) as SingleModeApplication;
+  application.agent = agent;
+  agent.application = application;
+  await application.ready();
+
   return application;
 }

--- a/packages/egg/test/__snapshots__/index.test.ts.snap
+++ b/packages/egg/test/__snapshots__/index.test.ts.snap
@@ -89,11 +89,14 @@ exports[`should expose properties 1`] = `
   "Singleton": [Function],
   "SingletonProto": [Function],
   "Subscription": [Function],
+  "buildSnapshot": [Function],
   "defineConfig": [Function],
   "defineConfigFactory": [Function],
   "definePluginFactory": [Function],
+  "restoreSnapshot": [Function],
   "start": [Function],
   "startCluster": [Function],
   "startEgg": [Function],
+  "startEggForSnapshot": [Function],
 }
 `;

--- a/packages/koa/src/application.ts
+++ b/packages/koa/src/application.ts
@@ -3,6 +3,7 @@ import Emitter from 'node:events';
 import http, { type IncomingMessage, type ServerResponse } from 'node:http';
 import Stream from 'node:stream';
 import util, { debuglog } from 'node:util';
+import v8 from 'node:v8';
 
 import { getAsyncLocalStorage } from 'gals';
 import { HttpError } from 'http-errors';
@@ -48,7 +49,7 @@ export class Application extends Emitter {
   maxIpsCount: number;
   protected _keys?: string[];
   middleware: MiddlewareFunc<Context>[];
-  ctxStorage: AsyncLocalStorage<Context>;
+  ctxStorage: AsyncLocalStorage<Context> | null;
   silent: boolean;
   ContextClass: ProtoImplClass<Context>;
   context: AnyProto;
@@ -88,7 +89,14 @@ export class Application extends Emitter {
       this._keys = options.keys;
     }
     this.middleware = [];
-    this.ctxStorage = getAsyncLocalStorage();
+    if (v8.startupSnapshot?.isBuildingSnapshot?.()) {
+      this.ctxStorage = null;
+      v8.startupSnapshot.addDeserializeCallback((app: Application) => {
+        app.ctxStorage = getAsyncLocalStorage();
+      }, this);
+    } else {
+      this.ctxStorage = getAsyncLocalStorage();
+    }
     this.silent = false;
     this.ContextClass = class ApplicationContext extends Context {} as ProtoImplClass<Context>;
     this.context = this.ContextClass.prototype;
@@ -184,9 +192,12 @@ export class Application extends Emitter {
 
     const handleRequest = (req: IncomingMessage, res: ServerResponse) => {
       const ctx = this.createContext(req, res);
-      return this.ctxStorage.run(ctx, async () => {
-        return await this.handleRequest(ctx, fn);
-      });
+      if (this.ctxStorage) {
+        return this.ctxStorage.run(ctx, async () => {
+          return await this.handleRequest(ctx, fn);
+        });
+      }
+      return this.handleRequest(ctx, fn);
     };
 
     return handleRequest;
@@ -196,7 +207,7 @@ export class Application extends Emitter {
    * return current context from async local storage
    */
   get currentContext(): Context | undefined {
-    return this.ctxStorage.getStore();
+    return this.ctxStorage?.getStore();
   }
 
   /**

--- a/packages/koa/test/application/snapshot.test.ts
+++ b/packages/koa/test/application/snapshot.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import v8 from 'node:v8';
+
+import { request } from '@eggjs/supertest';
+import { afterEach, describe, it } from 'vitest';
+
+import Koa from '../../src/index.ts';
+
+describe('v8 startup snapshot', () => {
+  const originalStartupSnapshot = v8.startupSnapshot;
+
+  afterEach(() => {
+    // Restore original v8.startupSnapshot
+    (v8 as Record<string, unknown>).startupSnapshot = originalStartupSnapshot;
+  });
+
+  it('should defer AsyncLocalStorage creation when building snapshot', () => {
+    let deserializeCallback: { cb: (data: unknown) => void; data: unknown } | undefined;
+    (v8 as Record<string, unknown>).startupSnapshot = {
+      isBuildingSnapshot: () => true,
+      addDeserializeCallback: (cb: (data: unknown) => void, data: unknown) => {
+        deserializeCallback = { cb, data };
+      },
+    };
+
+    const app = new Koa();
+    assert.strictEqual(app.ctxStorage, null);
+    assert.ok(deserializeCallback, 'deserialize callback should be registered');
+
+    // simulate snapshot deserialization
+    deserializeCallback.cb(deserializeCallback.data);
+    assert.ok(app.ctxStorage instanceof AsyncLocalStorage);
+  });
+
+  it('should return undefined for currentContext when ctxStorage is null', () => {
+    (v8 as Record<string, unknown>).startupSnapshot = {
+      isBuildingSnapshot: () => true,
+      addDeserializeCallback: () => {},
+    };
+
+    const app = new Koa();
+    assert.strictEqual(app.ctxStorage, null);
+    assert.strictEqual(app.currentContext, undefined);
+  });
+
+  it('should work normally after deserialization', async () => {
+    let deserializeCallback: { cb: (data: unknown) => void; data: unknown } | undefined;
+    (v8 as Record<string, unknown>).startupSnapshot = {
+      isBuildingSnapshot: () => true,
+      addDeserializeCallback: (cb: (data: unknown) => void, data: unknown) => {
+        deserializeCallback = { cb, data };
+      },
+    };
+
+    const app = new Koa();
+
+    // simulate snapshot deserialization
+    deserializeCallback!.cb(deserializeCallback!.data);
+
+    app.use(async (ctx) => {
+      assert.equal(ctx, app.currentContext);
+      ctx.body = 'ok';
+    });
+
+    await request(app.callback()).get('/').expect('ok');
+    assert.strictEqual(app.currentContext, undefined);
+  });
+
+  it('should not defer when not building snapshot', () => {
+    (v8 as Record<string, unknown>).startupSnapshot = {
+      isBuildingSnapshot: () => false,
+    };
+
+    const app = new Koa();
+    assert.ok(app.ctxStorage instanceof AsyncLocalStorage);
+  });
+
+  it('should handle callback without ctxStorage during snapshot build', async () => {
+    (v8 as Record<string, unknown>).startupSnapshot = {
+      isBuildingSnapshot: () => true,
+      addDeserializeCallback: () => {},
+    };
+
+    const app = new Koa();
+    assert.strictEqual(app.ctxStorage, null);
+
+    app.use(async (ctx) => {
+      // currentContext won't work without ctxStorage, but request handling should still work
+      assert.strictEqual(app.currentContext, undefined);
+      ctx.body = 'ok';
+    });
+
+    await request(app.callback()).get('/').expect('ok');
+  });
+});

--- a/packages/utils/src/import.ts
+++ b/packages/utils/src/import.ts
@@ -28,13 +28,24 @@ try {
   // If import.meta is not available, it's likely CJS
   isESM = false;
 }
+// V8 snapshot CJS bundle override: when building a snapshot, the bundle is CJS
+// and import() triggers ESM loader async hooks that corrupt the snapshot builder.
+// The snapshot-build esbuild pipeline sets __EGG_SNAPSHOT_CJS_BUNDLE__ to force
+// require() instead of import().
+if (typeof (globalThis as any).__EGG_SNAPSHOT_CJS_BUNDLE__ !== 'undefined') {
+  isESM = false;
+}
 const nodeMajorVersion = parseInt(process.versions.node.split('.', 1)[0], 10);
 const supportImportMetaResolve = nodeMajorVersion >= 18;
 
 let _customRequire: NodeRequire;
 export function getRequire(): NodeRequire {
   if (!_customRequire) {
-    if (typeof require !== 'undefined') {
+    // In V8 snapshot builder context, the built-in `require` is a restricted
+    // `requireForUserSnapshot` that lacks `.extensions` and `.resolve` for
+    // user-land modules. Prefer `createRequire` when `require.extensions` is
+    // missing, so that file resolution (isSupportTypeScript, etc.) works.
+    if (typeof require !== 'undefined' && require.extensions) {
       _customRequire = require;
     } else {
       _customRequire = createRequire(process.cwd());
@@ -368,6 +379,37 @@ export function importResolve(filepath: string, options?: ImportResolveOptions):
 
 export async function importModule(filepath: string, options?: ImportModuleOptions): Promise<any> {
   const moduleFilePath = importResolve(filepath, options);
+
+  // Snapshot module registry: if a pre-loaded module exists in the registry,
+  // use it instead of dynamic import(). This is set by the snapshot entry
+  // generator to avoid dynamic imports that bundlers cannot trace.
+  const registry = (globalThis as any).__snapshotModuleRegistry as Map<string, any> | undefined;
+  if (registry) {
+    const cached = registry.get(moduleFilePath);
+    if (cached) {
+      debug('[importModule:snapshot] found in registry: %s', moduleFilePath);
+      let obj = cached;
+      if (obj?.default?.__esModule === true && obj.default && 'default' in obj.default) {
+        obj = obj.default;
+      }
+      if (options?.importDefaultOnly) {
+        if (obj && 'default' in obj) {
+          obj = obj.default;
+        }
+      }
+      return obj;
+    }
+    debug('[importModule:snapshot] not in registry, falling through: %s', moduleFilePath);
+    // In V8 snapshot CJS bundle: if a file is not in the registry, we must
+    // NOT call require() on ESM packages (triggers ESM loader async hooks that
+    // corrupt the snapshot builder). Return an empty module as a safe fallback.
+    // The file will be properly loaded at restore time.
+    if (typeof (globalThis as any).__EGG_SNAPSHOT_CJS_BUNDLE__ !== 'undefined') {
+      debug('[importModule:snapshot] skipping load in snapshot mode: %s', moduleFilePath);
+      return {};
+    }
+  }
+
   let obj: any;
   if (isESM) {
     // esm
@@ -381,7 +423,7 @@ export async function importModule(filepath: string, options?: ImportModuleOptio
     //   one: 1,
     //   [Symbol(Symbol.toStringTag)]: 'Module'
     // }
-    if (obj?.default?.__esModule === true && 'default' in obj?.default) {
+    if (obj?.default?.__esModule === true && obj.default && 'default' in obj.default) {
       // 兼容 cjs 模拟 esm 的导出格式
       // {
       //   __esModule: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3749,6 +3749,9 @@ importers:
       '@oclif/core':
         specifier: 'catalog:'
         version: 4.5.6
+      esbuild:
+        specifier: 'catalog:'
+        version: 0.27.0
       node-homedir:
         specifier: 'catalog:'
         version: 2.0.0
@@ -3758,6 +3761,9 @@ importers:
       source-map-support:
         specifier: 'catalog:'
         version: 0.5.21
+      tsx:
+        specifier: 'catalog:'
+        version: 4.20.6
       utility:
         specifier: 'catalog:'
         version: 2.5.0

--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -29,6 +29,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./baseCommand": "./src/baseCommand.ts",
+    "./commands/snapshot-build": "./src/commands/snapshot-build.ts",
     "./commands/start": "./src/commands/start.ts",
     "./commands/stop": "./src/commands/stop.ts",
     "./helper": "./src/helper.ts",
@@ -40,6 +41,7 @@
     "exports": {
       ".": "./dist/index.js",
       "./baseCommand": "./dist/baseCommand.js",
+      "./commands/snapshot-build": "./dist/commands/snapshot-build.js",
       "./commands/start": "./dist/commands/start.js",
       "./commands/stop": "./dist/commands/stop.js",
       "./helper": "./dist/helper.js",
@@ -56,9 +58,11 @@
   "dependencies": {
     "@eggjs/utils": "workspace:*",
     "@oclif/core": "catalog:",
+    "esbuild": "catalog:",
     "node-homedir": "catalog:",
     "runscript": "catalog:",
     "source-map-support": "catalog:",
+    "tsx": "catalog:",
     "utility": "catalog:"
   },
   "devDependencies": {

--- a/tools/scripts/scripts/generate-snapshot-entry.mjs
+++ b/tools/scripts/scripts/generate-snapshot-entry.mjs
@@ -1,0 +1,626 @@
+/**
+ * Generate a snapshot entry file for an egg application.
+ *
+ * Scans the egg app (plugins, framework, app code) to discover all
+ * dynamically-loaded files, then generates a single entry file that:
+ * 1. Statically imports every discovered module
+ * 2. Builds a module registry (filepath -> module)
+ * 3. Sets globalThis.__snapshotModuleRegistry for importModule() interception
+ * 4. Calls startEgg() to initialize the app
+ *
+ * Usage:
+ *   node generate-snapshot-entry.mjs '{"baseDir":"...","framework":"...","env":"prod"}'
+ *
+ * Output:
+ *   <baseDir>/dist/snapshot-entry.mjs
+ *
+ * This script has NO external dependencies - only Node.js built-ins.
+ */
+
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { debuglog } from 'node:util';
+
+const debug = debuglog('egg/scripts/generate-snapshot-entry');
+
+const LOADABLE_EXTENSIONS = ['.ts', '.js', '.mjs', '.cjs'];
+const EXTEND_NAMES = ['application', 'agent', 'request', 'response', 'context', 'helper'];
+const CONFIG_NAMES = ['config.default', 'config.prod', 'config.local', 'config.unittest', 'plugin', 'plugin.default'];
+
+/**
+ * Read a JSON file synchronously.
+ */
+function readJSON(filepath) {
+  return JSON.parse(fs.readFileSync(filepath, 'utf-8'));
+}
+
+/**
+ * Resolve a package, returning undefined if not found.
+ */
+function tryResolvePackage(name, paths) {
+  const require = createRequire(import.meta.url);
+  for (const p of paths) {
+    try {
+      const localRequire = createRequire(path.join(p, 'noop.js'));
+      return path.dirname(localRequire.resolve(`${name}/package.json`));
+    } catch {
+      /* ignore */
+    }
+  }
+  try {
+    return path.dirname(require.resolve(`${name}/package.json`));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Recursively scan a directory for loadable files (mimics FileLoader.parse using globby patterns).
+ */
+function scanDirectory(directory) {
+  if (!fs.existsSync(directory)) return [];
+  const results = [];
+
+  function walk(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.isFile()) {
+        const ext = path.extname(entry.name);
+        if (LOADABLE_EXTENSIONS.includes(ext) && !entry.name.endsWith('.d.ts')) {
+          results.push(fullPath);
+        }
+      }
+    }
+  }
+
+  walk(directory);
+  return results;
+}
+
+/**
+ * Extract plugin package names from a plugin config file by static text analysis.
+ *
+ * This avoids dynamically importing the TypeScript config file (which would
+ * fail if Node.js cannot parse the TypeScript syntax or resolve all imports).
+ *
+ * Supports two patterns:
+ *   1. `package: '@eggjs/something'`  (explicit plugin declarations)
+ *   2. `import ... from '@eggjs/something'` (plugins imported as factory functions)
+ *
+ * Returns an array of package name strings.
+ */
+function extractPluginPackages(configFilePath) {
+  const content = fs.readFileSync(configFilePath, 'utf-8');
+  const packages = new Set();
+
+  // Pattern 1: package: '@scope/name' or package: 'name'
+  const packageRegex = /package:\s*['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = packageRegex.exec(content)) !== null) {
+    packages.add(match[1]);
+  }
+
+  // Pattern 2: import ... from '@scope/name' (for plugin factory imports)
+  // Only include scoped packages that look like egg plugins
+  const importRegex = /import\s+\w+\s+from\s+['"](@eggjs\/[^'"]+)['"]/g;
+  while ((match = importRegex.exec(content)) !== null) {
+    packages.add(match[1]);
+  }
+
+  return [...packages];
+}
+
+/**
+ * Resolve a plugin directory from its source directory.
+ * Returns the src dir (where config/, app/ etc. live).
+ */
+function resolvePluginSrcDir(pluginDir) {
+  let srcDir = pluginDir;
+  const pkgPath = path.join(pluginDir, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    const pluginPkg = readJSON(pkgPath);
+    if (pluginPkg.exports?.['.']) {
+      const mainExport = pluginPkg.exports['.'];
+      const mainPath =
+        typeof mainExport === 'string' ? mainExport : mainExport?.import?.default || mainExport?.import || '';
+      if (mainPath) {
+        srcDir = path.dirname(path.join(pluginDir, mainPath));
+      }
+    }
+  }
+  return srcDir;
+}
+
+/**
+ * Discover plugins from the egg framework plugin config.
+ *
+ * Uses static text analysis (not dynamic import) to extract plugin package
+ * names, then resolves each package using createRequire from the framework
+ * path. This works even when the TypeScript config file cannot be imported
+ * directly (e.g., due to non-strippable syntax or unresolvable imports).
+ */
+async function discoverPlugins(eggPaths, baseDir) {
+  const plugins = [];
+  const seen = new Set();
+
+  // Build a require function that can resolve from the framework's dependencies
+  const requirePaths = [...eggPaths, baseDir];
+  const frameworkRequire = createRequire(path.join(eggPaths[0], 'noop.js'));
+
+  for (const eggPath of eggPaths) {
+    // Find the plugin config file
+    let pluginConfigPath;
+    for (const baseName of ['plugin', 'plugin.default']) {
+      for (const ext of LOADABLE_EXTENSIONS) {
+        const candidate = path.join(eggPath, 'config/' + baseName + ext);
+        if (fs.existsSync(candidate)) {
+          pluginConfigPath = candidate;
+          break;
+        }
+      }
+      if (pluginConfigPath) break;
+    }
+
+    if (!pluginConfigPath) continue;
+    debug('Parsing plugin config from: %s', pluginConfigPath);
+
+    // Extract plugin package names by static analysis
+    const packageNames = extractPluginPackages(pluginConfigPath);
+    debug('Found plugin packages: %o', packageNames);
+
+    for (const pkgName of packageNames) {
+      if (seen.has(pkgName)) continue;
+      seen.add(pkgName);
+
+      // Resolve the plugin package directory
+      let pluginDir;
+      try {
+        const pkgJsonPath = frameworkRequire.resolve(`${pkgName}/package.json`);
+        pluginDir = path.dirname(pkgJsonPath);
+      } catch {
+        pluginDir = tryResolvePackage(pkgName, requirePaths);
+      }
+
+      if (!pluginDir || !fs.existsSync(pluginDir)) {
+        debug('Could not resolve plugin package %s', pkgName);
+        continue;
+      }
+
+      const srcDir = resolvePluginSrcDir(pluginDir);
+
+      // Derive a short plugin name from the package name
+      const shortName = pkgName.replace(/^@eggjs\//, '').replace(/-plugin$/, '');
+
+      plugins.push({
+        name: shortName,
+        package: pkgName,
+        path: pluginDir,
+        srcDir,
+      });
+      debug('Discovered plugin: %s (%s) at %s (src: %s)', shortName, pkgName, pluginDir, srcDir);
+    }
+  }
+
+  return plugins;
+}
+
+/**
+ * Discover all files that the egg loader would load from a load unit.
+ */
+function discoverUnitFiles(unitPath) {
+  const files = [];
+
+  // Config files
+  for (const configName of CONFIG_NAMES) {
+    for (const ext of LOADABLE_EXTENSIONS) {
+      const configFile = path.join(unitPath, 'config', configName + ext);
+      if (fs.existsSync(configFile)) {
+        files.push(configFile);
+      }
+    }
+  }
+
+  // Extend files
+  for (const name of EXTEND_NAMES) {
+    for (const ext of LOADABLE_EXTENSIONS) {
+      const extendFile = path.join(unitPath, 'app/extend', name + ext);
+      if (fs.existsSync(extendFile)) {
+        files.push(extendFile);
+      }
+      // Env-specific extends
+      for (const env of ['local', 'prod', 'unittest']) {
+        const envExtend = path.join(unitPath, 'app/extend', `${name}.${env}${ext}`);
+        if (fs.existsSync(envExtend)) {
+          files.push(envExtend);
+        }
+      }
+    }
+  }
+
+  // Scan all subdirectories: services, controllers, middleware, schedules,
+  // lib (for event-sources, etc.), and any other loadable files.
+  // This catches dynamically loaded files like watcher event-sources.
+  files.push(...scanDirectory(path.join(unitPath, 'app')));
+  files.push(...scanDirectory(path.join(unitPath, 'lib')));
+
+  // Boot hooks (app.ts / agent.ts at unit root)
+  for (const hookName of ['app', 'agent']) {
+    for (const ext of LOADABLE_EXTENSIONS) {
+      const hookFile = path.join(unitPath, hookName + ext);
+      if (fs.existsSync(hookFile)) {
+        files.push(hookFile);
+      }
+    }
+  }
+
+  // Router
+  for (const ext of LOADABLE_EXTENSIONS) {
+    const routerFile = path.join(unitPath, 'app/router' + ext);
+    if (fs.existsSync(routerFile)) {
+      files.push(routerFile);
+    }
+  }
+
+  return [...new Set(files)];
+}
+
+/**
+ * Resolve the egg framework path from baseDir.
+ */
+function resolveFrameworkPath(baseDir, framework) {
+  if (framework) {
+    if (path.isAbsolute(framework)) return framework;
+    // Try to resolve as a package
+    const resolved = tryResolvePackage(framework, [baseDir]);
+    if (resolved) return resolved;
+    return path.resolve(baseDir, framework);
+  }
+
+  // Default: look for 'egg' package
+  const eggDir = tryResolvePackage('egg', [baseDir]);
+  if (eggDir) return eggDir;
+  throw new Error('Cannot resolve egg framework from ' + baseDir);
+}
+
+/**
+ * Get the egg framework's source directory (where config/, app/ etc. live).
+ */
+function getFrameworkSrcDir(frameworkPath) {
+  const pkgPath = path.join(frameworkPath, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    const pkg = readJSON(pkgPath);
+    if (pkg.exports?.['.']) {
+      const mainExport = pkg.exports['.'];
+      const mainPath =
+        typeof mainExport === 'string' ? mainExport : mainExport?.import?.default || mainExport?.import || '';
+      if (mainPath) {
+        return path.dirname(path.join(frameworkPath, mainPath));
+      }
+    }
+  }
+  // Fallback: check if src/ exists
+  if (fs.existsSync(path.join(frameworkPath, 'src'))) {
+    return path.join(frameworkPath, 'src');
+  }
+  return frameworkPath;
+}
+
+async function main() {
+  const options = JSON.parse(process.argv[2]);
+  const { baseDir, env = 'prod', port = 7001 } = options;
+  const frameworkPath = resolveFrameworkPath(baseDir, options.framework);
+  const frameworkSrcDir = getFrameworkSrcDir(frameworkPath);
+
+  console.log('[generate] Scanning egg application...');
+  console.log('[generate]   baseDir:      %s', baseDir);
+  console.log('[generate]   framework:    %s', frameworkPath);
+  console.log('[generate]   frameworkSrc: %s', frameworkSrcDir);
+  console.log('[generate]   env:          %s', env);
+
+  // Step 1: Discover plugins
+  const plugins = await discoverPlugins([frameworkSrcDir], baseDir);
+  console.log('[generate]   plugins:      %d found', plugins.length);
+  for (const p of plugins) {
+    console.log('[generate]     - %s (%s) => %s', p.name, p.package || 'local', p.srcDir);
+  }
+
+  // Step 2: Collect all files from all load units
+  const loadUnits = [];
+
+  // Plugin files
+  for (const plugin of plugins) {
+    const unitFiles = discoverUnitFiles(plugin.srcDir);
+    loadUnits.push({ name: plugin.name, path: plugin.srcDir, type: 'plugin', files: unitFiles });
+  }
+
+  // Framework files
+  const frameworkFiles = discoverUnitFiles(frameworkSrcDir);
+  loadUnits.push({ name: 'framework', path: frameworkSrcDir, type: 'framework', files: frameworkFiles });
+
+  // App files
+  const appFiles = discoverUnitFiles(baseDir);
+  loadUnits.push({ name: 'app', path: baseDir, type: 'app', files: appFiles });
+
+  // Deduplicate all files
+  const allFilesSet = new Set();
+  for (const unit of loadUnits) {
+    for (const f of unit.files) {
+      allFilesSet.add(f);
+    }
+  }
+  const uniqueFiles = [...allFilesSet];
+  console.log('[generate]   total files:  %d', uniqueFiles.length);
+
+  // Step 3: Generate the snapshot entry file
+  const outputDir = path.join(baseDir, 'dist');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const entryPath = path.join(outputDir, 'snapshot-entry.mjs');
+  const lines = [];
+
+  lines.push('// AUTO-GENERATED by generate-snapshot-entry.mjs');
+  lines.push('// Do not edit manually.');
+  lines.push('');
+  // NOTE: The esbuild banner injects globalThis.__EGG_SNAPSHOT_CJS_BUNDLE__ = true
+  // at the very top of the CJS bundle (before any module init code). This forces
+  // importModule() to use require() instead of import(), avoiding ESM loader async
+  // hooks that corrupt the V8 snapshot builder.
+  // NOTE: Do NOT import node:http at the top level.
+  // require('node:http') registers global native handles (HTTPParser,
+  // ConnectionsList) that V8 cannot serialize. The esbuild httpDeferPlugin
+  // replaces the import with a lazy proxy, but we also avoid the top-level
+  // import here so the intent is clear.
+  lines.push('import v8 from "node:v8";');
+  lines.push('import { debuglog } from "node:util";');
+  lines.push('');
+
+  // Import the framework's startEgg function
+  // Check if the framework has an index.ts, .js, or .mjs
+  let frameworkEntry;
+  for (const ext of ['.ts', '.js', '.mjs']) {
+    const candidate = path.join(frameworkSrcDir, 'index' + ext);
+    if (fs.existsSync(candidate)) {
+      frameworkEntry = candidate;
+      break;
+    }
+  }
+  // Also check lib/start.ts
+  if (!frameworkEntry) {
+    for (const ext of ['.ts', '.js', '.mjs']) {
+      const candidate = path.join(frameworkSrcDir, 'lib/start' + ext);
+      if (fs.existsSync(candidate)) {
+        frameworkEntry = candidate;
+        break;
+      }
+    }
+  }
+
+  if (frameworkEntry) {
+    lines.push(`import * as framework from ${JSON.stringify(pathToFileURL(frameworkEntry).toString())};`);
+  } else {
+    lines.push(`import * as framework from ${JSON.stringify(frameworkPath)};`);
+  }
+  lines.push('');
+
+  // Static imports for all discovered files with module registry
+  lines.push('// === Pre-imported modules (discovered at generate time) ===');
+  lines.push('const __moduleRegistry = new Map();');
+  lines.push('');
+
+  // Register the framework entry in the module registry so that
+  // importModule(frameworkPath) finds it without calling require()/import().
+  // This is critical for --build-snapshot which restricts module loading.
+  if (frameworkEntry) {
+    lines.push(`// Framework entry — needed by startEgg() -> importModule()`);
+    lines.push(`__moduleRegistry.set(${JSON.stringify(frameworkEntry)}, framework);`);
+    // Also register the framework directory path, since importResolve may
+    // resolve the directory to its entry file via package.json exports.
+    lines.push(`__moduleRegistry.set(${JSON.stringify(frameworkPath)}, framework);`);
+    lines.push(`__moduleRegistry.set(${JSON.stringify(frameworkSrcDir)}, framework);`);
+    // Register real paths (resolving symlinks) for framework entries
+    const realFrameworkEntry = fs.realpathSync(frameworkEntry);
+    const realFrameworkPath = fs.realpathSync(frameworkPath);
+    const realFrameworkSrcDir = fs.realpathSync(frameworkSrcDir);
+    if (realFrameworkEntry !== frameworkEntry) {
+      lines.push(`__moduleRegistry.set(${JSON.stringify(realFrameworkEntry)}, framework);`);
+    }
+    if (realFrameworkPath !== frameworkPath) {
+      lines.push(`__moduleRegistry.set(${JSON.stringify(realFrameworkPath)}, framework);`);
+    }
+    if (realFrameworkSrcDir !== frameworkSrcDir) {
+      lines.push(`__moduleRegistry.set(${JSON.stringify(realFrameworkSrcDir)}, framework);`);
+    }
+    lines.push('');
+  }
+
+  for (let i = 0; i < uniqueFiles.length; i++) {
+    const file = uniqueFiles[i];
+    const varName = `__mod_${i}`;
+    const importUrl = pathToFileURL(file).toString();
+    lines.push(`import * as ${varName} from ${JSON.stringify(importUrl)};`);
+    // Register under both the original path and the realpath (resolving symlinks).
+    // The esbuild importMetaPolyfill replaces import.meta.dirname with the real
+    // source path, so the loader resolves config files using real paths. But the
+    // generator discovers files via symlinks (e.g., node_modules/egg -> packages/egg).
+    // Registering both ensures the registry lookup succeeds regardless.
+    lines.push(`__moduleRegistry.set(${JSON.stringify(file)}, ${varName});`);
+    const realFile = fs.realpathSync(file);
+    if (realFile !== file) {
+      lines.push(`__moduleRegistry.set(${JSON.stringify(realFile)}, ${varName});`);
+    }
+  }
+
+  lines.push('');
+  lines.push('// Expose the registry globally for importModule() interception');
+  lines.push('// (see @eggjs/utils importModule snapshot registry support)');
+  lines.push('globalThis.__snapshotModuleRegistry = __moduleRegistry;');
+  lines.push('');
+
+  // Build-time: no app initialization, just register the module registry
+  // and set up the deserialize main function. This avoids creating any
+  // async operations (loggers, timers, event emitters) that would corrupt
+  // the V8 snapshot builder's async hook stack.
+  lines.push('const debug = debuglog("egg/snapshot-entry");');
+  lines.push('');
+  lines.push('console.log("[snapshot] %d modules pre-loaded into registry", __moduleRegistry.size);');
+  lines.push('');
+  lines.push('// Store app options for deserialization');
+  lines.push(
+    `const __snapshotOptions = ${JSON.stringify(
+      {
+        baseDir,
+        framework: options.framework || frameworkPath,
+        env,
+        mode: 'single',
+      },
+      null,
+      2,
+    )};`,
+  );
+  lines.push('');
+  lines.push('// Main function for snapshot restore — starts the app at restore time');
+  lines.push('v8.startupSnapshot.setDeserializeMainFunction(async (data) => {');
+  lines.push('  const port = parseInt(process.env.PORT || "0") || data.port;');
+  lines.push('  const title = process.env.EGG_SERVER_TITLE || data.title || "";');
+  lines.push('  if (title) process.title = title;');
+  lines.push('');
+  lines.push('  debug("Starting egg app from snapshot, %d modules pre-loaded", __moduleRegistry.size);');
+  lines.push('');
+  lines.push(
+    '  const startFn = framework.startEgg ?? framework.default?.startEgg ?? framework.start ?? framework.default?.start;',
+  );
+  lines.push('  if (typeof startFn !== "function") {');
+  lines.push('    throw new Error("Cannot find startEgg from framework: " + JSON.stringify(Object.keys(framework)));');
+  lines.push('  }');
+  lines.push('');
+  lines.push('  const app = await startFn(__snapshotOptions);');
+  lines.push('');
+  lines.push('  // Create HTTP server');
+  lines.push('  const http = require("node:http");');
+  lines.push('  const server = http.createServer(app.callback());');
+  lines.push('  app.emit("server", server);');
+  lines.push('');
+  lines.push('  server.listen(port, () => {');
+  lines.push('    const addr = server.address();');
+  lines.push('    const url = typeof addr === "string" ? addr : `http://127.0.0.1:${addr.port}`;');
+  lines.push('    console.log("[snapshot] Server started on %s (from snapshot)", url);');
+  lines.push('    if (process.send) {');
+  lines.push('      process.send({ action: "egg-ready", data: { address: url, port: addr?.port ?? port } });');
+  lines.push('    }');
+  lines.push('  });');
+  lines.push('');
+  lines.push('  app.messenger.broadcast("egg-ready");');
+  lines.push('');
+  lines.push('  const shutdown = (signal) => {');
+  lines.push('    debug("shutdown: %s", signal);');
+  lines.push('    server.close(() => {');
+  lines.push('      app.close?.().then(() => process.exit(0)).catch(() => process.exit(1));');
+  lines.push('    });');
+  lines.push('    setTimeout(() => process.exit(1), 10000).unref();');
+  lines.push('  };');
+  lines.push('  process.once("SIGTERM", () => shutdown("SIGTERM"));');
+  lines.push('  process.once("SIGINT", () => shutdown("SIGINT"));');
+  lines.push(`}, { port: ${port}, title: ${JSON.stringify(options.title || '')} });`);
+  lines.push('');
+  lines.push('console.log("[snapshot] Ready for snapshot build");');
+
+  fs.writeFileSync(entryPath, lines.join('\n'), 'utf-8');
+  console.log('[generate] Written: %s', entryPath);
+
+  // Step 4: Generate utoopack.json
+  const utooConfig = {
+    entry: [{ import: './dist/snapshot-entry.mjs', name: 'snapshot' }],
+    target: 'node 22.18',
+    output: {
+      path: './dist/bundled',
+      clean: true,
+    },
+    sourceMaps: false,
+    optimization: {
+      moduleIds: 'named',
+      minify: false,
+      treeShaking: false,
+    },
+    externals: {},
+  };
+
+  // Externalize all node: built-in modules
+  const nodeBuiltins = [
+    'fs',
+    'path',
+    'http',
+    'https',
+    'url',
+    'util',
+    'os',
+    'crypto',
+    'stream',
+    'events',
+    'buffer',
+    'assert',
+    'zlib',
+    'net',
+    'tls',
+    'dns',
+    'child_process',
+    'cluster',
+    'worker_threads',
+    'v8',
+    'vm',
+    'readline',
+    'querystring',
+    'string_decoder',
+    'timers',
+    'async_hooks',
+    'perf_hooks',
+    'diagnostics_channel',
+    'inspector',
+    'process',
+    'module',
+    'constants',
+    'domain',
+    'punycode',
+    'tty',
+    'dgram',
+    'http2',
+    'console',
+  ];
+  for (const mod of nodeBuiltins) {
+    utooConfig.externals[`node:${mod}`] = `module node:${mod}`;
+  }
+  // Native addons
+  utooConfig.externals['fsevents'] = 'commonjs fsevents';
+  utooConfig.externals['cpu-features'] = 'commonjs cpu-features';
+
+  const utooConfigPath = path.join(baseDir, 'utoopack.json');
+  fs.writeFileSync(utooConfigPath, JSON.stringify(utooConfig, null, 2), 'utf-8');
+  console.log('[generate] Written: %s', utooConfigPath);
+
+  // Summary
+  console.log('');
+  console.log('[generate] === Summary ===');
+  for (const unit of loadUnits) {
+    console.log('[generate]   %s (%s): %d files', unit.name, unit.type, unit.files.length);
+    for (const f of unit.files) {
+      console.log('[generate]     %s', path.relative(baseDir, f));
+    }
+  }
+  console.log('[generate]');
+  console.log('[generate] Next steps:');
+  console.log('[generate]   1. cd %s', baseDir);
+  console.log('[generate]   2. ut x @utoo/pack-cli -- build');
+  console.log('[generate]   3. node --build-snapshot --snapshot-blob snapshot.blob dist/bundled/snapshot.mjs');
+  console.log('[generate]   OR (without utoo bundling):');
+  console.log('[generate]   2. node --build-snapshot --snapshot-blob snapshot.blob dist/snapshot-entry.mjs');
+}
+
+main().catch((err) => {
+  console.error('[generate] Error:', err);
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/tools/scripts/scripts/snapshot-builder.mjs
+++ b/tools/scripts/scripts/snapshot-builder.mjs
@@ -1,0 +1,157 @@
+import http from 'node:http';
+import { debuglog } from 'node:util';
+import v8 from 'node:v8';
+
+import { importModule } from '@eggjs/utils';
+
+const debug = debuglog('egg/scripts/snapshot-builder');
+
+async function main() {
+  debug('argv: %o', process.argv);
+  const options = JSON.parse(process.argv[2]);
+  debug('snapshot build options: %o', options);
+
+  // Load framework
+  const framework = await importModule(options.framework);
+  const startEgg = framework.start ?? framework.startEgg;
+  if (typeof startEgg !== 'function') {
+    throw new Error(`Cannot find start/startEgg function from framework: ${options.framework}`);
+  }
+
+  // Initialize the egg app in single mode
+  const app = await startEgg({
+    baseDir: options.baseDir,
+    framework: options.framework,
+    env: options.env,
+    mode: 'single',
+  });
+
+  // Create HTTP server (but don't listen yet)
+  const server = http.createServer(app.callback());
+  app.emit('server', server);
+
+  const defaultPort = options.port ?? 7001;
+
+  console.log('[snapshot] App initialized, preparing snapshot...');
+  debug('app initialized, registering snapshot callbacks');
+
+  // Let the framework register its own serialize/deserialize hooks if supported.
+  // This allows the app/agent to clean up and restore framework-specific resources
+  // (loggers, watchers, connections) in an extensible way.
+  if (typeof app.registerSnapshotCallbacks === 'function') {
+    app.registerSnapshotCallbacks();
+  }
+  if (app.agent && typeof app.agent.registerSnapshotCallbacks === 'function') {
+    app.agent.registerSnapshotCallbacks();
+  }
+
+  // Clean up external resources before V8 heap serialization.
+  // File descriptors, sockets, and timers cannot survive serialization.
+  // This is a fallback for frameworks that don't implement registerSnapshotCallbacks.
+  v8.startupSnapshot.addSerializeCallback(() => {
+    debug('serialize: cleaning up external resources');
+    // Close logger file handles
+    try {
+      if (app.coreLogger && typeof app.coreLogger.close === 'function') {
+        app.coreLogger.close();
+      }
+    } catch {
+      /* ignore */
+    }
+    try {
+      if (app.logger && typeof app.logger.close === 'function') {
+        app.logger.close();
+      }
+    } catch {
+      /* ignore */
+    }
+    try {
+      if (app.agent?.coreLogger && typeof app.agent.coreLogger.close === 'function') {
+        app.agent.coreLogger.close();
+      }
+    } catch {
+      /* ignore */
+    }
+    try {
+      if (app.agent?.logger && typeof app.agent.logger.close === 'function') {
+        app.agent.logger.close();
+      }
+    } catch {
+      /* ignore */
+    }
+  });
+
+  // Re-initialize resources after deserialization
+  v8.startupSnapshot.addDeserializeCallback(() => {
+    debug('deserialize: re-initializing resources');
+    // TODO: Re-open logger file handles, reconnect services, etc.
+    // For now, loggers will need to be re-initialized by the app on first write.
+  });
+
+  // Set the main function to run when restoring from snapshot.
+  // The `data` argument is serialized into the snapshot and passed back on restore.
+  v8.startupSnapshot.setDeserializeMainFunction(
+    (snapshotData) => {
+      const port = parseInt(process.env.PORT || '0') || snapshotData.port;
+      const title = process.env.EGG_SERVER_TITLE || snapshotData.title || '';
+      debug('deserialize main: starting server on port %d', port);
+
+      if (title) {
+        process.title = title;
+      }
+
+      server.listen(port, () => {
+        const address = server.address();
+        const url = typeof address === 'string' ? address : `http://127.0.0.1:${address.port}`;
+
+        debug('server started on %s (from snapshot)', url);
+        console.log('[snapshot] Server started on %s', url);
+
+        // Notify parent process (daemon mode IPC)
+        if (process.send) {
+          process.send({
+            action: 'egg-ready',
+            data: { address: url, port: address?.port ?? port },
+          });
+        }
+      });
+
+      // Broadcast egg-ready to app and agent messenger
+      app.messenger.broadcast('egg-ready');
+
+      // Graceful shutdown
+      const shutdown = async (signal) => {
+        debug('receive signal %s, closing server', signal);
+        server.close(() => {
+          debug('server closed');
+          if (typeof app.close === 'function') {
+            app
+              .close()
+              .then(() => process.exit(0))
+              .catch(() => process.exit(1));
+          } else {
+            process.exit(0);
+          }
+        });
+        // Force exit after timeout
+        setTimeout(() => process.exit(1), 10000).unref();
+      };
+
+      process.once('SIGTERM', () => shutdown('SIGTERM'));
+      process.once('SIGINT', () => shutdown('SIGINT'));
+      process.once('SIGQUIT', () => shutdown('SIGQUIT'));
+    },
+    {
+      port: defaultPort,
+      title: options.title || '',
+      baseDir: options.baseDir,
+    },
+  );
+
+  console.log('[snapshot] Snapshot callbacks registered, building snapshot on exit...');
+}
+
+main().catch((err) => {
+  console.error('[snapshot] Build failed:', err);
+  process.exit(1);
+});

--- a/tools/scripts/scripts/start-single.cjs
+++ b/tools/scripts/scripts/start-single.cjs
@@ -1,0 +1,83 @@
+const http = require('node:http');
+const { debuglog } = require('node:util');
+
+const { importModule } = require('@eggjs/utils');
+
+const debug = debuglog('egg/scripts/start-single/cjs');
+
+async function main() {
+  debug('argv: %o', process.argv);
+  const options = JSON.parse(process.argv[2]);
+  debug('start single options: %o', options);
+  const exports = await importModule(options.framework);
+  let startEgg = exports.start ?? exports.startEgg;
+  if (typeof startEgg !== 'function') {
+    startEgg = exports.default?.start ?? exports.default?.startEgg;
+  }
+  if (typeof startEgg !== 'function') {
+    throw new Error(`Cannot find start/startEgg function from framework: ${options.framework}`);
+  }
+  const app = await startEgg({
+    baseDir: options.baseDir,
+    framework: options.framework,
+    env: options.env,
+    mode: 'single',
+  });
+
+  const port = options.port ?? 7001;
+  const server = http.createServer(app.callback());
+  app.emit('server', server);
+
+  await new Promise((resolve, reject) => {
+    server.listen(port, () => {
+      resolve(undefined);
+    });
+    server.once('error', reject);
+  });
+
+  const address = server.address();
+  const url = typeof address === 'string' ? address : `http://127.0.0.1:${address.port}`;
+
+  debug('server started on %s', url);
+
+  // notify parent process (daemon mode)
+  if (process.send) {
+    process.send({
+      action: 'egg-ready',
+      data: { address: url, port: address.port ?? port },
+    });
+  }
+
+  // graceful shutdown
+  const shutdown = async (signal) => {
+    debug('receive signal %s, closing server', signal);
+    server.close(() => {
+      debug('server closed');
+      if (typeof app.close === 'function') {
+        app
+          .close()
+          .then(() => {
+            process.exit(0);
+          })
+          .catch(() => {
+            process.exit(1);
+          });
+      } else {
+        process.exit(0);
+      }
+    });
+    // force exit after timeout
+    setTimeout(() => {
+      process.exit(1);
+    }, 10000).unref();
+  };
+
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
+  process.once('SIGQUIT', () => shutdown('SIGQUIT'));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/scripts/scripts/start-single.mjs
+++ b/tools/scripts/scripts/start-single.mjs
@@ -1,0 +1,80 @@
+import http from 'node:http';
+import { debuglog } from 'node:util';
+
+import { importModule } from '@eggjs/utils';
+
+const debug = debuglog('egg/scripts/start-single/esm');
+
+async function main() {
+  debug('argv: %o', process.argv);
+  const options = JSON.parse(process.argv[2]);
+  debug('start single options: %o', options);
+  const framework = await importModule(options.framework);
+  const startEgg = framework.start ?? framework.startEgg;
+  if (typeof startEgg !== 'function') {
+    throw new Error(`Cannot find start/startEgg function from framework: ${options.framework}`);
+  }
+  const app = await startEgg({
+    baseDir: options.baseDir,
+    framework: options.framework,
+    env: options.env,
+    mode: 'single',
+  });
+
+  const port = options.port ?? 7001;
+  const server = http.createServer(app.callback());
+  app.emit('server', server);
+
+  await new Promise((resolve, reject) => {
+    server.listen(port, () => {
+      resolve(undefined);
+    });
+    server.once('error', reject);
+  });
+
+  const address = server.address();
+  const url = typeof address === 'string' ? address : `http://127.0.0.1:${address.port}`;
+
+  debug('server started on %s', url);
+
+  // notify parent process (daemon mode)
+  if (process.send) {
+    process.send({
+      action: 'egg-ready',
+      data: { address: url, port: address.port ?? port },
+    });
+  }
+
+  // graceful shutdown
+  const shutdown = async (signal) => {
+    debug('receive signal %s, closing server', signal);
+    server.close(() => {
+      debug('server closed');
+      if (typeof app.close === 'function') {
+        app
+          .close()
+          .then(() => {
+            process.exit(0);
+          })
+          .catch(() => {
+            process.exit(1);
+          });
+      } else {
+        process.exit(0);
+      }
+    });
+    // force exit after timeout
+    setTimeout(() => {
+      process.exit(1);
+    }, 10000).unref();
+  };
+
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
+  process.once('SIGQUIT', () => shutdown('SIGQUIT'));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/scripts/src/commands/snapshot-build.ts
+++ b/tools/scripts/src/commands/snapshot-build.ts
@@ -1,0 +1,536 @@
+import { spawn, type SpawnOptions } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { debuglog } from 'node:util';
+
+import { getFrameworkPath } from '@eggjs/utils';
+import { Args, Flags } from '@oclif/core';
+import { build as esbuildBundle, type Plugin as EsbuildPlugin } from 'esbuild';
+import { readJSON } from 'utility';
+
+import { BaseCommand } from '../baseCommand.ts';
+
+const debug = debuglog('egg/scripts/commands/snapshot-build');
+
+/**
+ * esbuild plugin: resolve file:// URL imports to file paths.
+ * The generated snapshot entry uses file:// URLs for absolute imports.
+ */
+function fileUrlResolverPlugin(): EsbuildPlugin {
+  return {
+    name: 'file-url-resolver',
+    setup(build) {
+      build.onResolve({ filter: /^file:\/\// }, (args) => ({
+        path: fileURLToPath(args.path),
+      }));
+    },
+  };
+}
+
+/**
+ * esbuild plugin: replace `urllib` with a lightweight stub.
+ *
+ * urllib (via undici) compiles a WASM llhttp parser at module-evaluation
+ * time. WebAssembly is not available inside `node --build-snapshot`, so
+ * we replace urllib with a minimal stub that exports a no-op HttpClient
+ * base class. The egg HttpClient getter is lazy and never constructs an
+ * instance during snapshot build, so the stub is never exercised.
+ *
+ * At snapshot restore time, `registerSnapshotCallbacks()` in egg.ts
+ * patches the prototype chain with the real urllib.HttpClient loaded via
+ * `createRequire`, so HTTP requests work normally after restore.
+ */
+function urllibStubPlugin(): EsbuildPlugin {
+  return {
+    name: 'urllib-stub',
+    setup(build) {
+      build.onResolve({ filter: /^urllib$/ }, () => ({
+        path: 'urllib',
+        namespace: 'urllib-stub',
+      }));
+      build.onLoad({ filter: /.*/, namespace: 'urllib-stub' }, () => ({
+        contents: `
+          // Stub for urllib — avoids WebAssembly dependency during snapshot build.
+          // The real urllib is loaded at restore time via createRequire().
+          class HttpClient {
+            constructor(options) { this.options = options || {}; }
+            async request() { throw new Error('urllib stub: not available during snapshot build'); }
+          }
+          module.exports = { HttpClient };
+          module.exports.default = { HttpClient };
+        `,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+/**
+ * esbuild plugin: defer `node:http` loading via a lazy Proxy.
+ *
+ * `require('node:http')` at module evaluation time registers global
+ * native handles (HTTPParser, ConnectionsList) that V8 cannot serialize
+ * into a startup snapshot. This plugin replaces `node:http` (and `http`)
+ * with a lazy Proxy that defers `require('node:http')` until the first
+ * property access at restore time.
+ *
+ * During snapshot build, the egg framework only uses `http` for type
+ * annotations and event listener registration (no property access), so
+ * the proxy is never triggered. At restore time, the first access to
+ * e.g. `http.createServer` loads the real module transparently.
+ */
+function httpDeferPlugin(): EsbuildPlugin {
+  return {
+    name: 'http-defer',
+    setup(build) {
+      // Match both 'http' and 'node:http', but not from within the proxy itself
+      build.onResolve({ filter: /^(node:)?http$/ }, (args) => {
+        // Only intercept bare 'http' / 'node:http', not 'node:http2' etc.
+        if (args.path !== 'http' && args.path !== 'node:http') return null;
+        // Don't intercept the require inside our own proxy module
+        if (args.namespace === 'http-defer') return { path: 'node:http', external: true };
+        return {
+          path: 'node:http',
+          namespace: 'http-defer',
+        };
+      });
+      build.onLoad({ filter: /.*/, namespace: 'http-defer' }, () => ({
+        contents: `
+          // Lazy proxy for node:http — defers require() until first property access.
+          // This avoids registering HTTPParser/ConnectionsList global handles during
+          // V8 snapshot build (which would cause CheckGlobalAndEternalHandles failure).
+          //
+          // Static data is provided for METHODS and STATUS_CODES so that packages
+          // like 'methods' (used by koa-router) which read http.METHODS at module
+          // evaluation time don't trigger loading the real module.
+          //
+          // IMPORTANT: ownKeys/getOwnPropertyDescriptor must NOT trigger loading the
+          // real module, because esbuild's __toESM() helper enumerates exports via
+          // Object.getOwnPropertyNames() at bundle evaluation time.
+          let _real;
+          function getReal() {
+            if (!_real) _real = require('node:http');
+            return _real;
+          }
+
+          // Static copies of http.METHODS and http.STATUS_CODES.
+          // These are stable across Node.js versions and safe to inline.
+          const METHODS = [
+            'ACL','BIND','CHECKOUT','CONNECT','COPY','DELETE','GET','HEAD',
+            'LINK','LOCK','M-SEARCH','MERGE','MKACTIVITY','MKCALENDAR',
+            'MKCOL','MOVE','NOTIFY','OPTIONS','PATCH','POST','PRI',
+            'PROPFIND','PROPPATCH','PURGE','PUT','QUERY','REBIND','REPORT',
+            'SEARCH','SOURCE','SUBSCRIBE','TRACE','UNBIND','UNLINK',
+            'UNLOCK','UNSUBSCRIBE',
+          ];
+          const STATUS_CODES = {
+            100:'Continue',101:'Switching Protocols',102:'Processing',
+            103:'Early Hints',200:'OK',201:'Created',202:'Accepted',
+            203:'Non-Authoritative Information',204:'No Content',
+            205:'Reset Content',206:'Partial Content',207:'Multi-Status',
+            208:'Already Reported',226:'IM Used',300:'Multiple Choices',
+            301:'Moved Permanently',302:'Found',303:'See Other',
+            304:'Not Modified',305:'Use Proxy',307:'Temporary Redirect',
+            308:'Permanent Redirect',400:'Bad Request',401:'Unauthorized',
+            402:'Payment Required',403:'Forbidden',404:'Not Found',
+            405:'Method Not Allowed',406:'Not Acceptable',
+            407:'Proxy Authentication Required',408:'Request Timeout',
+            409:'Conflict',410:'Gone',411:'Length Required',
+            412:'Precondition Failed',413:'Payload Too Large',
+            414:'URI Too Long',415:'Unsupported Media Type',
+            416:'Range Not Satisfiable',417:'Expectation Failed',
+            418:"I'm a Teapot",421:'Misdirected Request',
+            422:'Unprocessable Entity',423:'Locked',424:'Failed Dependency',
+            425:'Too Early',426:'Upgrade Required',
+            428:'Precondition Required',429:'Too Many Requests',
+            431:'Request Header Fields Too Large',
+            451:'Unavailable For Legal Reasons',
+            500:'Internal Server Error',501:'Not Implemented',
+            502:'Bad Gateway',503:'Service Unavailable',
+            504:'Gateway Timeout',505:'HTTP Version Not Supported',
+            506:'Variant Also Negotiates',507:'Insufficient Storage',
+            508:'Loop Detected',510:'Not Extended',
+            511:'Network Authentication Required',
+          };
+
+          // Properties that can be served without loading the real module.
+          const STATIC = { METHODS, STATUS_CODES };
+
+          module.exports = new Proxy({}, {
+            get(_, prop) {
+              if (prop === '__esModule') return false;
+              if (prop === 'default') return module.exports;
+              if (prop in STATIC) return STATIC[prop];
+              return getReal()[prop];
+            },
+            set(_, prop, value) {
+              getReal()[prop] = value;
+              return true;
+            },
+            has(_, prop) {
+              if (prop in STATIC) return true;
+              if (!_real) return false;
+              return prop in _real;
+            },
+            ownKeys() {
+              if (!_real) return Object.keys(STATIC);
+              return Reflect.ownKeys(_real);
+            },
+            getOwnPropertyDescriptor(_, prop) {
+              if (prop in STATIC) {
+                return { value: STATIC[prop], writable: true, enumerable: true, configurable: true };
+              }
+              if (!_real) return undefined;
+              return Object.getOwnPropertyDescriptor(_real, prop);
+            },
+          });
+        `,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+/**
+ * esbuild plugin: defer `node:http2` loading via a lazy Proxy.
+ *
+ * `require('node:http2')` internally triggers `undici` initialization which
+ * compiles WebAssembly (llhttp parser). WebAssembly is not available during
+ * `node --build-snapshot`, so we defer http2 loading until first property
+ * access at restore time.
+ */
+function http2DeferPlugin(): EsbuildPlugin {
+  return {
+    name: 'http2-defer',
+    setup(build) {
+      build.onResolve({ filter: /^(node:)?http2$/ }, (args) => {
+        if (args.path !== 'http2' && args.path !== 'node:http2') return null;
+        if (args.namespace === 'http2-defer') return { path: 'node:http2', external: true };
+        return { path: 'node:http2', namespace: 'http2-defer' };
+      });
+      build.onLoad({ filter: /.*/, namespace: 'http2-defer' }, () => ({
+        contents: `
+          let _real;
+          function getReal() {
+            if (!_real) _real = require('node:http2');
+            return _real;
+          }
+          module.exports = new Proxy({}, {
+            get(_, prop) {
+              if (prop === '__esModule') return false;
+              if (prop === 'default') return module.exports;
+              return getReal()[prop];
+            },
+            set(_, prop, value) { getReal()[prop] = value; return true; },
+            has(_, prop) { if (!_real) return false; return prop in _real; },
+            ownKeys() { if (!_real) return []; return Reflect.ownKeys(_real); },
+            getOwnPropertyDescriptor(_, prop) {
+              if (!_real) return undefined;
+              return Object.getOwnPropertyDescriptor(_real, prop);
+            },
+          });
+        `,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+/**
+ * esbuild plugin: stub optional dependencies that may not be installed.
+ *
+ * Database drivers (mysql2, pg, etc.) are often transitive dependencies of
+ * ORM packages but are only needed at runtime when actually connecting to
+ * a database. In the snapshot builder, `requireForUserSnapshot` cannot load
+ * npm packages, so these must be stubbed.
+ */
+function optionalDepsStubPlugin(): EsbuildPlugin {
+  const stubs = new Set([
+    'pg',
+    'pg-types',
+    'sql.js',
+    'sqlite3',
+    'better-sqlite3',
+    'mysql',
+    'mysql2',
+    'oracledb',
+    'tedious',
+  ]);
+  return {
+    name: 'optional-deps-stub',
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (stubs.has(args.path)) {
+          return { path: args.path, namespace: 'optional-stub' };
+        }
+        return null;
+      });
+      build.onLoad({ filter: /.*/, namespace: 'optional-stub' }, (args) => ({
+        contents: `module.exports = new Proxy({}, { get(_, prop) { if (prop === '__esModule') return false; throw new Error('Optional dependency "${args.path}" is not available during snapshot build'); } });`,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+/**
+ * esbuild plugin: polyfill import.meta.dirname/url/filename for CJS output.
+ *
+ * When bundling ESM to CJS, import.meta is empty. This plugin replaces
+ * import.meta references with literal values computed from each source
+ * file's real path at bundle time.
+ */
+function importMetaPolyfillPlugin(): EsbuildPlugin {
+  return {
+    name: 'import-meta-polyfill',
+    setup(build) {
+      build.onLoad({ filter: /\.(ts|js|mjs|cjs)$/ }, async (args) => {
+        const contents = await fs.readFile(args.path, 'utf8');
+        if (!contents.includes('import.meta.')) return null;
+
+        const dirname = path.dirname(args.path);
+        const url = pathToFileURL(args.path).href;
+
+        const modified = contents
+          .replace(/\bimport\.meta\.dirname\b/g, JSON.stringify(dirname))
+          .replace(/\bimport\.meta\.url\b/g, JSON.stringify(url))
+          .replace(/\bimport\.meta\.filename\b/g, JSON.stringify(args.path));
+
+        if (modified === contents) return null;
+
+        const ext = path.extname(args.path);
+        const loader = ext === '.ts' ? ('ts' as const) : ('js' as const);
+        return { contents: modified, loader };
+      });
+    },
+  };
+}
+
+export default class SnapshotBuild<T extends typeof SnapshotBuild> extends BaseCommand<T> {
+  static override description = 'Build a V8 startup snapshot for faster application startup';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --output ./snapshot.blob',
+    '<%= config.bin %> <%= command.id %> --env prod --port 3000',
+  ];
+
+  static override args = {
+    baseDir: Args.string({
+      description: 'directory of application',
+      required: false,
+    }),
+  };
+
+  static override flags = {
+    framework: Flags.string({
+      description: 'specify framework that can be absolute path or npm package',
+    }),
+    env: Flags.string({
+      description: 'server env for the snapshot',
+      default: 'prod',
+    }),
+    port: Flags.integer({
+      description: 'default port baked into snapshot (overridable at start time via PORT env)',
+      char: 'p',
+      default: 7001,
+    }),
+    output: Flags.string({
+      description: 'output path for the snapshot blob file',
+      char: 'o',
+      default: 'snapshot.blob',
+    }),
+    node: Flags.string({
+      description: 'custom node command path',
+      default: 'node',
+    }),
+    title: Flags.string({
+      description: 'default process title baked into snapshot',
+    }),
+    sourcemap: Flags.boolean({
+      summary: 'whether enable sourcemap support',
+      aliases: ['ts', 'typescript'],
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { args, flags } = this;
+
+    const cwd = process.cwd();
+    let baseDir = args.baseDir || cwd;
+    if (!path.isAbsolute(baseDir)) {
+      baseDir = path.join(cwd, baseDir);
+    }
+    await this.initBaseInfo(baseDir);
+
+    const frameworkPath = await getFrameworkPath({
+      framework: flags.framework,
+      baseDir,
+    });
+
+    let frameworkName = 'egg';
+    try {
+      const frameworkPkg = await readJSON(path.join(frameworkPath, 'package.json'));
+      if (frameworkPkg.name) {
+        frameworkName = frameworkPkg.name;
+      }
+    } catch {
+      // ignore
+    }
+
+    const title = flags.title || `egg-server-${this.pkg.name}`;
+    const output = path.resolve(flags.output);
+
+    // Ensure output directory exists
+    await mkdir(path.dirname(output), { recursive: true });
+
+    this.log('Building V8 startup snapshot for %s', frameworkName);
+    this.log('  baseDir:   %s', baseDir);
+    this.log('  framework: %s', frameworkPath);
+    this.log('  env:       %s', flags.env);
+    this.log('  port:      %d (default, overridable via PORT env)', flags.port);
+    this.log('  output:    %s', output);
+    this.log('');
+
+    const snapshotOptions = JSON.stringify({
+      baseDir,
+      framework: frameworkPath,
+      env: flags.env,
+      port: flags.port,
+      title,
+    });
+
+    // ── Stage 1: Generate snapshot entry ──────────────────────────────
+    // Scans the egg app (plugins, framework, app code) to discover all
+    // dynamically-loaded files, then generates a single ESM entry file with
+    // static imports and a module registry for importModule() interception.
+    this.log('[Stage 1/3] Generating snapshot entry...');
+    const generateScript = path.join(import.meta.dirname, '../../scripts/generate-snapshot-entry.mjs');
+
+    await this.spawnProcess(flags.node, [generateScript, snapshotOptions], {
+      stdio: 'inherit',
+      cwd: baseDir,
+    });
+
+    const entryPath = path.join(baseDir, 'dist/snapshot-entry.mjs');
+
+    // ── Stage 2: Bundle to CJS with esbuild ──────────────────────────
+    // node --build-snapshot forces CJS mode (minimalRunCjs in
+    // node:internal/main/mksnapshot) and cannot load user-land modules.
+    // We bundle everything into a single CJS file with all dependencies
+    // inlined and only Node.js built-ins as external requires.
+    this.log('');
+    this.log('[Stage 2/3] Bundling snapshot entry to CJS...');
+    const bundlePath = path.join(baseDir, 'dist/snapshot-bundle.cjs');
+
+    await esbuildBundle({
+      entryPoints: [entryPath],
+      bundle: true,
+      format: 'cjs',
+      platform: 'node',
+      target: 'node22',
+      outfile: bundlePath,
+      // Enable experimental decorators for tegg plugins that use parameter decorators.
+      tsconfigRaw: JSON.stringify({
+        compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+      }),
+      // platform: 'node' automatically externalizes node:* built-ins.
+      // Also externalize native addons that cannot be bundled.
+      external: ['fsevents', 'cpu-features'],
+      logLevel: 'warning',
+      // Inject CJS mode flag and Web API stubs at the very top of the bundle.
+      // - __EGG_SNAPSHOT_CJS_BUNDLE__: forces importModule() to use require()
+      //   instead of import(), avoiding ESM loader async hooks that corrupt
+      //   the V8 snapshot builder.
+      // - Request/Response/Headers stubs: prevent @hono/node-server from
+      //   triggering Node.js built-in undici initialization (which uses
+      //   WebAssembly, unavailable during --build-snapshot).
+      banner: {
+        js: [
+          'globalThis.__EGG_SNAPSHOT_CJS_BUNDLE__ = true;',
+          // Delete the Web API lazy getters first to prevent triggering Node.js
+          // built-in undici initialization (which uses WebAssembly, unavailable
+          // during --build-snapshot). Then install lightweight stubs so that
+          // packages like @hono/node-server can read them at module init time.
+          'delete globalThis.Request; delete globalThis.Response; delete globalThis.Headers; delete globalThis.fetch;',
+          'globalThis.Request = class Request { constructor(u,o){this.url=u;this.method=(o&&o.method)||"GET";this.headers=new Map();} };',
+          'globalThis.Response = class Response { constructor(b,o){this.body=b;this.status=(o&&o.status)||200;this.headers=new Map();} };',
+          'globalThis.Headers = class Headers extends Map {};',
+        ].join('\n'),
+      },
+      plugins: [
+        httpDeferPlugin(),
+        http2DeferPlugin(),
+        urllibStubPlugin(),
+        optionalDepsStubPlugin(),
+        fileUrlResolverPlugin(),
+        importMetaPolyfillPlugin(),
+      ],
+    });
+
+    this.log('  bundled: %s', bundlePath);
+
+    // ── Stage 3: Build V8 snapshot ───────────────────────────────────
+    // Run the bundled CJS file under --build-snapshot to serialize the
+    // initialized application state into a V8 snapshot blob.
+    this.log('');
+    this.log('[Stage 3/3] Building V8 snapshot...');
+
+    const buildArgs: string[] = [
+      '--no-deprecation',
+      '--trace-warnings',
+      '--build-snapshot',
+      `--snapshot-blob=${output}`,
+      bundlePath,
+    ];
+
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      NODE_ENV: 'production',
+      PATH: [
+        path.join(baseDir, 'node_modules/.bin'),
+        path.join(baseDir, '.node/bin'),
+        process.env.PATH ?? process.env.Path,
+      ]
+        .filter(Boolean)
+        .join(path.delimiter),
+    };
+
+    if (flags.env) {
+      env.EGG_SERVER_ENV = flags.env;
+    }
+
+    debug('command: %s, args: %o', flags.node, buildArgs);
+    this.log('Running: %s %s', flags.node, buildArgs.map((a) => `'${a}'`).join(' '));
+    this.log('');
+
+    await this.spawnProcess(flags.node, buildArgs, {
+      env,
+      stdio: 'inherit',
+      cwd: baseDir,
+    });
+
+    this.log('');
+    this.log('Snapshot built successfully: %s', output);
+    this.log('');
+    this.log('To start from this snapshot:');
+    this.log('  %s start --snapshot --snapshot-blob %s', this.config.bin, path.relative(cwd, output) || output);
+  }
+
+  private spawnProcess(command: string, args: string[], options: SpawnOptions): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      debug('spawn: %s %o', command, args);
+      const child = spawn(command, args, options);
+      child.on('exit', (code) => {
+        if (code !== 0) {
+          reject(this.error(`Command failed with exit code ${code}`));
+        } else {
+          resolve();
+        }
+      });
+      child.on('error', reject);
+    });
+  }
+}

--- a/tools/scripts/src/commands/start.ts
+++ b/tools/scripts/src/commands/start.ts
@@ -81,6 +81,17 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
       summary: 'whether enable sourcemap support, will load `source-map-support` etc',
       aliases: ['ts', 'typescript'],
     }),
+    single: Flags.boolean({
+      description: 'start as single process mode (no cluster), required for snapshot support',
+      default: false,
+    }),
+    snapshot: Flags.boolean({
+      description: 'start from a pre-built V8 snapshot blob (implies --single)',
+      default: false,
+    }),
+    'snapshot-blob': Flags.string({
+      description: 'path to snapshot blob file (resolved relative to baseDir). When provided, implies --snapshot',
+    }),
   };
 
   isReady = false;
@@ -104,8 +115,9 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
     return name;
   }
 
-  protected async getServerBin(): Promise<string> {
-    const serverBinName = this.isESM ? 'start-cluster.mjs' : 'start-cluster.cjs';
+  protected async getServerBin(single?: boolean): Promise<string> {
+    const prefix = single ? 'start-single' : 'start-cluster';
+    const serverBinName = this.isESM ? `${prefix}.mjs` : `${prefix}.cjs`;
     return path.join(import.meta.dirname, '../../scripts', serverBinName);
   }
 
@@ -126,12 +138,18 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
     }
     await this.initBaseInfo(baseDir);
 
-    flags.framework = await this.getFrameworkPath({
-      framework: flags.framework,
-      baseDir,
-    });
+    // Snapshot mode: explicit --snapshot flag OR --snapshot-blob provided
+    const isSnapshot = flags.snapshot || !!flags['snapshot-blob'];
 
-    const frameworkName = await this.getFrameworkName(flags.framework);
+    // Framework resolution (skip for snapshot mode — framework is baked into the blob)
+    let frameworkName = 'egg';
+    if (!isSnapshot) {
+      flags.framework = await this.getFrameworkPath({
+        framework: flags.framework,
+        baseDir,
+      });
+      frameworkName = await this.getFrameworkName(flags.framework);
+    }
 
     flags.title = flags.title || `egg-server-${this.pkg.name}`;
 
@@ -145,8 +163,12 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
     // normalize env
     this.env.HOME = HOME;
     this.env.NODE_ENV = 'production';
-    // disable ts file loader
-    this.env.EGG_TS_ENABLE = 'false';
+    // Disable ts file loader in cluster mode.
+    // In single/snapshot mode, Node.js 22.18+ native type stripping handles .ts files.
+    const isSingle = flags.single || isSnapshot;
+    if (!isSingle) {
+      this.env.EGG_TS_ENABLE = 'false';
+    }
 
     // it makes env big but more robust
     this.env.PATH = this.env.Path = [
@@ -173,6 +195,11 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
 
     // additional execArgv
     const execArgv: string[] = ['--no-deprecation', '--trace-warnings'];
+    // Single mode loads framework .ts source directly; use tsx for full TypeScript
+    // support including decorators (Node.js native type stripping can't handle them).
+    if (isSingle && !isSnapshot) {
+      execArgv.push('--import=tsx/esm');
+    }
     if (this.pkgEgg.revert) {
       const reverts = Array.isArray(this.pkgEgg.revert) ? this.pkgEgg.revert : [this.pkgEgg.revert];
       for (const revert of reverts) {
@@ -242,20 +269,54 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
       cwd: baseDir,
     };
 
-    this.log('Starting %s application at %s', frameworkName, baseDir);
+    // Build spawn arguments — snapshot mode vs normal mode
+    let eggArgs: string[];
+    if (isSnapshot) {
+      // Snapshot mode: restore from pre-built V8 snapshot blob.
+      // No server script needed — the deserialize main function baked into the
+      // snapshot handles server startup.
+      // Resolve snapshot-blob path relative to baseDir
+      const blobPath = flags['snapshot-blob'] ?? 'snapshot.blob';
+      const snapshotPath = path.isAbsolute(blobPath) ? blobPath : path.join(baseDir, blobPath);
+      eggArgs = [...execArgv, `--snapshot-blob=${snapshotPath}`];
+      // Pass runtime config via environment variables (read by the deserialize function)
+      if (flags.port !== undefined) {
+        this.env.PORT = String(flags.port);
+      }
+      this.env.EGG_SERVER_TITLE = flags.title;
+      this.log('Starting application from snapshot at %s', snapshotPath);
+    } else {
+      // Normal mode: cluster or single process
+      this.log('Starting %s application at %s%s', frameworkName, baseDir, isSingle ? ' (single process mode)' : '');
 
-    // remove unused properties from stringify, alias had been remove by `removeAlias`
-    const ignoreKeys = ['env', 'daemon', 'stdout', 'stderr', 'timeout', 'ignore-stderr', 'node'];
-    const clusterOptions = stringify(
-      {
-        ...flags,
-        baseDir,
-      },
-      ignoreKeys,
-    );
-    // Note: `spawn` is not like `fork`, had to pass `execArgv` yourself
-    const serverBin = await this.getServerBin();
-    const eggArgs = [...execArgv, serverBin, clusterOptions, `--title=${flags.title}`];
+      // remove unused properties from stringify, alias had been remove by `removeAlias`
+      const ignoreKeys = [
+        'env',
+        'daemon',
+        'stdout',
+        'stderr',
+        'timeout',
+        'ignore-stderr',
+        'node',
+        'single',
+        'snapshot-blob',
+      ];
+      if (isSingle) {
+        // workers is not used in single mode
+        ignoreKeys.push('workers');
+      }
+      const clusterOptions = stringify(
+        {
+          ...flags,
+          baseDir,
+        },
+        ignoreKeys,
+      );
+      // Note: `spawn` is not like `fork`, had to pass `execArgv` yourself
+      const serverBin = await this.getServerBin(isSingle);
+      eggArgs = [...execArgv, serverBin, clusterOptions, `--title=${flags.title}`];
+    }
+
     const spawnScript = `${command} ${eggArgs.map((a) => `'${a}'`).join(' ')}`;
     this.log('Spawn %o', spawnScript);
 
@@ -266,19 +327,10 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
       options.stdio = ['ignore', stdout, stderr, 'ipc'];
       options.detached = true;
       const child = (this.#child = spawn(command, eggArgs, options));
-      this.isReady = false;
-      child.on('message', (msg: any) => {
-        // https://github.com/eggjs/cluster/blob/master/src/master.ts#L119
-        if (msg && msg.action === 'egg-ready') {
-          this.isReady = true;
-          this.log('%s started on %s', frameworkName, msg.data.address);
-          child.unref();
-          child.disconnect();
-        }
-      });
+      const readyLabel = isSnapshot ? 'snapshot' : frameworkName;
 
-      // check start status
-      await this.checkStatus();
+      // Wait for egg-ready IPC message instead of polling with sleep
+      await this.waitForReady(child, readyLabel);
     } else {
       options.stdio = ['inherit', 'inherit', 'inherit', 'ipc'];
       const child = (this.#child = spawn(command, eggArgs, options));
@@ -299,52 +351,69 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
     }
   }
 
-  protected async checkStatus(): Promise<void> {
-    let count = 0;
-    let hasError = false;
-    let isSuccess = true;
-    const timeout = this.flags.timeout / 1000;
+  protected async waitForReady(child: ChildProcess, readyLabel: string): Promise<void> {
+    const timeoutMs = this.flags.timeout;
     const stderrFile = this.flags.stderr!;
-    while (!this.isReady) {
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error(`Start failed, ${timeoutMs / 1000}s timeout`));
+        }, timeoutMs);
+
+        child.on('message', (msg: any) => {
+          // https://github.com/eggjs/cluster/blob/master/src/master.ts#L119
+          if (msg && msg.action === 'egg-ready') {
+            clearTimeout(timer);
+            this.isReady = true;
+            this.log('%s started on %s', readyLabel, msg.data.address);
+            child.unref();
+            child.disconnect();
+            resolve();
+          }
+        });
+
+        child.on('exit', (code) => {
+          if (code) {
+            clearTimeout(timer);
+            reject(new Error(`Child process exited with code ${code}`));
+          }
+        });
+      });
+    } catch (err: any) {
+      // Check stderr for error details
+      let hasStderrContent = false;
       try {
         const stats = await stat(stderrFile);
         if (stats && stats.size > 0) {
-          hasError = true;
-          break;
+          hasStderrContent = true;
         }
       } catch {
-        // nothing
+        // stderr file may not exist
       }
 
-      if (count >= timeout) {
-        this.logToStderr('Start failed, %ds timeout', timeout);
-        isSuccess = false;
-        break;
+      if (hasStderrContent) {
+        try {
+          const args = ['-n', '100', stderrFile];
+          this.logToStderr('tail %s', args.join(' '));
+          const { stdout: headStdout } = await execFile('head', args);
+          const { stdout: tailStdout } = await execFile('tail', args);
+          this.logToStderr('Got error when startup: ');
+          this.logToStderr(headStdout);
+          this.logToStderr('...');
+          this.logToStderr(tailStdout);
+        } catch (tailErr) {
+          this.logToStderr('ignore tail error: %s', tailErr);
+        }
+        if (this.flags['ignore-stderr']) {
+          return; // User opted to ignore stderr errors
+        }
+        this.logToStderr('Start got error, see %o', stderrFile);
+        this.logToStderr('Or use `--ignore-stderr` to ignore stderr at startup.');
+      } else {
+        this.logToStderr('%s', err.message);
       }
 
-      await scheduler.wait(1000);
-      this.log('Wait Start: %d...', ++count);
-    }
-
-    if (hasError) {
-      try {
-        const args = ['-n', '100', stderrFile];
-        this.logToStderr('tail %s', args.join(' '));
-        const { stdout: headStdout } = await execFile('head', args);
-        const { stdout: tailStdout } = await execFile('tail', args);
-        this.logToStderr('Got error when startup: ');
-        this.logToStderr(headStdout);
-        this.logToStderr('...');
-        this.logToStderr(tailStdout);
-      } catch (err) {
-        this.logToStderr('ignore tail error: %s', err);
-      }
-      isSuccess = this.flags['ignore-stderr'];
-      this.logToStderr('Start got error, see %o', stderrFile);
-      this.logToStderr('Or use `--ignore-stderr` to ignore stderr at startup.');
-    }
-
-    if (!isSuccess) {
       this.#child.kill('SIGTERM');
       await scheduler.wait(1000);
       this.exit(1);

--- a/tools/scripts/src/commands/stop.ts
+++ b/tools/scripts/src/commands/stop.ts
@@ -44,11 +44,18 @@ export default class Stop<T extends typeof Stop> extends BaseCommand<T> {
     this.log(`stopping egg application${flags.title ? ` with --title=${flags.title}` : ''}`);
 
     // node ~/eggjs/scripts/scripts/start-cluster.cjs {"title":"egg-server","workers":4,"port":7001,"baseDir":"~/eggjs/test/showcase","framework":"~/eggjs/test/showcase/node_modules/egg"}
+    // node ~/eggjs/scripts/scripts/start-single.mjs {"title":"egg-server","port":7001,"baseDir":"~/eggjs/test/showcase","framework":"~/eggjs/test/showcase/node_modules/egg"}
+    // node --snapshot-blob=./snapshot.blob (snapshot mode — title set via process.title, not in args)
     let processList = await this.findNodeProcesses((item) => {
       const cmd = item.cmd;
+      const isEggProcess =
+        cmd.includes('start-cluster') ||
+        cmd.includes('start-single') ||
+        cmd.includes('--snapshot-blob') ||
+        cmd.startsWith('egg-server');
       const matched = flags.title
-        ? cmd.includes('start-cluster') && cmd.includes(format(osRelated.titleTemplate, flags.title))
-        : cmd.includes('start-cluster');
+        ? isEggProcess && cmd.includes(format(osRelated.titleTemplate, flags.title))
+        : isEggProcess;
       if (matched) {
         debug('find master process: %o', item);
       }

--- a/tools/scripts/src/helper.ts
+++ b/tools/scripts/src/helper.ts
@@ -21,7 +21,7 @@ export async function findNodeProcess(filterFn?: FilterFunction): Promise<NodePr
     .stdout!.toString()
     .split('\n')
     .reduce<NodeProcess[]>((arr, line) => {
-      if (!!line && !line.includes('/bin/sh') && line.includes('node')) {
+      if (!!line && !line.includes('/bin/sh') && (line.includes('node') || line.includes('egg-server'))) {
         const m = line.match(REGEX);
         if (m) {
           const item: NodeProcess = isWindows ? { pid: parseInt(m[2]), cmd: m[1] } : { pid: parseInt(m[1]), cmd: m[2] };

--- a/tools/scripts/src/index.ts
+++ b/tools/scripts/src/index.ts
@@ -1,6 +1,8 @@
+import SnapshotBuild from './commands/snapshot-build.ts';
 import Start from './commands/start.ts';
 
 // exports.StopCommand = require('./lib/cmd/stop');
 
 export * from './baseCommand.ts';
 export { Start, Start as StartCommand };
+export { SnapshotBuild, SnapshotBuild as SnapshotBuildCommand };

--- a/tools/scripts/test/fixtures/snapshot-app/.gitignore
+++ b/tools/scripts/test/fixtures/snapshot-app/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/scripts/test/fixtures/snapshot-app/app/router.js
+++ b/tools/scripts/test/fixtures/snapshot-app/app/router.js
@@ -1,0 +1,8 @@
+module.exports = (app) => {
+  app.get('/', async function () {
+    this.body = {
+      message: 'hello from snapshot app',
+      pid: process.pid,
+    };
+  });
+};

--- a/tools/scripts/test/fixtures/snapshot-app/config/config.default.js
+++ b/tools/scripts/test/fixtures/snapshot-app/config/config.default.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.keys = 'snapshot-test-keys';
+
+exports.logger = {
+  level: 'WARN',
+  consoleLevel: 'WARN',
+};

--- a/tools/scripts/test/fixtures/snapshot-app/package.json
+++ b/tools/scripts/test/fixtures/snapshot-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "snapshot-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "egg": "^1.0.0"
+  }
+}

--- a/tools/scripts/test/fixtures/snapshot-app/rebuild.mjs
+++ b/tools/scripts/test/fixtures/snapshot-app/rebuild.mjs
@@ -1,0 +1,210 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+import { build } from 'esbuild';
+
+const HTTP_STUB = `
+let _real;
+function getReal() {
+  if (!_real) {
+    console.trace('[HTTP-DEFER] Loading real node:http');
+    _real = require('node:http');
+  }
+  return _real;
+}
+const METHODS = ['ACL','BIND','CHECKOUT','CONNECT','COPY','DELETE','GET','HEAD','LINK','LOCK','M-SEARCH','MERGE','MKACTIVITY','MKCALENDAR','MKCOL','MOVE','NOTIFY','OPTIONS','PATCH','POST','PRI','PROPFIND','PROPPATCH','PURGE','PUT','QUERY','REBIND','REPORT','SEARCH','SOURCE','SUBSCRIBE','TRACE','UNBIND','UNLINK','UNLOCK','UNSUBSCRIBE'];
+const STATUS_CODES = {100:'Continue',101:'Switching Protocols',200:'OK',201:'Created',202:'Accepted',204:'No Content',206:'Partial Content',301:'Moved Permanently',302:'Found',303:'See Other',304:'Not Modified',307:'Temporary Redirect',308:'Permanent Redirect',400:'Bad Request',401:'Unauthorized',403:'Forbidden',404:'Not Found',405:'Method Not Allowed',408:'Request Timeout',409:'Conflict',410:'Gone',413:'Payload Too Large',414:'URI Too Long',415:'Unsupported Media Type',416:'Range Not Satisfiable',422:'Unprocessable Entity',429:'Too Many Requests',500:'Internal Server Error',501:'Not Implemented',502:'Bad Gateway',503:'Service Unavailable',504:'Gateway Timeout'};
+const STATIC = { METHODS, STATUS_CODES };
+module.exports = new Proxy({}, {
+  get(_, prop) {
+    if (prop === '__esModule') return false;
+    if (prop === 'default') return module.exports;
+    if (prop in STATIC) return STATIC[prop];
+    return getReal()[prop];
+  },
+  set(_, prop, value) { getReal()[prop] = value; return true; },
+  has(_, prop) { if (prop in STATIC) return true; if (!_real) return false; return prop in _real; },
+  ownKeys() { if (!_real) return Object.keys(STATIC); return Reflect.ownKeys(_real); },
+  getOwnPropertyDescriptor(_, prop) {
+    if (prop in STATIC) return { value: STATIC[prop], writable: true, enumerable: true, configurable: true };
+    if (!_real) return undefined;
+    return Object.getOwnPropertyDescriptor(_real, prop);
+  },
+});
+`;
+
+function httpDeferPlugin() {
+  return {
+    name: 'http-defer',
+    setup(build) {
+      build.onResolve({ filter: /^(node:)?http$/ }, (args) => {
+        if (args.path !== 'http' && args.path !== 'node:http') return null;
+        if (args.namespace === 'http-defer') return { path: 'node:http', external: true };
+        return { path: 'node:http', namespace: 'http-defer' };
+      });
+      build.onLoad({ filter: /.*/, namespace: 'http-defer' }, () => ({
+        contents: HTTP_STUB,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+function http2DeferPlugin() {
+  return {
+    name: 'http2-defer',
+    setup(build) {
+      build.onResolve({ filter: /^(node:)?http2$/ }, (args) => {
+        if (args.path !== 'http2' && args.path !== 'node:http2') return null;
+        if (args.namespace === 'http2-defer') return { path: 'node:http2', external: true };
+        return { path: 'node:http2', namespace: 'http2-defer' };
+      });
+      build.onLoad({ filter: /.*/, namespace: 'http2-defer' }, () => ({
+        contents: `
+let _real;
+function getReal() {
+  if (!_real) _real = require('node:http2');
+  return _real;
+}
+module.exports = new Proxy({}, {
+  get(_, prop) {
+    if (prop === '__esModule') return false;
+    if (prop === 'default') return module.exports;
+    return getReal()[prop];
+  },
+  set(_, prop, value) { getReal()[prop] = value; return true; },
+  has(_, prop) { if (!_real) return false; return prop in _real; },
+  ownKeys() { if (!_real) return []; return Reflect.ownKeys(_real); },
+  getOwnPropertyDescriptor(_, prop) {
+    if (!_real) return undefined;
+    return Object.getOwnPropertyDescriptor(_real, prop);
+  },
+});
+`,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+function urllibStubPlugin() {
+  return {
+    name: 'urllib-stub',
+    setup(build) {
+      build.onResolve({ filter: /^urllib$/ }, () => ({ path: 'urllib', namespace: 'urllib-stub' }));
+      build.onLoad({ filter: /.*/, namespace: 'urllib-stub' }, () => ({
+        contents: `
+          class HttpClient { constructor(o) { this.options = o || {}; } async request() { throw new Error('stub'); } }
+          module.exports = { HttpClient };
+          module.exports.default = { HttpClient };
+        `,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+function fileUrlResolverPlugin() {
+  return {
+    name: 'file-url-resolver',
+    setup(build) {
+      build.onResolve({ filter: /^file:\/\// }, (args) => ({
+        path: fileURLToPath(args.path),
+      }));
+    },
+  };
+}
+
+function optionalDepsStubPlugin() {
+  // Optional dependencies that may not be installed. Stub them so esbuild
+  // can bundle the code that references them, and the snapshot builder's
+  // requireForUserSnapshot doesn't crash.
+  const stubs = new Set([
+    'pg',
+    'pg-types',
+    'sql.js',
+    'sqlite3',
+    'better-sqlite3',
+    'mysql',
+    'mysql2',
+    'oracledb',
+    'tedious',
+  ]);
+  return {
+    name: 'optional-deps-stub',
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        if (stubs.has(args.path)) {
+          return { path: args.path, namespace: 'optional-stub' };
+        }
+        return null;
+      });
+      build.onLoad({ filter: /.*/, namespace: 'optional-stub' }, (args) => ({
+        contents: `module.exports = new Proxy({}, { get(_, prop) { if (prop === '__esModule') return false; throw new Error('Optional dependency "${args.path}" is not available during snapshot build'); } });`,
+        loader: 'js',
+      }));
+    },
+  };
+}
+
+function importMetaPolyfillPlugin() {
+  return {
+    name: 'import-meta-polyfill',
+    setup(build) {
+      build.onLoad({ filter: /\.(ts|js|mjs|cjs)$/ }, async (args) => {
+        const contents = await fs.promises.readFile(args.path, 'utf8');
+        if (!contents.includes('import.meta.')) return null;
+        const dirname = path.dirname(args.path);
+        const url = pathToFileURL(args.path).href;
+        const modified = contents
+          .replace(/\bimport\.meta\.dirname\b/g, JSON.stringify(dirname))
+          .replace(/\bimport\.meta\.url\b/g, JSON.stringify(url))
+          .replace(/\bimport\.meta\.filename\b/g, JSON.stringify(args.path));
+        if (modified === contents) return null;
+        const ext = path.extname(args.path);
+        const loader = ext === '.ts' ? 'ts' : 'js';
+        return { contents: modified, loader };
+      });
+    },
+  };
+}
+
+const entryPath = 'dist/snapshot-entry.mjs';
+const bundlePath = 'dist/snapshot-bundle.cjs';
+
+await build({
+  entryPoints: [entryPath],
+  bundle: true,
+  format: 'cjs',
+  platform: 'node',
+  target: 'node22',
+  outfile: bundlePath,
+  tsconfigRaw: JSON.stringify({
+    compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true },
+  }),
+  external: ['fsevents', 'cpu-features'],
+  logLevel: 'warning',
+  banner: {
+    js: [
+      'globalThis.__EGG_SNAPSHOT_CJS_BUNDLE__ = true;',
+      // Delete the Web API lazy getters first to prevent triggering Node.js
+      // built-in undici initialization (which uses WebAssembly, unavailable
+      // during --build-snapshot). Then install lightweight stubs so that
+      // packages like @hono/node-server can read them at module init time.
+      'delete globalThis.Request; delete globalThis.Response; delete globalThis.Headers; delete globalThis.fetch;',
+      'globalThis.Request = class Request { constructor(u,o){this.url=u;this.method=(o&&o.method)||"GET";this.headers=new Map();} };',
+      'globalThis.Response = class Response { constructor(b,o){this.body=b;this.status=(o&&o.status)||200;this.headers=new Map();} };',
+      'globalThis.Headers = class Headers extends Map {};',
+    ].join('\n'),
+  },
+  plugins: [
+    httpDeferPlugin(),
+    http2DeferPlugin(),
+    urllibStubPlugin(),
+    optionalDepsStubPlugin(),
+    fileUrlResolverPlugin(),
+    importMetaPolyfillPlugin(),
+  ],
+});
+console.log('Bundle rebuilt:', bundlePath);

--- a/tools/scripts/test/snapshot.test.ts
+++ b/tools/scripts/test/snapshot.test.ts
@@ -1,0 +1,323 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { scheduler } from 'node:timers/promises';
+
+import coffee from 'coffee';
+import { detectPort } from 'detect-port';
+import { mm, restore } from 'mm';
+import { request } from 'urllib';
+import { describe, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+
+import { cleanup } from './utils.ts';
+
+const __dirname = import.meta.dirname;
+
+const eggBin = path.join(__dirname, '../bin/run.js');
+const fixturePath = path.join(__dirname, 'fixtures/snapshot-app');
+const homePath = path.join(__dirname, 'fixtures/home-snapshot');
+const logDir = path.join(homePath, 'logs');
+
+describe.sequential('test/snapshot.test.ts', () => {
+  beforeAll(async () => {
+    await fs.mkdir(homePath, { recursive: true });
+    await fs.mkdir(logDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await fs.rm(homePath, { force: true, recursive: true });
+    // Clean up any leftover blob files
+    const files = await fs.readdir(fixturePath);
+    for (const file of files) {
+      if (file.endsWith('.blob')) {
+        await fs.rm(path.join(fixturePath, file), { force: true });
+      }
+    }
+  });
+
+  beforeEach(() => mm(process.env, 'MOCK_HOME_DIR', homePath));
+  afterEach(restore);
+
+  describe('snapshot-build command', () => {
+    let blobPath: string;
+
+    afterEach(async () => {
+      if (blobPath) {
+        await fs.rm(blobPath, { force: true });
+        blobPath = '';
+      }
+    });
+
+    it('should build a snapshot blob file', async () => {
+      blobPath = path.join(fixturePath, 'snapshot.blob');
+      await coffee
+        .fork(eggBin, ['snapshot-build', '--output', blobPath, fixturePath])
+        // .debug()
+        .expect('stdout', /Building V8 startup snapshot/)
+        .expect('stdout', /Snapshot built successfully/)
+        .expect('code', 0)
+        .end();
+
+      const stat = await fs.stat(blobPath);
+      assert(stat.size > 0, 'snapshot blob should be non-empty');
+    });
+
+    it('should build to custom output path', async () => {
+      blobPath = path.join(fixturePath, 'custom-dir', 'my-snapshot.blob');
+      await coffee
+        .fork(eggBin, ['snapshot-build', '--output', blobPath, fixturePath])
+        // .debug()
+        .expect('stdout', /Snapshot built successfully/)
+        .expect('code', 0)
+        .end();
+
+      const stat = await fs.stat(blobPath);
+      assert(stat.size > 0, 'custom output snapshot blob should be non-empty');
+      // cleanup the custom directory
+      await fs.rm(path.dirname(blobPath), { force: true, recursive: true });
+      blobPath = ''; // already cleaned
+    });
+
+    it('should build with custom port and env', async () => {
+      blobPath = path.join(fixturePath, 'snapshot.blob');
+      await coffee
+        .fork(eggBin, ['snapshot-build', '--output', blobPath, '--port', '3000', '--env', 'prod', fixturePath])
+        // .debug()
+        .expect('stdout', /port:\s+3000/)
+        .expect('stdout', /env:\s+prod/)
+        .expect('stdout', /Snapshot built successfully/)
+        .expect('code', 0)
+        .end();
+
+      const stat = await fs.stat(blobPath);
+      assert(stat.size > 0, 'snapshot blob should be non-empty');
+    });
+
+    it('should show help info', async () => {
+      await coffee
+        .fork(eggBin, ['snapshot-build', '--help'])
+        // .debug()
+        .expect('stdout', /Build a V8 startup snapshot/)
+        .expect('code', 0)
+        .end();
+    });
+  });
+
+  describe('start with --snapshot-blob', () => {
+    const blobPath = path.join(fixturePath, 'test-snapshot.blob');
+
+    beforeAll(async () => {
+      // Build the snapshot first
+      await coffee.fork(eggBin, ['snapshot-build', '--output', blobPath, fixturePath]).expect('code', 0).end();
+
+      const stat = await fs.stat(blobPath);
+      assert(stat.size > 0, 'snapshot blob should be built before start tests');
+    });
+
+    afterAll(async () => {
+      await cleanup(fixturePath);
+      await fs.rm(blobPath, { force: true });
+    });
+
+    afterEach(async () => {
+      // Stop any running app and clean up processes
+      await coffee.fork(eggBin, ['stop', fixturePath]).end();
+      await cleanup(fixturePath);
+      // Wait for port release
+      await scheduler.wait(500);
+    });
+
+    it('should start from snapshot and serve HTTP requests', async () => {
+      const port = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+
+      await coffee
+        .fork(eggBin, ['start', '--snapshot-blob', blobPath, '--daemon', `--port=${port}`, fixturePath])
+        // .debug()
+        .expect('stdout', /Starting application from snapshot/)
+        .expect('stdout', /started on http:\/\/127\.0\.0\.1:\d+/)
+        .expect('code', 0)
+        .end();
+
+      // Verify HTTP response
+      const result = await request(`http://127.0.0.1:${port}`);
+      assert.equal(result.status, 200);
+      const body = JSON.parse(result.data.toString());
+      assert.equal(body.message, 'hello from snapshot app');
+      assert(body.pid > 0, 'should have a valid pid');
+    });
+
+    it('should stop snapshot-started app via eggctl stop', async () => {
+      const port = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+
+      // Start
+      await coffee
+        .fork(eggBin, ['start', '--snapshot-blob', blobPath, '--daemon', `--port=${port}`, fixturePath])
+        .expect('code', 0)
+        .end();
+
+      // Verify running
+      const result = await request(`http://127.0.0.1:${port}`);
+      assert.equal(result.status, 200);
+
+      // Stop — the stop command should detect --snapshot-blob processes
+      await coffee
+        .fork(eggBin, ['stop', fixturePath])
+        // .debug()
+        .expect('stdout', /got master pid/)
+        .expect('stdout', /stopped/)
+        .end();
+
+      // Verify stopped (request should fail)
+      try {
+        await request(`http://127.0.0.1:${port}`, { timeout: 2000 });
+        assert.fail('should not be able to connect after stop');
+      } catch {
+        // expected: connection refused
+      }
+    });
+
+    it('should start from same snapshot blob multiple times', async () => {
+      // First start
+      const port1 = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+
+      await coffee
+        .fork(eggBin, ['start', '--snapshot-blob', blobPath, '--daemon', `--port=${port1}`, fixturePath])
+        .expect('code', 0)
+        .end();
+
+      const result1 = await request(`http://127.0.0.1:${port1}`);
+      assert.equal(result1.status, 200);
+      const body1 = JSON.parse(result1.data.toString());
+
+      // Stop first
+      await coffee.fork(eggBin, ['stop', fixturePath]).end();
+      await cleanup(fixturePath);
+      await scheduler.wait(1000);
+
+      // Second start from same blob
+      const port2 = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+
+      await coffee
+        .fork(eggBin, ['start', '--snapshot-blob', blobPath, '--daemon', `--port=${port2}`, fixturePath])
+        .expect('code', 0)
+        .end();
+
+      const result2 = await request(`http://127.0.0.1:${port2}`);
+      assert.equal(result2.status, 200);
+      const body2 = JSON.parse(result2.data.toString());
+
+      // Both should serve correctly but with different PIDs
+      assert.equal(body1.message, 'hello from snapshot app');
+      assert.equal(body2.message, 'hello from snapshot app');
+      assert.notEqual(body1.pid, body2.pid, 'different starts should have different PIDs');
+    });
+  });
+
+  // TODO: --single mode with TS source requires emitDecoratorMetadata support
+  // (needed by @eggjs/tegg). tsx/esbuild don't support it. Use compiled dist/ in production.
+  // Will be fixed when tegg migrates to TC39 decorators or swc loader is added.
+  describe.skip('start with --single (no snapshot)', () => {
+    afterEach(async () => {
+      await coffee.fork(eggBin, ['stop', fixturePath]).end();
+      await cleanup(fixturePath);
+      await scheduler.wait(500);
+    });
+
+    it('should start in single process mode', async () => {
+      const port = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+
+      await coffee
+        .fork(eggBin, ['start', '--single', '--daemon', `--port=${port}`, fixturePath])
+        // .debug()
+        .expect('stdout', /single process mode/)
+        .expect('stdout', /started on http:\/\/127\.0\.0\.1:\d+/)
+        .expect('code', 0)
+        .end();
+
+      // Verify HTTP response
+      const result = await request(`http://127.0.0.1:${port}`);
+      assert.equal(result.status, 200);
+      const body = JSON.parse(result.data.toString());
+      assert.equal(body.message, 'hello from snapshot app');
+    });
+  });
+
+  // TODO: Performance comparison requires --single mode cold start, which needs
+  // emitDecoratorMetadata support. Skipped until single mode TS loading is resolved.
+  describe.skip('snapshot startup performance', () => {
+    const blobPath = path.join(fixturePath, 'perf-snapshot.blob');
+
+    beforeAll(async () => {
+      // Build snapshot
+      await coffee.fork(eggBin, ['snapshot-build', '--output', blobPath, fixturePath]).expect('code', 0).end();
+    });
+
+    afterAll(async () => {
+      await cleanup(fixturePath);
+      await fs.rm(blobPath, { force: true });
+    });
+
+    afterEach(async () => {
+      await coffee.fork(eggBin, ['stop', fixturePath]).end();
+      await cleanup(fixturePath);
+      await scheduler.wait(500);
+    });
+
+    it('should start faster from snapshot than cold start', async () => {
+      // Cold start (single mode, no snapshot)
+      const port1 = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+      const coldStart = Date.now();
+      await coffee
+        .fork(eggBin, ['start', '--single', '--daemon', `--port=${port1}`, fixturePath])
+        .expect('code', 0)
+        .end();
+      const coldTime = Date.now() - coldStart;
+
+      // Verify cold start works
+      const coldResult = await request(`http://127.0.0.1:${port1}`);
+      assert.equal(coldResult.status, 200);
+
+      // Stop cold start
+      await coffee.fork(eggBin, ['stop', fixturePath]).end();
+      await cleanup(fixturePath);
+      await scheduler.wait(1000);
+
+      // Snapshot start
+      const port2 = await detectPort();
+      await fs.rm(path.join(logDir, 'master-stderr.log'), { force: true });
+      const snapStart = Date.now();
+      await coffee
+        .fork(eggBin, ['start', '--snapshot-blob', blobPath, '--daemon', `--port=${port2}`, fixturePath])
+        .expect('code', 0)
+        .end();
+      const snapTime = Date.now() - snapStart;
+
+      // Verify snapshot start works
+      const snapResult = await request(`http://127.0.0.1:${port2}`);
+      assert.equal(snapResult.status, 200);
+
+      // Log timing comparison (informational, not a hard assertion in CI)
+      console.log(`Cold start (single mode): ${coldTime}ms`);
+      console.log(`Snapshot start: ${snapTime}ms`);
+      if (coldTime > 0) {
+        const speedup = ((1 - snapTime / coldTime) * 100).toFixed(1);
+        console.log(`Speedup: ${speedup}%`);
+      }
+
+      // Soft assertion: snapshot should generally be faster.
+      // We don't hard-fail because CI timing can be noisy.
+      if (snapTime >= coldTime) {
+        console.warn(
+          `WARNING: Snapshot start (${snapTime}ms) was not faster than cold start (${coldTime}ms). ` +
+            'This may be due to CI timing variance.',
+        );
+      }
+    });
+  });
+});

--- a/tools/scripts/tsdown.config.ts
+++ b/tools/scripts/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  unused: {
+    level: 'error',
+    // tsx is used at runtime via --import=tsx/esm in spawned processes, not directly imported
+    ignore: ['tsx', 'runscript'],
+  },
+});


### PR DESCRIPTION
## Summary

Add V8 startup snapshot support for eggjs to dramatically reduce application cold start time. The snapshot pre-loads all framework modules (295+) into a V8 heap snapshot blob that restores in ~236ms vs ~1632ms for a normal cluster cold start.

### Key changes:
- **packages/koa**: Defer `AsyncLocalStorage` creation during snapshot building via `v8.startupSnapshot.isBuildingSnapshot()`
- **packages/core**: Snapshot-aware lifecycle — stops after `didLoad` phase (skips willReady/didReady)
- **packages/egg**: Metadata-only loading mode, `buildSnapshot()`/`restoreSnapshot()` APIs, serialize/deserialize hooks
- **packages/utils**: Snapshot module registry in `importModule()`, handle restricted `requireForUserSnapshot`
- **tools/scripts**: New `eggctl snapshot-build` command, `--snapshot-blob` start, `--single` mode, Promise-based IPC readiness (replaces 1s polling sleep)
- **CI**: New `test-snapshot` job (Node.js 22+24)

## Performance (21 plugins, 295 modules, Apple Silicon)

| Mode | Avg | vs Cold Start |
|------|-----|---------------|
| Cold start (cluster) | 1632ms | baseline |
| **Snapshot via eggctl daemon** | **398ms** | **4.1x faster** |
| **Snapshot direct node** | **236ms** | **6.9x faster** |

### Snapshot build pipeline
```
generate-snapshot-entry.mjs → esbuild bundle (ESM→CJS) → node --build-snapshot → snapshot.blob
```

### Usage
```bash
# Build snapshot (deploy-time, ~1.7s)
eggctl snapshot-build --output ./snapshot.blob

# Start from snapshot (fast startup)
eggctl start --snapshot-blob ./snapshot.blob --port 3000

# Or direct (fastest, for containers/systemd)
node --snapshot-blob=snapshot.blob
```

## Known Limitations
- `--single` mode with TS source + tegg decorators requires `emitDecoratorMetadata` (not supported by tsx/esbuild). Use compiled `dist/` in production.
- Snapshot blob (~30MB) must be rebuilt when app code changes.
- `node --build-snapshot` requires CJS (Node.js limitation) — resolved by esbuild bundling step.

## Test plan
- [x] Koa snapshot tests (5 tests) — AsyncLocalStorage deferral
- [x] Core lifecycle tests (351 tests) — no regressions
- [x] Egg exports test — `buildSnapshot`/`restoreSnapshot` exported
- [x] eggctl snapshot-build (4 tests) — blob creation
- [x] eggctl start --snapshot-blob (3 tests) — daemon start/stop/restart
- [x] Manual E2E: build → start → curl → stop verified
- [x] Performance benchmark: 5 runs each, consistent results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added V8 startup snapshot support for faster application startup
  * New `snapshot-build` CLI command to generate optimized snapshots
  * New `--snapshot-blob` flag to start applications from pre-built snapshots
  * New snapshot APIs (`buildSnapshot`, `restoreSnapshot`) for framework integration

* **Documentation**
  * Added snapshot design specification and testing strategy
  * Added bundling integration guide for snapshot workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->