### PR TITLE
feat(core): add ManifestStore.setBundleStore hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,13 @@ The framework follows a specific loading order:
 - `pnpm lint` - Run oxlint with type-aware checking in all packages
 - `pnpm lint:fix` - Auto-fix linting issues with oxlint
 
+### TypeScript Global Types
+
+- Package-wide global type declarations should live in a dedicated `src/global.d.ts` file for that package, not inside implementation modules.
+- Use `import type` for any referenced local types, then add the ambient declaration with `declare global { ... }` and `export {};`.
+- Declare global runtime properties with `var` inside `declare global` so TypeScript adds them to `globalThis`; runtime code can then use `globalThis.<name>` or `globalThis[KEY]` without local `as` casts.
+- For app or fixture-specific globals, use that app's `typings/global.d.ts`.
+
 ### Examples
 
 - `pnpm run example:commonjs` - Run CommonJS example

--- a/packages/core/src/global.d.ts
+++ b/packages/core/src/global.d.ts
@@ -1,0 +1,7 @@
+import type { ManifestStore } from './loader/manifest.ts';
+
+declare global {
+  var __EGG_BUNDLE_STORE__: ManifestStore | undefined;
+}
+
+export {};

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -34,9 +34,9 @@ export interface StartupManifest {
   fileDiscovery: Record<string, string[]>;
 }
 
-type GlobalThisWithBundleStore = typeof globalThis & {
-  [BUNDLE_STORE_KEY]?: ManifestStore;
-};
+declare global {
+  var __EGG_BUNDLE_STORE__: ManifestStore | undefined;
+}
 
 export class ManifestStore {
   readonly data: StartupManifest;
@@ -64,14 +64,14 @@ export class ManifestStore {
    * share the same store instance.
    */
   static setBundleStore(store: ManifestStore | undefined): void {
-    (globalThis as GlobalThisWithBundleStore)[BUNDLE_STORE_KEY] = store;
+    globalThis[BUNDLE_STORE_KEY] = store;
   }
 
   /**
    * Return the registered bundle store, if any.
    */
   static getBundleStore(): ManifestStore | undefined {
-    return (globalThis as GlobalThisWithBundleStore)[BUNDLE_STORE_KEY];
+    return globalThis[BUNDLE_STORE_KEY];
   }
 
   /**

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -34,10 +34,6 @@ export interface StartupManifest {
   fileDiscovery: Record<string, string[]>;
 }
 
-declare global {
-  var __EGG_BUNDLE_STORE__: ManifestStore | undefined;
-}
-
 export class ManifestStore {
   readonly data: StartupManifest;
   readonly baseDir: string;

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -50,10 +50,35 @@ export class ManifestStore {
   // --- Factory Methods ---
 
   /**
+   * Register a pre-built manifest store for bundled egg apps. When set,
+   * `ManifestStore.load()` returns this store unconditionally, bypassing
+   * disk reads and invalidation checks. The bundler-generated entry calls
+   * this at startup before creating the Application.
+   *
+   * Uses globalThis so that bundled and external copies of @eggjs/core
+   * share the same store instance.
+   */
+  static setBundleStore(store: ManifestStore | undefined): void {
+    (globalThis as any).__EGG_BUNDLE_STORE__ = store;
+  }
+
+  /**
+   * Return the registered bundle store, if any.
+   */
+  static getBundleStore(): ManifestStore | undefined {
+    return (globalThis as any).__EGG_BUNDLE_STORE__;
+  }
+
+  /**
    * Load and validate manifest from `.egg/manifest.json`.
    * Returns null if manifest doesn't exist or is invalid.
    */
   static load(baseDir: string, serverEnv: string, serverScope: string): ManifestStore | null {
+    const bundleStore: ManifestStore | undefined = (globalThis as any).__EGG_BUNDLE_STORE__;
+    if (bundleStore) {
+      debug('load: returning registered bundle store');
+      return bundleStore;
+    }
     if (serverEnv === 'local' && process.env.EGG_MANIFEST !== 'true') {
       debug('skip manifest in local env (set EGG_MANIFEST=true to enable)');
       return null;

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -34,6 +34,10 @@ export interface StartupManifest {
   fileDiscovery: Record<string, string[]>;
 }
 
+type GlobalThisWithBundleStore = typeof globalThis & {
+  [BUNDLE_STORE_KEY]?: ManifestStore;
+};
+
 export class ManifestStore {
   readonly data: StartupManifest;
   readonly baseDir: string;
@@ -60,14 +64,14 @@ export class ManifestStore {
    * share the same store instance.
    */
   static setBundleStore(store: ManifestStore | undefined): void {
-    (globalThis as typeof globalThis & { [BUNDLE_STORE_KEY]?: ManifestStore })[BUNDLE_STORE_KEY] = store;
+    (globalThis as GlobalThisWithBundleStore)[BUNDLE_STORE_KEY] = store;
   }
 
   /**
    * Return the registered bundle store, if any.
    */
   static getBundleStore(): ManifestStore | undefined {
-    return (globalThis as typeof globalThis & { [BUNDLE_STORE_KEY]?: ManifestStore })[BUNDLE_STORE_KEY];
+    return (globalThis as GlobalThisWithBundleStore)[BUNDLE_STORE_KEY];
   }
 
   /**

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -85,6 +85,20 @@ export class ManifestStore {
   }
 
   /**
+   * Create a ManifestStore from pre-validated bundled data.
+   * Skips invalidation checks — the caller (bundler) is responsible for
+   * guaranteeing the data matches the shipped artifact.
+   */
+  static fromBundle(data: StartupManifest, baseDir: string): ManifestStore {
+    if (data.version !== MANIFEST_VERSION) {
+      throw new Error(
+        `[@eggjs/core] bundled manifest version mismatch: expected ${MANIFEST_VERSION}, got ${data.version}`,
+      );
+    }
+    return new ManifestStore(data, baseDir);
+  }
+
+  /**
    * Create a collector-only ManifestStore (no cached data).
    * Used during normal startup to collect data for future manifest generation.
    */

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -12,6 +12,7 @@ const debug = debuglog('egg/core/loader/manifest');
 const MANIFEST_VERSION = 1;
 
 const LOCKFILE_NAMES = ['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock'] as const;
+const BUNDLE_STORE_KEY = '__EGG_BUNDLE_STORE__' as const;
 
 export interface ManifestInvalidation {
   lockfileFingerprint: string;
@@ -51,22 +52,22 @@ export class ManifestStore {
 
   /**
    * Register a pre-built manifest store for bundled egg apps. When set,
-   * `ManifestStore.load()` returns this store unconditionally, bypassing
-   * disk reads and invalidation checks. The bundler-generated entry calls
-   * this at startup before creating the Application.
+   * `ManifestStore.load()` returns this store for matching baseDir requests,
+   * bypassing disk reads and invalidation checks. The bundler-generated entry
+   * calls this at startup before creating the Application.
    *
    * Uses globalThis so that bundled and external copies of @eggjs/core
    * share the same store instance.
    */
   static setBundleStore(store: ManifestStore | undefined): void {
-    (globalThis as any).__EGG_BUNDLE_STORE__ = store;
+    (globalThis as typeof globalThis & { [BUNDLE_STORE_KEY]?: ManifestStore })[BUNDLE_STORE_KEY] = store;
   }
 
   /**
    * Return the registered bundle store, if any.
    */
   static getBundleStore(): ManifestStore | undefined {
-    return (globalThis as any).__EGG_BUNDLE_STORE__;
+    return (globalThis as typeof globalThis & { [BUNDLE_STORE_KEY]?: ManifestStore })[BUNDLE_STORE_KEY];
   }
 
   /**
@@ -74,9 +75,9 @@ export class ManifestStore {
    * Returns null if manifest doesn't exist or is invalid.
    */
   static load(baseDir: string, serverEnv: string, serverScope: string): ManifestStore | null {
-    const bundleStore: ManifestStore | undefined = (globalThis as any).__EGG_BUNDLE_STORE__;
-    if (bundleStore) {
-      debug('load: returning registered bundle store');
+    const bundleStore = ManifestStore.getBundleStore();
+    if (bundleStore && bundleStore.baseDir === baseDir) {
+      debug('load: returning registered bundle store for %s', baseDir);
       return bundleStore;
     }
     if (serverEnv === 'local' && process.env.EGG_MANIFEST !== 'true') {

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -18,6 +18,7 @@ describe('ManifestStore', () => {
 
   afterEach(() => {
     mm.restore();
+    ManifestStore.setBundleStore(undefined);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -257,6 +258,15 @@ describe('ManifestStore', () => {
   });
 
   describe('load()', () => {
+    function createBundleStore(baseDir: string, serverEnv = 'prod') {
+      const manifest = ManifestStore.createCollector(baseDir).generateManifest({
+        serverEnv,
+        serverScope: '',
+        typescriptEnabled: true,
+      });
+      return ManifestStore.fromBundle(manifest, baseDir);
+    }
+
     it('should load a valid manifest', async () => {
       const baseDir = setupBaseDir();
       try {
@@ -267,6 +277,69 @@ describe('ManifestStore', () => {
         assert.equal(store.baseDir, baseDir);
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return registered bundle store when manifest file does not exist', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const bundleStore = createBundleStore(baseDir);
+        ManifestStore.setBundleStore(bundleStore);
+
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.equal(store, bundleStore);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return registered bundle store before reading invalid manifest JSON', () => {
+      const baseDir = setupBaseDir();
+      try {
+        const eggDir = path.join(baseDir, '.egg');
+        fs.mkdirSync(eggDir, { recursive: true });
+        fs.writeFileSync(path.join(eggDir, 'manifest.json'), 'not json{{{');
+
+        const bundleStore = createBundleStore(baseDir);
+        ManifestStore.setBundleStore(bundleStore);
+
+        const store = ManifestStore.load(baseDir, 'prod', '');
+        assert.equal(store, bundleStore);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return registered bundle store in local env when EGG_MANIFEST is unset', () => {
+      const baseDir = setupBaseDir();
+      const savedEggManifest = process.env.EGG_MANIFEST;
+      try {
+        delete process.env.EGG_MANIFEST;
+        const bundleStore = createBundleStore(baseDir, 'local');
+        ManifestStore.setBundleStore(bundleStore);
+
+        const store = ManifestStore.load(baseDir, 'local', '');
+        assert.equal(store, bundleStore);
+      } finally {
+        if (savedEggManifest !== undefined) {
+          process.env.EGG_MANIFEST = savedEggManifest;
+        } else {
+          delete process.env.EGG_MANIFEST;
+        }
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should ignore registered bundle store for a different baseDir', () => {
+      const bundleBaseDir = setupBaseDir();
+      try {
+        const bundleStore = createBundleStore(bundleBaseDir);
+        ManifestStore.setBundleStore(bundleStore);
+
+        const store = ManifestStore.load(tmpDir, 'prod', '');
+        assert.equal(store, null);
+      } finally {
+        fs.rmSync(bundleBaseDir, { recursive: true, force: true });
       }
     });
 


### PR DESCRIPTION
Adds `setBundleStore(store)` on `globalThis.__EGG_BUNDLE_STORE__`. When registered for the requested `baseDir`, `load()` returns the bundle store, bypassing disk reads and invalidation.

Part of #5863 split. Tracking: #5871. Stacked on: A2 (fromBundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)