### PR TITLE
fix(scripts): findNodeProcess compatible busybox ps command

### DIFF
--- a/tools/scripts/src/helper.ts
+++ b/tools/scripts/src/helper.ts
@@ -15,7 +15,7 @@ export async function findNodeProcess(filterFn?: FilterFunction): Promise<NodePr
   const command = isWindows
     ? 'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId'
     : // command, cmd are alias of args, not POSIX standard, so we use args
-      'ps -wweo "pid,args"';
+      'command -v ps >/dev/null 2>&1 && ps --help 2>&1 | grep -q BusyBox && ps -o "pid,args" || ps -wweo "pid,args"';
   const stdio = await runScript(command, { stdio: 'pipe' });
   const processList = stdio
     .stdout!.toString()

--- a/tools/scripts/src/helper.ts
+++ b/tools/scripts/src/helper.ts
@@ -15,7 +15,7 @@ export async function findNodeProcess(filterFn?: FilterFunction): Promise<NodePr
   const command = isWindows
     ? 'wmic Path win32_process Where "Name = \'node.exe\'" Get CommandLine,ProcessId'
     : // command, cmd are alias of args, not POSIX standard, so we use args
-      'command -v ps >/dev/null 2>&1 && ps --help 2>&1 | grep -q BusyBox && ps -o "pid,args" || ps -wweo "pid,args"';
+      'ps --help 2>&1 | grep -q BusyBox && ps -o "pid,args" || ps -wweo "pid,args"';
   const stdio = await runScript(command, { stdio: 'pipe' });
   const processList = stdio
     .stdout!.toString()


### PR DESCRIPTION
Fixed an error when executing the `npm stop` command within the Alpine Node.js container in Kubernetes.

Error
```
$ npm stop

> nfb@1.0.0 stop
> egg-scripts stop --title=NFB

[egg-scripts] stopping egg application with --title=NFB
⚠️  RunScriptError: Run "sh -c ps -wweo "pid,args"" error, exit code 1
⚠️  Command Error, enable `DEBUG=common-bin` for detail
```

The `busybox ps` no other parameter
```
# ps --help
BusyBox v1.37.0 (2025-08-05 16:40:33 UTC) multi-call binary.

Usage: ps [-o COL1,COL2=HEADER] [-T]

Show list of processes

        -o COL1,COL2=HEADER     Select columns for display
        -T                      Show threads
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node process detection on BusyBox-based and other non-standard Linux environments by enhancing runtime command probing and conditional handling, yielding more reliable process listing and detection across diverse systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->