### PR TITLE
feat(core): add ManifestStore.fromBundle for bundled artifacts

### DIFF
--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -85,6 +85,20 @@ export class ManifestStore {
   }
 
   /**
+   * Create a ManifestStore from pre-validated bundled data.
+   * Skips invalidation checks — the caller (bundler) is responsible for
+   * guaranteeing the data matches the shipped artifact.
+   */
+  static fromBundle(data: StartupManifest, baseDir: string): ManifestStore {
+    if (data.version !== MANIFEST_VERSION) {
+      throw new Error(
+        `[@eggjs/core] bundled manifest version mismatch: expected ${MANIFEST_VERSION}, got ${data.version}`,
+      );
+    }
+    return new ManifestStore(data, baseDir);
+  }
+
+  /**
    * Create a collector-only ManifestStore (no cached data).
    * Used during normal startup to collect data for future manifest generation.
    */

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -90,11 +90,15 @@ export class ManifestStore {
    * guaranteeing the data matches the shipped artifact.
    */
   static fromBundle(data: StartupManifest, baseDir: string): ManifestStore {
-    if (data.version !== MANIFEST_VERSION) {
+    if (!data || data.version !== MANIFEST_VERSION) {
       throw new Error(
-        `[@eggjs/core] bundled manifest version mismatch: expected ${MANIFEST_VERSION}, got ${data.version}`,
+        `[@eggjs/core] bundled manifest version mismatch: expected ${MANIFEST_VERSION}, got ${data?.version}`,
       );
     }
+    if (!data.invalidation) {
+      throw new Error('[@eggjs/core] bundled manifest missing invalidation data');
+    }
+    debug('manifest loaded from bundle');
     return new ManifestStore(data, baseDir);
   }
 

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -7,6 +7,7 @@ import mm from 'mm';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 import { ManifestStore } from '../../src/loader/manifest.ts';
+import type { StartupManifest } from '../../src/loader/manifest.ts';
 import { createTmpDir, setupBaseDir, generateAndWrite } from './manifest_helper.ts';
 
 let tmpDir: string;
@@ -371,6 +372,95 @@ describe('ManifestStore', () => {
         const store = ManifestStore.load(baseDir, 'local', '');
         assert.ok(store);
         assert.equal(store.data.invalidation.serverEnv, 'local');
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('fromBundle()', () => {
+    it('should create store from bundled manifest data', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.createCollector(baseDir).generateManifest({
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        manifest.resolveCache['config/plugin'] = 'config/plugin.ts';
+
+        const store = ManifestStore.fromBundle(manifest, baseDir);
+        const result = store.resolveModule(path.join(baseDir, 'config/plugin'), () => {
+          throw new Error('should not be called');
+        });
+
+        assert.equal(store.baseDir, baseDir);
+        assert.equal(store.data, manifest);
+        assert.equal(result, path.join(baseDir, 'config/plugin.ts'));
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should throw when bundled manifest version mismatches', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.createCollector(baseDir).generateManifest({
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        manifest.version = 999;
+
+        assert.throws(
+          () => ManifestStore.fromBundle(manifest, baseDir),
+          /bundled manifest version mismatch: expected 1, got 999/,
+        );
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should throw when bundled manifest is missing invalidation data', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const manifest = ManifestStore.createCollector(baseDir).generateManifest({
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        delete (manifest as Partial<StartupManifest>).invalidation;
+
+        assert.throws(() => ManifestStore.fromBundle(manifest, baseDir), /bundled manifest missing invalidation data/);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should throw a clear error when bundled manifest data is null', () => {
+      assert.throws(
+        () => ManifestStore.fromBundle(null as unknown as StartupManifest, tmpDir),
+        /bundled manifest version mismatch: expected 1, got undefined/,
+      );
+    });
+
+    it('should bypass normal invalidation checks for bundled manifest data', async () => {
+      const baseDir = setupBaseDir({ lockfile: 'pnpm' });
+      try {
+        const manifest = ManifestStore.createCollector(baseDir).generateManifest({
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        manifest.invalidation.serverEnv = 'stale-env';
+        manifest.invalidation.serverScope = 'stale-scope';
+        manifest.invalidation.typescriptEnabled = !manifest.invalidation.typescriptEnabled;
+        manifest.invalidation.lockfileFingerprint = 'stale-lockfile';
+        manifest.invalidation.configFingerprint = 'stale-config';
+        await ManifestStore.write(baseDir, manifest);
+
+        assert.equal(ManifestStore.load(baseDir, 'prod', ''), null);
+        assert.doesNotThrow(() => ManifestStore.fromBundle(manifest, baseDir));
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }


### PR DESCRIPTION
Adds static `ManifestStore.fromBundle(data, baseDir)` that creates a store from pre-validated bundled manifest data, skipping lockfile/config fingerprint checks.

Part of #5863 split. Tracking: #5871. Stacked on: #5867 (A1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)