### PR TITLE
refactor(watcher): use direct class imports for event sources

### DIFF
--- a/plugins/watcher/src/config/config.default.ts
+++ b/plugins/watcher/src/config/config.default.ts
@@ -1,4 +1,8 @@
-import path from 'node:path';
+import type { BaseEventSource } from '../lib/event-sources/base.ts';
+import DefaultEventSource from '../lib/event-sources/default.ts';
+import DevelopmentEventSource from '../lib/event-sources/development.ts';
+
+type EventSourceClass = new (...args: any[]) => BaseEventSource;
 
 export interface WatcherConfig {
   /**
@@ -8,9 +12,9 @@ export interface WatcherConfig {
   type: string;
   /**
    * event sources
-   * key is event source type, value is event source module path
+   * key is event source type, value is string (module path) or event source class
    */
-  eventSources: Record<string, string>;
+  eventSources: Record<string, string | EventSourceClass>;
 }
 
 export default {
@@ -22,8 +26,8 @@ export default {
   watcher: {
     type: 'default', // default event source
     eventSources: {
-      default: path.join(import.meta.dirname, '../lib/event-sources/default'),
-      development: path.join(import.meta.dirname, '../lib/event-sources/development'),
+      default: DefaultEventSource,
+      development: DevelopmentEventSource,
     },
   } as WatcherConfig,
 };

--- a/plugins/watcher/test/watcher.test.ts
+++ b/plugins/watcher/test/watcher.test.ts
@@ -5,6 +5,8 @@ import { mm, type MockApplication } from '@eggjs/mock';
 import { describe, it, afterEach } from 'vitest';
 
 import type { ChangeInfo } from '../src/index.ts';
+import DefaultEventSource from '../src/lib/event-sources/default.ts';
+import DevelopmentEventSource from '../src/lib/event-sources/development.ts';
 import { getFilePath } from './utils.ts';
 
 describe('test/watcher.test.ts', () => {
@@ -80,5 +82,17 @@ describe('test/watcher.test.ts', () => {
         resolve();
       });
     });
+  });
+
+  it('should handle built-in event source no-op paths', async () => {
+    const defaultEventSource = new DefaultEventSource();
+    const messages: string[] = [];
+    defaultEventSource.on('info', (msg) => messages.push(msg));
+    defaultEventSource.unwatch();
+    assert(messages.includes('[@eggjs/watcher] using defaultEventSource watcher.unwatch() does NOTHING'));
+
+    const developmentEventSource = new DevelopmentEventSource();
+    developmentEventSource.watch(getFilePath('not-exists'));
+    developmentEventSource.unwatch('');
   });
 });


### PR DESCRIPTION
## Summary

Changes the default \`eventSources\` config in \`plugins/watcher/src/config/config.default.ts\` from \`path.join(import.meta.dirname, ...)\` strings to direct ES \`import\` of the event source classes.

## Why

This is **batch 1, part of a 19-PR split of #5863** (the egg-bundler PR). #5863 is kept open as a tracking reference. This PR is independent of the other batch-1 PRs.

The current path-string form requires the watcher plugin to dynamically resolve and \`require()\` event source files at runtime, which a static bundler cannot follow. Switching to direct class imports makes the references statically discoverable, so the plugin can be bundled by turbopack.

Pure refactor — runtime behavior is identical (the watcher already resolved these paths into class instances at boot).

## Test plan

- [x] \`pnpm --filter=@eggjs/watcher test\` — 4/4 passed (+ 4 expected skips)
- [x] typecheck clean

## Stack context

Other batch-1 PRs (independent, can land in any order):
- \`feat(utils): add setBundleModuleLoader runtime hook\`
- \`refactor(onerror): inline error page template as string constant\`
- \`refactor(development): inline loader trace template as string constant\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Watcher plugin configuration now accepts event sources as either module path strings or direct class references, and the default configuration uses direct references for simplicity.
  * Inline documentation updated to reflect the new accepted formats.

* **Tests**
  * New unit test verifies built-in event source behaviors complete without errors and emit expected informational messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->