### PR TITLE
chore(ecosystem-ci): bump cnpmcore hash to v4.32.1

### DIFF
--- a/ecosystem-ci/repo.json
+++ b/ecosystem-ci/repo.json
@@ -2,7 +2,7 @@
   "cnpmcore": {
     "repository": "https://github.com/cnpm/cnpmcore.git",
     "branch": "master",
-    "hash": "e82df3f4093c0ec9fd5354563605e60f7f613035"
+    "hash": "98463c33188bbd32513a74e6c3a2c4cc559ef5da"
   },
   "examples": {
     "repository": "https://github.com/eggjs/examples.git",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
   "devDependencies": {
     "@eggjs/bin": "workspace:*",
     "@eggjs/tsconfig": "workspace:*",
+    "@types/content-type": "catalog:",
     "@types/js-yaml": "catalog:",
+    "@types/koa-compose": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -178,7 +178,7 @@ catalog:
   oxc-minify: ^0.105.0
   oxfmt: ^0.20.0
   oxlint: ^1.32.0
-  oxlint-tsgolint: ^0.11.0
+  oxlint-tsgolint: ^0.15.0
   parseurl: ^1.3.3
   path-to-regexp: ^6.3.0
   performance-ms: ^1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,6 @@ catalog:
   '@fengmk2/ps-tree': ^2.0.1
   '@oclif/core': ^4.2.0
   '@oxc-node/core': ^0.0.35
-  typebox: ^1.0.65
   '@swc-node/register': ^1.11.1
   '@swc/core': ^1.15.1
   '@types/accepts': ^1.3.7
@@ -131,9 +130,9 @@ catalog:
   http-errors: ^2.0.0
   humanize-ms: ^2.0.0
   husky: ^9.1.7
+  iconv-lite: ^0.6.3
   inflection: ^3.0.0
   ini: ^6.0.0
-  iconv-lite: ^0.6.3
   ioredis: ^5.4.2
   ioredis-mock: ^8.13.1
   is-type-of: ^2.2.0
@@ -178,7 +177,7 @@ catalog:
   oxc-minify: ^0.105.0
   oxfmt: ^0.20.0
   oxlint: ^1.32.0
-  oxlint-tsgolint: ^0.15.0
+  oxlint-tsgolint: ^0.18.1
   parseurl: ^1.3.3
   path-to-regexp: ^6.3.0
   performance-ms: ^1.1.0
@@ -208,6 +207,7 @@ catalog:
   tsx: 4.20.6
   type-fest: ^5.0.1
   type-is: ^2.0.0
+  typebox: ^1.0.65
   typescript: ^5.9.3
   unplugin-unused: ^0.5.4
   urijs: ^1.19.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -176,7 +176,7 @@ catalog:
   oss-client: ^2.5.1
   oxc-minify: ^0.105.0
   oxfmt: ^0.20.0
-  oxlint: ^1.32.0
+  oxlint: ^1.60.0
   oxlint-tsgolint: ^0.18.1
   parseurl: ^1.3.3
   path-to-regexp: ^6.3.0

--- a/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
+++ b/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
@@ -23,7 +23,6 @@ import { isInitializeRequest, isJSONRPCRequest } from '@modelcontextprotocol/sdk
 import type { JSONRPCMessage, MessageExtraInfo } from '@modelcontextprotocol/sdk/types.js';
 // @ts-expect-error await-event is not typed
 import awaitEvent from 'await-event';
-// @ts-expect-error content-type is not typed
 import contentType from 'content-type';
 import type { Application, Context, Router } from 'egg';
 import compose from 'koa-compose';

--- a/tegg/plugin/mcp-proxy/src/index.ts
+++ b/tegg/plugin/mcp-proxy/src/index.ts
@@ -13,12 +13,10 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import awaitEvent from 'await-event';
 // @ts-expect-error cluster-client is not typed
 import { APIClientBase } from 'cluster-client';
-// @ts-expect-error content-type is not typed
 import contentType from 'content-type';
 import type { Application, Context } from 'egg';
 import type { EggLogger } from 'egg';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
-// @ts-expect-error koa-compose is not typed
 import compose from 'koa-compose';
 import getRawBody from 'raw-body';
 


### PR DESCRIPTION
## Summary

Update cnpmcore E2E hash to v4.32.1 (`98463c33`) which includes the EdgedriverBinary fix (cnpm/cnpmcore#1026).

Microsoft disabled Azure Blob public access (~April 7), causing the old XML listing API to return 404. v4.32.1 uses generated per-platform URLs with `ignoreDownloadStatuses: [404]`.

## Test plan

- [ ] E2E cnpmcore: EdgedriverBinary test should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI metadata to reference a newer commit of an upstream repository.
  * Bumped a workspace tool version in project configuration.
* **Style / Code clean-up**
  * Removed internal TypeScript error-suppression annotations to tidy imports.
* No user-facing functionality or public APIs changed; these updates only adjust CI references, tooling and internal annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->