### PR TITLE
feat(bundler): add ManifestLoader with realpath normalization

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+import type {} from './global.d.ts';
 import utils from './utils/index.ts';
 
 export { utils };

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -60,14 +60,14 @@ export class ManifestStore {
    * share the same store instance.
    */
   static setBundleStore(store: ManifestStore | undefined): void {
-    globalThis[BUNDLE_STORE_KEY] = store;
+    (globalThis as Partial<Record<typeof BUNDLE_STORE_KEY, ManifestStore>>)[BUNDLE_STORE_KEY] = store;
   }
 
   /**
    * Return the registered bundle store, if any.
    */
   static getBundleStore(): ManifestStore | undefined {
-    return globalThis[BUNDLE_STORE_KEY];
+    return (globalThis as Partial<Record<typeof BUNDLE_STORE_KEY, ManifestStore>>)[BUNDLE_STORE_KEY];
   }
 
   /**

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -60,14 +60,14 @@ export class ManifestStore {
    * share the same store instance.
    */
   static setBundleStore(store: ManifestStore | undefined): void {
-    (globalThis as Partial<Record<typeof BUNDLE_STORE_KEY, ManifestStore>>)[BUNDLE_STORE_KEY] = store;
+    globalThis[BUNDLE_STORE_KEY] = store;
   }
 
   /**
    * Return the registered bundle store, if any.
    */
   static getBundleStore(): ManifestStore | undefined {
-    return (globalThis as Partial<Record<typeof BUNDLE_STORE_KEY, ManifestStore>>)[BUNDLE_STORE_KEY];
+    return globalThis[BUNDLE_STORE_KEY];
   }
 
   /**

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@eggjs/core": "workspace:*",
     "@utoo/pack": "catalog:",
+    "execa": "catalog:",
     "tsx": "catalog:"
   },
   "devDependencies": {

--- a/tools/egg-bundler/src/lib/ManifestLoader.ts
+++ b/tools/egg-bundler/src/lib/ManifestLoader.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { debuglog } from 'node:util';
 
-import type { ManifestStore, StartupManifest } from '@eggjs/core';
+import { ManifestStore, type StartupManifest } from '@eggjs/core';
 
 const debug = debuglog('egg/bundler/manifest-loader');
 
@@ -33,7 +33,7 @@ interface TeggManifestExtension {
 
 interface ModuleMapEntry {
   realDir: string;
-  pkgName: string;
+  normalizedDir: string;
 }
 
 export class ManifestLoader {
@@ -44,6 +44,8 @@ export class ManifestLoader {
   readonly #scope: string | undefined;
   readonly #framework: string;
   readonly #execArgv: string[] | undefined;
+  readonly #baseRequire: NodeJS.Require;
+  readonly #realpathCache = new Map<string, string>();
   #manifest: StartupManifest | undefined;
   #store: ManifestStore | undefined;
 
@@ -55,6 +57,7 @@ export class ManifestLoader {
     this.#scope = options.scope;
     this.#framework = options.framework ?? FRAMEWORK_DEFAULT;
     this.#execArgv = options.execArgv;
+    this.#baseRequire = createRequire(path.join(this.#baseDir, 'package.json'));
   }
 
   async load(): Promise<StartupManifest> {
@@ -74,8 +77,7 @@ export class ManifestLoader {
 
     const normalized = this.#normalize(data);
     this.#manifest = normalized;
-    // TODO: wire ManifestStore.fromBundle once @eggjs/core exposes it (tracked in
-    // a separate runtime split). Until then, the #store getter throws when accessed.
+    this.#store = ManifestStore.fromBundle(normalized, this.#baseDir);
     return normalized;
   }
 
@@ -124,13 +126,12 @@ export class ManifestLoader {
   #resolveFromBase(rel: string): string {
     if (path.isAbsolute(rel)) return rel;
     if (rel.startsWith('node_modules/')) {
-      const req = createRequire(path.join(this.#baseDir, 'package.json'));
       const rest = rel.slice('node_modules/'.length);
       const slashIdx = rest.startsWith('@') ? rest.indexOf('/', rest.indexOf('/') + 1) : rest.indexOf('/');
       const pkgName = slashIdx === -1 ? rest : rest.slice(0, slashIdx);
       const sub = slashIdx === -1 ? '' : rest.slice(slashIdx + 1);
       try {
-        const pkgJson = req.resolve(`${pkgName}/package.json`);
+        const pkgJson = this.#baseRequire.resolve(`${pkgName}/package.json`);
         return path.resolve(path.dirname(pkgJson), sub);
       } catch {
         return path.resolve(this.#baseDir, rel);
@@ -146,7 +147,15 @@ export class ManifestLoader {
     } catch {
       return undefined;
     }
-    const parsed = JSON.parse(raw) as StartupManifest;
+    let parsed: StartupManifest;
+    try {
+      parsed = JSON.parse(raw) as StartupManifest;
+    } catch (error) {
+      throw new Error(
+        `[@eggjs/egg-bundler] invalid manifest JSON at ${this.#manifestPath}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
     if (parsed.version !== SUPPORTED_MANIFEST_VERSION) {
       throw new Error(
         `[@eggjs/egg-bundler] manifest version mismatch at ${this.#manifestPath}: expected ${SUPPORTED_MANIFEST_VERSION}, got ${parsed.version}`,
@@ -189,8 +198,7 @@ export class ManifestLoader {
   #resolveFrameworkPath(): string {
     if (path.isAbsolute(this.#framework)) return this.#framework;
     try {
-      const req = createRequire(path.join(this.#baseDir, 'package.json'));
-      const pkgJson = req.resolve(`${this.#framework}/package.json`);
+      const pkgJson = this.#baseRequire.resolve(`${this.#framework}/package.json`);
       return path.dirname(pkgJson);
     } catch {
       return this.#framework;
@@ -216,7 +224,7 @@ export class ManifestLoader {
       normalizedResolveCache[newKey] = newValue;
     }
 
-    const normalizedExtensions = this.#normalizeExtensions(data.extensions, moduleMap);
+    const normalizedExtensions = this.#normalizeExtensions(data.extensions ?? {}, moduleMap);
 
     return {
       ...data,
@@ -228,24 +236,22 @@ export class ManifestLoader {
 
   #normalizeRelKey(relKey: string, moduleMap: ModuleMapEntry[]): string {
     if (!relKey) return relKey;
-    // Already inside baseDir and not escaping — leave as-is.
-    if (!relKey.startsWith('..') && !relKey.includes('node_modules/') && !relKey.includes('.pnpm/')) {
+    // Already inside baseDir, relative, and not escaping — leave as-is.
+    if (
+      !path.isAbsolute(relKey) &&
+      !relKey.startsWith('..') &&
+      !relKey.includes('node_modules/') &&
+      !relKey.includes('.pnpm/')
+    ) {
       return relKey;
     }
     const abs = path.resolve(this.#baseDir, relKey);
-    let realAbs: string;
-    try {
-      realAbs = fs.realpathSync(abs);
-    } catch {
-      realAbs = abs;
-    }
-    // Longest-prefix match
+    const realAbs = this.#realpath(abs);
     let best: ModuleMapEntry | undefined;
     for (const entry of moduleMap) {
       if (realAbs === entry.realDir || realAbs.startsWith(entry.realDir + path.sep)) {
-        if (!best || entry.realDir.length > best.realDir.length) {
-          best = entry;
-        }
+        best = entry;
+        break;
       }
     }
     if (!best) {
@@ -253,11 +259,11 @@ export class ManifestLoader {
       return relKey;
     }
     const rest = realAbs === best.realDir ? '' : realAbs.slice(best.realDir.length + 1);
-    const normalized = ['node_modules', best.pkgName, rest].filter(Boolean).join('/').replaceAll(path.sep, '/');
+    const normalized = [best.normalizedDir, rest].filter(Boolean).join('/').replaceAll(path.sep, '/');
     return normalized;
   }
 
-  #normalizeExtensions(extensions: Record<string, unknown>, moduleMap: ModuleMapEntry[]): Record<string, unknown> {
+  #normalizeExtensions(extensions: Record<string, unknown> = {}, moduleMap: ModuleMapEntry[]): Record<string, unknown> {
     const result: Record<string, unknown> = { ...extensions };
     const tegg = extensions?.tegg as TeggManifestExtension | undefined;
     if (tegg?.moduleDescriptors) {
@@ -265,16 +271,12 @@ export class ManifestLoader {
         ...tegg,
         moduleDescriptors: tegg.moduleDescriptors.map((desc) => {
           if (!path.isAbsolute(desc.unitPath)) return desc;
-          let real: string;
-          try {
-            real = fs.realpathSync(desc.unitPath);
-          } catch {
-            real = desc.unitPath;
-          }
+          const real = this.#realpath(desc.unitPath);
           let best: ModuleMapEntry | undefined;
           for (const entry of moduleMap) {
             if (real === entry.realDir || real.startsWith(entry.realDir + path.sep)) {
-              if (!best || entry.realDir.length > best.realDir.length) best = entry;
+              best = entry;
+              break;
             }
           }
           if (!best) {
@@ -283,7 +285,7 @@ export class ManifestLoader {
             return { ...desc, unitPath: rel };
           }
           const rest = real === best.realDir ? '' : real.slice(best.realDir.length + 1);
-          const unitPath = ['node_modules', best.pkgName, rest].filter(Boolean).join('/');
+          const unitPath = [best.normalizedDir, rest].filter(Boolean).join('/').replaceAll(path.sep, '/');
           return { ...desc, unitPath };
         }),
       };
@@ -293,9 +295,9 @@ export class ManifestLoader {
 
   #buildModuleMap(): ModuleMapEntry[] {
     const entries = new Map<string, string>();
-    const seenPkgs = new Set<string>();
+    const seen = new Set<string>();
 
-    const addFromPackageJson = (packageJsonPath: string): void => {
+    const addPackageDeps = (packageJsonPath: string, parentNormalizedDir: string): void => {
       let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
       try {
         pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
@@ -305,24 +307,40 @@ export class ManifestLoader {
       const req = createRequire(packageJsonPath);
       const depNames = [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})];
       for (const name of depNames) {
-        if (seenPkgs.has(name)) continue;
-        seenPkgs.add(name);
         try {
           const depPkgJson = req.resolve(`${name}/package.json`);
-          const realDir = fs.realpathSync(path.dirname(depPkgJson));
-          if (!entries.has(realDir)) entries.set(realDir, name);
+          const realDir = this.#realpath(path.dirname(depPkgJson));
+          if (seen.has(realDir)) continue;
+          seen.add(realDir);
+          const normalizedDir = [parentNormalizedDir, 'node_modules', name].filter(Boolean).join('/');
+          if (!entries.has(realDir)) entries.set(realDir, normalizedDir);
+          addPackageDeps(depPkgJson, normalizedDir);
         } catch {
           /* dep not resolvable (optional/peer); skip */
         }
       }
     };
 
-    addFromPackageJson(path.join(this.#baseDir, 'package.json'));
+    addPackageDeps(path.join(this.#baseDir, 'package.json'), '');
     const frameworkDir = this.#resolveFrameworkPath();
-    addFromPackageJson(path.join(frameworkDir, 'package.json'));
+    const frameworkNormalizedDir = entries.get(this.#realpath(frameworkDir)) ?? '';
+    addPackageDeps(path.join(frameworkDir, 'package.json'), frameworkNormalizedDir);
 
-    return Array.from(entries, ([realDir, pkgName]) => ({ realDir, pkgName })).sort(
+    return Array.from(entries, ([realDir, normalizedDir]) => ({ realDir, normalizedDir })).sort(
       (a, b) => b.realDir.length - a.realDir.length,
     );
+  }
+
+  #realpath(filepath: string): string {
+    const cached = this.#realpathCache.get(filepath);
+    if (cached) return cached;
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(filepath);
+    } catch {
+      resolved = filepath;
+    }
+    this.#realpathCache.set(filepath, resolved);
+    return resolved;
   }
 }

--- a/tools/egg-bundler/src/lib/ManifestLoader.ts
+++ b/tools/egg-bundler/src/lib/ManifestLoader.ts
@@ -52,7 +52,7 @@ export class ManifestLoader {
   constructor(options: ManifestLoaderOptions) {
     this.#baseDir = options.baseDir;
     this.#manifestPath = options.manifestPath ?? path.join(options.baseDir, '.egg', 'manifest.json');
-    this.#autoGenerate = options.autoGenerate ?? true;
+    this.#autoGenerate = options.autoGenerate ?? false;
     this.#env = options.env;
     this.#scope = options.scope;
     this.#framework = options.framework ?? FRAMEWORK_DEFAULT;
@@ -167,6 +167,9 @@ export class ManifestLoader {
   async #generate(): Promise<void> {
     const scriptUrl = new URL('../scripts/generate-manifest.mjs', import.meta.url);
     const scriptPath = fileURLToPath(scriptUrl);
+    if (!fs.existsSync(scriptPath)) {
+      throw new Error(`[@eggjs/egg-bundler] manifest auto-generation is not available: ${scriptPath} does not exist`);
+    }
     const payload = {
       baseDir: this.#baseDir,
       framework: this.#resolveFrameworkPath(),

--- a/tools/egg-bundler/src/lib/ManifestLoader.ts
+++ b/tools/egg-bundler/src/lib/ManifestLoader.ts
@@ -1,16 +1,17 @@
-import { fork } from 'node:child_process';
-import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { debuglog } from 'node:util';
 
 import { ManifestStore, type StartupManifest } from '@eggjs/core';
+import { execaNode } from 'execa';
 
 const debug = debuglog('egg/bundler/manifest-loader');
 
 const SUPPORTED_MANIFEST_VERSION = 1;
 const FRAMEWORK_DEFAULT = 'egg';
+const PACKAGE_ENTRY_CONDITIONS = ['import', 'module', 'node', 'default', 'require', 'development', 'production'];
 
 export interface ManifestLoaderOptions {
   baseDir: string;
@@ -63,19 +64,19 @@ export class ManifestLoader {
   async load(): Promise<StartupManifest> {
     if (this.#manifest) return this.#manifest;
 
-    let data = this.#readFromDisk();
+    let data = await this.#readFromDisk();
     if (!data) {
       if (!this.#autoGenerate) {
         throw new Error(`[@eggjs/egg-bundler] manifest not found at ${this.#manifestPath}`);
       }
       await this.#generate();
-      data = this.#readFromDisk();
+      data = await this.#readFromDisk();
       if (!data) {
         throw new Error(`[@eggjs/egg-bundler] manifest generation did not produce ${this.#manifestPath}`);
       }
     }
 
-    const normalized = this.#normalize(data);
+    const normalized = await this.#normalize(data);
     this.#manifest = normalized;
     this.#store = ManifestStore.fromBundle(normalized, this.#baseDir);
     return normalized;
@@ -140,10 +141,10 @@ export class ManifestLoader {
     return path.resolve(this.#baseDir, rel);
   }
 
-  #readFromDisk(): StartupManifest | undefined {
+  async #readFromDisk(): Promise<StartupManifest | undefined> {
     let raw: string;
     try {
-      raw = fs.readFileSync(this.#manifestPath, 'utf-8');
+      raw = await fsp.readFile(this.#manifestPath, 'utf-8');
     } catch {
       return undefined;
     }
@@ -167,35 +168,140 @@ export class ManifestLoader {
   async #generate(): Promise<void> {
     const scriptUrl = new URL('../scripts/generate-manifest.mjs', import.meta.url);
     const scriptPath = fileURLToPath(scriptUrl);
-    if (!fs.existsSync(scriptPath)) {
+    try {
+      await fsp.access(scriptPath);
+    } catch {
       throw new Error(`[@eggjs/egg-bundler] manifest auto-generation is not available: ${scriptPath} does not exist`);
     }
     const payload = {
       baseDir: this.#baseDir,
       framework: this.#resolveFrameworkPath(),
+      frameworkEntry: await this.#resolveFrameworkEntryUrl(),
       env: this.#env,
       scope: this.#scope,
     };
-    debug('fork generate-manifest: %o', payload);
+    debug('execa generate-manifest: %o', payload);
 
-    await new Promise<void>((resolve, reject) => {
-      const child = fork(scriptPath, [JSON.stringify(payload)], {
-        stdio: 'inherit',
-        execArgv: this.#execArgv ?? process.execArgv,
-        env: {
-          ...process.env,
-          EGG_MANIFEST: 'true',
-        },
-      });
-      child.on('exit', (code, signal) => {
-        if (code === 0) resolve();
-        else
-          reject(
-            new Error(`[@eggjs/egg-bundler] manifest generate subprocess exited with code=${code} signal=${signal}`),
-          );
-      });
-      child.on('error', reject);
+    await execaNode(scriptPath, [JSON.stringify(payload)], {
+      stdio: 'inherit',
+      nodeOptions: this.#buildExecArgv(),
+      env: {
+        ...process.env,
+        EGG_MANIFEST: 'true',
+      },
     });
+  }
+
+  #isTsxImportTarget(specifier: string): boolean {
+    if (specifier === 'tsx' || specifier === 'tsx/esm') return true;
+
+    let normalized = specifier;
+    if (specifier.startsWith('file://')) {
+      try {
+        normalized = fileURLToPath(specifier);
+      } catch {
+        return false;
+      }
+    }
+
+    normalized = normalized.replaceAll('\\', '/');
+    return normalized.endsWith('/tsx/dist/esm/index.mjs') || normalized.endsWith('/tsx/esm/index.mjs');
+  }
+
+  #hasTsxLoader(base: readonly string[]): boolean {
+    for (let i = 0; i < base.length; i++) {
+      const arg = base[i];
+      let importTarget: string | undefined;
+
+      if (arg === '--import') {
+        importTarget = base[i + 1];
+        i++;
+      } else if (arg.startsWith('--import=')) {
+        importTarget = arg.slice('--import='.length);
+      }
+
+      if (importTarget && this.#isTsxImportTarget(importTarget)) return true;
+    }
+
+    return false;
+  }
+
+  #buildExecArgv(): string[] {
+    const base = this.#execArgv ?? process.execArgv;
+    if (this.#hasTsxLoader(base)) return [...base];
+    try {
+      const req = createRequire(import.meta.url);
+      const tsxEsm = req.resolve('tsx/esm');
+      return [...base, `--import=${pathToFileURL(tsxEsm).href}`];
+    } catch {
+      debug('tsx/esm not resolvable from @eggjs/egg-bundler; falling back to inherited execArgv');
+      return [...base];
+    }
+  }
+
+  #resolvePackageEntry(target: unknown): string | undefined {
+    if (typeof target === 'string') return target;
+    if (Array.isArray(target)) {
+      for (const item of target) {
+        const resolved = this.#resolvePackageEntry(item);
+        if (resolved) return resolved;
+      }
+      return undefined;
+    }
+    if (!target || typeof target !== 'object') return undefined;
+
+    const map = target as Record<string, unknown>;
+    const used = new Set<string>();
+    for (const key of PACKAGE_ENTRY_CONDITIONS) {
+      used.add(key);
+      const resolved = this.#resolvePackageEntry(map[key]);
+      if (resolved) return resolved;
+    }
+    for (const [key, value] of Object.entries(map)) {
+      if (used.has(key)) continue;
+      const resolved = this.#resolvePackageEntry(value);
+      if (resolved) return resolved;
+    }
+    return undefined;
+  }
+
+  #resolveExportsEntry(exportsField: Record<string, unknown> | string): string | undefined {
+    if (typeof exportsField === 'string') return exportsField;
+
+    const keys = Object.keys(exportsField);
+    const rootTarget = keys.length > 0 && !keys.some((key) => key.startsWith('.')) ? exportsField : exportsField['.'];
+    return this.#resolvePackageEntry(rootTarget);
+  }
+
+  #resolvePackageEntryUrl(frameworkDir: string, entryRel: string, pkgJsonPath: string): string {
+    if (path.isAbsolute(entryRel) || /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(entryRel)) {
+      throw new Error(`[@eggjs/egg-bundler] framework package ${pkgJsonPath} entry must be a relative path`);
+    }
+    const entryPath = path.resolve(frameworkDir, entryRel);
+    const rel = path.relative(frameworkDir, entryPath);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error(`[@eggjs/egg-bundler] framework package ${pkgJsonPath} entry escapes package root`);
+    }
+    return pathToFileURL(entryPath).href;
+  }
+
+  async #resolveFrameworkEntryUrl(): Promise<string> {
+    const frameworkDir = this.#resolveFrameworkPath();
+    const pkgJsonPath = path.join(frameworkDir, 'package.json');
+    const pkg = JSON.parse(await fsp.readFile(pkgJsonPath, 'utf-8')) as {
+      exports?: Record<string, unknown> | string;
+      main?: string;
+      module?: string;
+    };
+    let entryRel: string | undefined;
+    if (pkg.exports) {
+      entryRel = this.#resolveExportsEntry(pkg.exports);
+    }
+    entryRel = entryRel ?? pkg.module ?? pkg.main;
+    if (!entryRel) {
+      throw new Error(`[@eggjs/egg-bundler] framework package ${pkgJsonPath} has no resolvable entry`);
+    }
+    return this.#resolvePackageEntryUrl(frameworkDir, entryRel, pkgJsonPath);
   }
 
   #resolveFrameworkPath(): string {
@@ -210,24 +316,24 @@ export class ManifestLoader {
 
   // --- Key normalization ---
 
-  #normalize(data: StartupManifest): StartupManifest {
-    const moduleMap = this.#buildModuleMap();
+  async #normalize(data: StartupManifest): Promise<StartupManifest> {
+    const moduleMap = await this.#buildModuleMap();
     debug('moduleMap size: %d', moduleMap.length);
 
     const normalizedDiscovery: Record<string, string[]> = {};
     for (const [key, files] of Object.entries(data.fileDiscovery)) {
-      const newKey = this.#normalizeRelKey(key, moduleMap);
+      const newKey = await this.#normalizeRelKey(key, moduleMap);
       normalizedDiscovery[newKey] = files;
     }
 
     const normalizedResolveCache: Record<string, string | null> = {};
     for (const [key, value] of Object.entries(data.resolveCache)) {
-      const newKey = this.#normalizeRelKey(key, moduleMap);
-      const newValue = value === null ? null : this.#normalizeRelKey(value, moduleMap);
+      const newKey = await this.#normalizeRelKey(key, moduleMap);
+      const newValue = value === null ? null : await this.#normalizeRelKey(value, moduleMap);
       normalizedResolveCache[newKey] = newValue;
     }
 
-    const normalizedExtensions = this.#normalizeExtensions(data.extensions ?? {}, moduleMap);
+    const normalizedExtensions = await this.#normalizeExtensions(data.extensions ?? {}, moduleMap);
 
     return {
       ...data,
@@ -237,7 +343,7 @@ export class ManifestLoader {
     };
   }
 
-  #normalizeRelKey(relKey: string, moduleMap: ModuleMapEntry[]): string {
+  async #normalizeRelKey(relKey: string, moduleMap: ModuleMapEntry[]): Promise<string> {
     if (!relKey) return relKey;
     // Already inside baseDir, relative, and not escaping — leave as-is.
     if (
@@ -249,7 +355,7 @@ export class ManifestLoader {
       return relKey;
     }
     const abs = path.resolve(this.#baseDir, relKey);
-    const realAbs = this.#realpath(abs);
+    const realAbs = await this.#realpath(abs);
     let best: ModuleMapEntry | undefined;
     for (const entry of moduleMap) {
       if (realAbs === entry.realDir || realAbs.startsWith(entry.realDir + path.sep)) {
@@ -266,44 +372,49 @@ export class ManifestLoader {
     return normalized;
   }
 
-  #normalizeExtensions(extensions: Record<string, unknown> = {}, moduleMap: ModuleMapEntry[]): Record<string, unknown> {
+  async #normalizeExtensions(
+    extensions: Record<string, unknown> = {},
+    moduleMap: ModuleMapEntry[],
+  ): Promise<Record<string, unknown>> {
     const result: Record<string, unknown> = { ...extensions };
     const tegg = extensions?.tegg as TeggManifestExtension | undefined;
     if (tegg?.moduleDescriptors) {
       result.tegg = {
         ...tegg,
-        moduleDescriptors: tegg.moduleDescriptors.map((desc) => {
-          if (!path.isAbsolute(desc.unitPath)) return desc;
-          const real = this.#realpath(desc.unitPath);
-          let best: ModuleMapEntry | undefined;
-          for (const entry of moduleMap) {
-            if (real === entry.realDir || real.startsWith(entry.realDir + path.sep)) {
-              best = entry;
-              break;
+        moduleDescriptors: await Promise.all(
+          tegg.moduleDescriptors.map(async (desc) => {
+            if (!path.isAbsolute(desc.unitPath)) return desc;
+            const real = await this.#realpath(desc.unitPath);
+            let best: ModuleMapEntry | undefined;
+            for (const entry of moduleMap) {
+              if (real === entry.realDir || real.startsWith(entry.realDir + path.sep)) {
+                best = entry;
+                break;
+              }
             }
-          }
-          if (!best) {
-            // keep as relative-to-baseDir form so runtime can resolve via #resolveFromBase
-            const rel = path.relative(this.#baseDir, real).replaceAll(path.sep, '/');
-            return { ...desc, unitPath: rel };
-          }
-          const rest = real === best.realDir ? '' : real.slice(best.realDir.length + 1);
-          const unitPath = [best.normalizedDir, rest].filter(Boolean).join('/').replaceAll(path.sep, '/');
-          return { ...desc, unitPath };
-        }),
+            if (!best) {
+              // keep as relative-to-baseDir form so runtime can resolve via #resolveFromBase
+              const rel = path.relative(this.#baseDir, real).replaceAll(path.sep, '/');
+              return { ...desc, unitPath: rel };
+            }
+            const rest = real === best.realDir ? '' : real.slice(best.realDir.length + 1);
+            const unitPath = [best.normalizedDir, rest].filter(Boolean).join('/').replaceAll(path.sep, '/');
+            return { ...desc, unitPath };
+          }),
+        ),
       };
     }
     return result;
   }
 
-  #buildModuleMap(): ModuleMapEntry[] {
+  async #buildModuleMap(): Promise<ModuleMapEntry[]> {
     const entries = new Map<string, string>();
     const seen = new Set<string>();
 
-    const addPackageDeps = (packageJsonPath: string, parentNormalizedDir: string): void => {
+    const addPackageDeps = async (packageJsonPath: string, parentNormalizedDir: string): Promise<void> => {
       let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
       try {
-        pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+        pkg = JSON.parse(await fsp.readFile(packageJsonPath, 'utf-8'));
       } catch {
         return;
       }
@@ -312,34 +423,34 @@ export class ManifestLoader {
       for (const name of depNames) {
         try {
           const depPkgJson = req.resolve(`${name}/package.json`);
-          const realDir = this.#realpath(path.dirname(depPkgJson));
+          const realDir = await this.#realpath(path.dirname(depPkgJson));
           if (seen.has(realDir)) continue;
           seen.add(realDir);
           const normalizedDir = [parentNormalizedDir, 'node_modules', name].filter(Boolean).join('/');
           if (!entries.has(realDir)) entries.set(realDir, normalizedDir);
-          addPackageDeps(depPkgJson, normalizedDir);
+          await addPackageDeps(depPkgJson, normalizedDir);
         } catch {
           /* dep not resolvable (optional/peer); skip */
         }
       }
     };
 
-    addPackageDeps(path.join(this.#baseDir, 'package.json'), '');
+    await addPackageDeps(path.join(this.#baseDir, 'package.json'), '');
     const frameworkDir = this.#resolveFrameworkPath();
-    const frameworkNormalizedDir = entries.get(this.#realpath(frameworkDir)) ?? '';
-    addPackageDeps(path.join(frameworkDir, 'package.json'), frameworkNormalizedDir);
+    const frameworkNormalizedDir = entries.get(await this.#realpath(frameworkDir)) ?? '';
+    await addPackageDeps(path.join(frameworkDir, 'package.json'), frameworkNormalizedDir);
 
     return Array.from(entries, ([realDir, normalizedDir]) => ({ realDir, normalizedDir })).sort(
       (a, b) => b.realDir.length - a.realDir.length,
     );
   }
 
-  #realpath(filepath: string): string {
+  async #realpath(filepath: string): Promise<string> {
     const cached = this.#realpathCache.get(filepath);
     if (cached) return cached;
     let resolved: string;
     try {
-      resolved = fs.realpathSync(filepath);
+      resolved = await fsp.realpath(filepath);
     } catch {
       resolved = filepath;
     }

--- a/tools/egg-bundler/src/lib/ManifestLoader.ts
+++ b/tools/egg-bundler/src/lib/ManifestLoader.ts
@@ -1,0 +1,328 @@
+import { fork } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { debuglog } from 'node:util';
+
+import type { ManifestStore, StartupManifest } from '@eggjs/core';
+
+const debug = debuglog('egg/bundler/manifest-loader');
+
+const SUPPORTED_MANIFEST_VERSION = 1;
+const FRAMEWORK_DEFAULT = 'egg';
+
+export interface ManifestLoaderOptions {
+  baseDir: string;
+  framework?: string;
+  manifestPath?: string;
+  autoGenerate?: boolean;
+  env?: string;
+  scope?: string;
+  execArgv?: string[];
+}
+
+interface TeggModuleDescriptor {
+  unitPath: string;
+  decoratedFiles?: string[];
+}
+
+interface TeggManifestExtension {
+  moduleDescriptors?: TeggModuleDescriptor[];
+}
+
+interface ModuleMapEntry {
+  realDir: string;
+  pkgName: string;
+}
+
+export class ManifestLoader {
+  readonly #baseDir: string;
+  readonly #manifestPath: string;
+  readonly #autoGenerate: boolean;
+  readonly #env: string | undefined;
+  readonly #scope: string | undefined;
+  readonly #framework: string;
+  readonly #execArgv: string[] | undefined;
+  #manifest: StartupManifest | undefined;
+  #store: ManifestStore | undefined;
+
+  constructor(options: ManifestLoaderOptions) {
+    this.#baseDir = options.baseDir;
+    this.#manifestPath = options.manifestPath ?? path.join(options.baseDir, '.egg', 'manifest.json');
+    this.#autoGenerate = options.autoGenerate ?? true;
+    this.#env = options.env;
+    this.#scope = options.scope;
+    this.#framework = options.framework ?? FRAMEWORK_DEFAULT;
+    this.#execArgv = options.execArgv;
+  }
+
+  async load(): Promise<StartupManifest> {
+    if (this.#manifest) return this.#manifest;
+
+    let data = this.#readFromDisk();
+    if (!data) {
+      if (!this.#autoGenerate) {
+        throw new Error(`[@eggjs/egg-bundler] manifest not found at ${this.#manifestPath}`);
+      }
+      await this.#generate();
+      data = this.#readFromDisk();
+      if (!data) {
+        throw new Error(`[@eggjs/egg-bundler] manifest generation did not produce ${this.#manifestPath}`);
+      }
+    }
+
+    const normalized = this.#normalize(data);
+    this.#manifest = normalized;
+    // TODO: wire ManifestStore.fromBundle once @eggjs/core exposes it (tracked in
+    // a separate runtime split). Until then, the #store getter throws when accessed.
+    return normalized;
+  }
+
+  get manifest(): StartupManifest {
+    if (!this.#manifest) {
+      throw new Error('[@eggjs/egg-bundler] ManifestLoader.load() must be awaited before accessing manifest');
+    }
+    return this.#manifest;
+  }
+
+  get store(): ManifestStore {
+    if (!this.#store) {
+      throw new Error('[@eggjs/egg-bundler] ManifestLoader.load() must be awaited before accessing store');
+    }
+    return this.#store;
+  }
+
+  getAllDiscoveredFiles(): string[] {
+    const m = this.manifest;
+    const files: string[] = [];
+    for (const [relDir, relFiles] of Object.entries(m.fileDiscovery)) {
+      const absDir = this.#resolveFromBase(relDir);
+      for (const relFile of relFiles) {
+        files.push(path.resolve(absDir, relFile));
+      }
+    }
+    files.sort();
+    return files;
+  }
+
+  getTeggDecoratedFiles(): string[] {
+    const ext = this.manifest.extensions?.tegg as TeggManifestExtension | undefined;
+    const descriptors = ext?.moduleDescriptors;
+    if (!descriptors) return [];
+    const files: string[] = [];
+    for (const desc of descriptors) {
+      const unitAbs = path.isAbsolute(desc.unitPath) ? desc.unitPath : this.#resolveFromBase(desc.unitPath);
+      for (const rel of desc.decoratedFiles ?? []) {
+        files.push(path.resolve(unitAbs, rel));
+      }
+    }
+    files.sort();
+    return files;
+  }
+
+  #resolveFromBase(rel: string): string {
+    if (path.isAbsolute(rel)) return rel;
+    if (rel.startsWith('node_modules/')) {
+      const req = createRequire(path.join(this.#baseDir, 'package.json'));
+      const rest = rel.slice('node_modules/'.length);
+      const slashIdx = rest.startsWith('@') ? rest.indexOf('/', rest.indexOf('/') + 1) : rest.indexOf('/');
+      const pkgName = slashIdx === -1 ? rest : rest.slice(0, slashIdx);
+      const sub = slashIdx === -1 ? '' : rest.slice(slashIdx + 1);
+      try {
+        const pkgJson = req.resolve(`${pkgName}/package.json`);
+        return path.resolve(path.dirname(pkgJson), sub);
+      } catch {
+        return path.resolve(this.#baseDir, rel);
+      }
+    }
+    return path.resolve(this.#baseDir, rel);
+  }
+
+  #readFromDisk(): StartupManifest | undefined {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.#manifestPath, 'utf-8');
+    } catch {
+      return undefined;
+    }
+    const parsed = JSON.parse(raw) as StartupManifest;
+    if (parsed.version !== SUPPORTED_MANIFEST_VERSION) {
+      throw new Error(
+        `[@eggjs/egg-bundler] manifest version mismatch at ${this.#manifestPath}: expected ${SUPPORTED_MANIFEST_VERSION}, got ${parsed.version}`,
+      );
+    }
+    return parsed;
+  }
+
+  async #generate(): Promise<void> {
+    const scriptUrl = new URL('../scripts/generate-manifest.mjs', import.meta.url);
+    const scriptPath = fileURLToPath(scriptUrl);
+    const payload = {
+      baseDir: this.#baseDir,
+      framework: this.#resolveFrameworkPath(),
+      env: this.#env,
+      scope: this.#scope,
+    };
+    debug('fork generate-manifest: %o', payload);
+
+    await new Promise<void>((resolve, reject) => {
+      const child = fork(scriptPath, [JSON.stringify(payload)], {
+        stdio: 'inherit',
+        execArgv: this.#execArgv ?? process.execArgv,
+        env: {
+          ...process.env,
+          EGG_MANIFEST: 'true',
+        },
+      });
+      child.on('exit', (code, signal) => {
+        if (code === 0) resolve();
+        else
+          reject(
+            new Error(`[@eggjs/egg-bundler] manifest generate subprocess exited with code=${code} signal=${signal}`),
+          );
+      });
+      child.on('error', reject);
+    });
+  }
+
+  #resolveFrameworkPath(): string {
+    if (path.isAbsolute(this.#framework)) return this.#framework;
+    try {
+      const req = createRequire(path.join(this.#baseDir, 'package.json'));
+      const pkgJson = req.resolve(`${this.#framework}/package.json`);
+      return path.dirname(pkgJson);
+    } catch {
+      return this.#framework;
+    }
+  }
+
+  // --- Key normalization ---
+
+  #normalize(data: StartupManifest): StartupManifest {
+    const moduleMap = this.#buildModuleMap();
+    debug('moduleMap size: %d', moduleMap.length);
+
+    const normalizedDiscovery: Record<string, string[]> = {};
+    for (const [key, files] of Object.entries(data.fileDiscovery)) {
+      const newKey = this.#normalizeRelKey(key, moduleMap);
+      normalizedDiscovery[newKey] = files;
+    }
+
+    const normalizedResolveCache: Record<string, string | null> = {};
+    for (const [key, value] of Object.entries(data.resolveCache)) {
+      const newKey = this.#normalizeRelKey(key, moduleMap);
+      const newValue = value === null ? null : this.#normalizeRelKey(value, moduleMap);
+      normalizedResolveCache[newKey] = newValue;
+    }
+
+    const normalizedExtensions = this.#normalizeExtensions(data.extensions, moduleMap);
+
+    return {
+      ...data,
+      extensions: normalizedExtensions,
+      fileDiscovery: normalizedDiscovery,
+      resolveCache: normalizedResolveCache,
+    };
+  }
+
+  #normalizeRelKey(relKey: string, moduleMap: ModuleMapEntry[]): string {
+    if (!relKey) return relKey;
+    // Already inside baseDir and not escaping — leave as-is.
+    if (!relKey.startsWith('..') && !relKey.includes('node_modules/') && !relKey.includes('.pnpm/')) {
+      return relKey;
+    }
+    const abs = path.resolve(this.#baseDir, relKey);
+    let realAbs: string;
+    try {
+      realAbs = fs.realpathSync(abs);
+    } catch {
+      realAbs = abs;
+    }
+    // Longest-prefix match
+    let best: ModuleMapEntry | undefined;
+    for (const entry of moduleMap) {
+      if (realAbs === entry.realDir || realAbs.startsWith(entry.realDir + path.sep)) {
+        if (!best || entry.realDir.length > best.realDir.length) {
+          best = entry;
+        }
+      }
+    }
+    if (!best) {
+      debug('normalize: no match for %o (real=%o)', relKey, realAbs);
+      return relKey;
+    }
+    const rest = realAbs === best.realDir ? '' : realAbs.slice(best.realDir.length + 1);
+    const normalized = ['node_modules', best.pkgName, rest].filter(Boolean).join('/').replaceAll(path.sep, '/');
+    return normalized;
+  }
+
+  #normalizeExtensions(extensions: Record<string, unknown>, moduleMap: ModuleMapEntry[]): Record<string, unknown> {
+    const result: Record<string, unknown> = { ...extensions };
+    const tegg = extensions?.tegg as TeggManifestExtension | undefined;
+    if (tegg?.moduleDescriptors) {
+      result.tegg = {
+        ...tegg,
+        moduleDescriptors: tegg.moduleDescriptors.map((desc) => {
+          if (!path.isAbsolute(desc.unitPath)) return desc;
+          let real: string;
+          try {
+            real = fs.realpathSync(desc.unitPath);
+          } catch {
+            real = desc.unitPath;
+          }
+          let best: ModuleMapEntry | undefined;
+          for (const entry of moduleMap) {
+            if (real === entry.realDir || real.startsWith(entry.realDir + path.sep)) {
+              if (!best || entry.realDir.length > best.realDir.length) best = entry;
+            }
+          }
+          if (!best) {
+            // keep as relative-to-baseDir form so runtime can resolve via #resolveFromBase
+            const rel = path.relative(this.#baseDir, real).replaceAll(path.sep, '/');
+            return { ...desc, unitPath: rel };
+          }
+          const rest = real === best.realDir ? '' : real.slice(best.realDir.length + 1);
+          const unitPath = ['node_modules', best.pkgName, rest].filter(Boolean).join('/');
+          return { ...desc, unitPath };
+        }),
+      };
+    }
+    return result;
+  }
+
+  #buildModuleMap(): ModuleMapEntry[] {
+    const entries = new Map<string, string>();
+    const seenPkgs = new Set<string>();
+
+    const addFromPackageJson = (packageJsonPath: string): void => {
+      let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+      try {
+        pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      } catch {
+        return;
+      }
+      const req = createRequire(packageJsonPath);
+      const depNames = [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})];
+      for (const name of depNames) {
+        if (seenPkgs.has(name)) continue;
+        seenPkgs.add(name);
+        try {
+          const depPkgJson = req.resolve(`${name}/package.json`);
+          const realDir = fs.realpathSync(path.dirname(depPkgJson));
+          if (!entries.has(realDir)) entries.set(realDir, name);
+        } catch {
+          /* dep not resolvable (optional/peer); skip */
+        }
+      }
+    };
+
+    addFromPackageJson(path.join(this.#baseDir, 'package.json'));
+    const frameworkDir = this.#resolveFrameworkPath();
+    addFromPackageJson(path.join(frameworkDir, 'package.json'));
+
+    return Array.from(entries, ([realDir, pkgName]) => ({ realDir, pkgName })).sort(
+      (a, b) => b.realDir.length - a.realDir.length,
+    );
+  }
+}

--- a/tools/egg-bundler/src/scripts/generate-manifest.mjs
+++ b/tools/egg-bundler/src/scripts/generate-manifest.mjs
@@ -1,0 +1,68 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { debuglog } from 'node:util';
+
+const debug = debuglog('egg/bundler/scripts/generate-manifest');
+
+async function readOptions() {
+  if (process.argv[2]) {
+    return JSON.parse(process.argv[2]);
+  }
+
+  let raw = '';
+  for await (const chunk of process.stdin) {
+    raw += chunk;
+  }
+  return JSON.parse(raw);
+}
+
+async function main() {
+  debug('argv: %o', process.argv);
+  const options = await readOptions();
+  debug('generate manifest options: %o', options);
+
+  if (options.env) {
+    process.env.EGG_SERVER_ENV = options.env;
+  }
+  if (options.scope) {
+    process.env.EGG_SERVER_SCOPE = options.scope;
+  }
+  process.env.EGG_MANIFEST = 'true';
+
+  const { ManifestStore } = await import('@eggjs/core');
+
+  let framework;
+  if (options.frameworkEntry) {
+    framework = await import(options.frameworkEntry);
+  } else if (options.framework) {
+    const specifier = path.isAbsolute(options.framework) ? pathToFileURL(options.framework).href : options.framework;
+    framework = await import(specifier);
+  } else {
+    framework = await import('egg');
+  }
+
+  const app = await framework.start({
+    baseDir: options.baseDir,
+    framework: options.framework,
+    env: options.env,
+    mode: 'single',
+  });
+
+  const manifest = app.loader.generateManifest();
+  await ManifestStore.write(options.baseDir, manifest);
+
+  const resolveCacheCount = Object.keys(manifest.resolveCache).length;
+  const fileDiscoveryCount = Object.keys(manifest.fileDiscovery).length;
+  const extensionCount = Object.keys(manifest.extensions).length;
+  console.log('[bundler-manifest] generated v%d at %s', manifest.version, manifest.generatedAt);
+  console.log('[bundler-manifest]   resolveCache: %d', resolveCacheCount);
+  console.log('[bundler-manifest]   fileDiscovery: %d', fileDiscoveryCount);
+  console.log('[bundler-manifest]   extensions: %d', extensionCount);
+
+  await app.close();
+}
+
+main().catch((err) => {
+  console.error('[bundler-manifest] generation failed:', err);
+  process.exit(1);
+});

--- a/tools/egg-bundler/test/ManifestLoader.test.ts
+++ b/tools/egg-bundler/test/ManifestLoader.test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { StartupManifest } from '@eggjs/core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ManifestLoader } from '../src/lib/ManifestLoader.ts';
+
+const tempDirs: string[] = [];
+
+function createTempApp(): string {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'egg-bundler-manifest-loader-'));
+  tempDirs.push(baseDir);
+  return baseDir;
+}
+
+function writeJson(filepath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filepath), { recursive: true });
+  fs.writeFileSync(filepath, JSON.stringify(data, null, 2));
+}
+
+function manifest(overrides: Partial<StartupManifest> = {}): StartupManifest {
+  return {
+    version: 1,
+    generatedAt: '2026-04-30T00:00:00.000Z',
+    invalidation: {
+      lockfileFingerprint: '',
+      configFingerprint: '',
+      serverEnv: 'prod',
+      serverScope: '',
+      typescriptEnabled: true,
+    },
+    extensions: {},
+    resolveCache: {},
+    fileDiscovery: {},
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('ManifestLoader', () => {
+  it('normalizes absolute manifest paths through nested dependency package roots', async () => {
+    const baseDir = createTempApp();
+    const directRoot = path.join(baseDir, 'node_modules/direct');
+    const transitiveRoot = path.join(directRoot, 'node_modules/transitive');
+    const transitiveLib = path.join(transitiveRoot, 'lib');
+    const transitiveFile = path.join(transitiveLib, 'svc.ts');
+
+    writeJson(path.join(baseDir, 'package.json'), {
+      dependencies: {
+        direct: '1.0.0',
+      },
+    });
+    writeJson(path.join(directRoot, 'package.json'), {
+      name: 'direct',
+      version: '1.0.0',
+      dependencies: {
+        transitive: '1.0.0',
+      },
+    });
+    writeJson(path.join(transitiveRoot, 'package.json'), {
+      name: 'transitive',
+      version: '1.0.0',
+    });
+    fs.mkdirSync(transitiveLib, { recursive: true });
+    fs.writeFileSync(transitiveFile, 'export const value = 1;\n');
+
+    const manifestPath = path.join(baseDir, '.egg/manifest.json');
+    writeJson(
+      manifestPath,
+      manifest({
+        fileDiscovery: {
+          [transitiveLib]: ['svc.ts'],
+        },
+        resolveCache: {
+          [path.join(transitiveRoot, 'entry')]: transitiveFile,
+        },
+        extensions: {
+          tegg: {
+            moduleDescriptors: [
+              {
+                unitPath: transitiveRoot,
+                decoratedFiles: ['lib/svc.ts'],
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    const loader = new ManifestLoader({ baseDir, manifestPath, autoGenerate: false });
+    const loaded = await loader.load();
+
+    expect(loaded.fileDiscovery).toEqual({
+      'node_modules/direct/node_modules/transitive/lib': ['svc.ts'],
+    });
+    expect(loaded.resolveCache).toEqual({
+      'node_modules/direct/node_modules/transitive/entry': 'node_modules/direct/node_modules/transitive/lib/svc.ts',
+    });
+    expect(loaded.extensions.tegg).toEqual({
+      moduleDescriptors: [
+        {
+          unitPath: 'node_modules/direct/node_modules/transitive',
+          decoratedFiles: ['lib/svc.ts'],
+        },
+      ],
+    });
+    expect(loader.getAllDiscoveredFiles()).toEqual([transitiveFile]);
+    expect(loader.getTeggDecoratedFiles()).toEqual([transitiveFile]);
+    expect(loader.store.data).toBe(loaded);
+  });
+
+  it('loads older minimal manifests without extensions', async () => {
+    const baseDir = createTempApp();
+    writeJson(path.join(baseDir, 'package.json'), {});
+    const manifestPath = path.join(baseDir, '.egg/manifest.json');
+    writeJson(manifestPath, {
+      ...manifest(),
+      extensions: undefined,
+    });
+
+    const loaded = await new ManifestLoader({ baseDir, manifestPath, autoGenerate: false }).load();
+
+    expect(loaded.extensions).toEqual({});
+  });
+
+  it('includes the manifest path when JSON parsing fails', async () => {
+    const baseDir = createTempApp();
+    const manifestPath = path.join(baseDir, '.egg/manifest.json');
+    fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+    fs.writeFileSync(manifestPath, 'not json{{{');
+
+    const loader = new ManifestLoader({ baseDir, manifestPath, autoGenerate: false });
+
+    await expect(loader.load()).rejects.toThrow(`invalid manifest JSON at ${manifestPath}`);
+  });
+});

--- a/tools/egg-bundler/test/ManifestLoader.test.ts
+++ b/tools/egg-bundler/test/ManifestLoader.test.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import type { StartupManifest } from '@eggjs/core';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -36,6 +38,76 @@ function manifest(overrides: Partial<StartupManifest> = {}): StartupManifest {
     fileDiscovery: {},
     ...overrides,
   };
+}
+
+function generatedManifest(): StartupManifest {
+  return manifest({
+    generatedAt: '2026-04-30T00:00:00.000Z',
+    invalidation: {
+      lockfileFingerprint: '',
+      configFingerprint: '',
+      serverEnv: 'prod',
+      serverScope: '',
+      typescriptEnabled: false,
+    },
+    extensions: {
+      generated: true,
+    },
+    resolveCache: {
+      'app/service/user': 'app/service/user.ts',
+    },
+    fileDiscovery: {
+      'app/service': ['user.ts'],
+    },
+  });
+}
+
+async function createFrameworkFixture(): Promise<{ appDir: string; frameworkDir: string }> {
+  const root = createTempApp();
+  const appDir = path.join(root, 'app');
+  const frameworkDir = path.join(root, 'framework');
+  await fsp.mkdir(path.join(frameworkDir, 'src'), { recursive: true });
+  await fsp.mkdir(appDir, { recursive: true });
+
+  await fsp.writeFile(path.join(appDir, 'package.json'), JSON.stringify({ name: 'app', dependencies: {} }));
+  await fsp.writeFile(
+    path.join(frameworkDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'fake-framework',
+        type: 'module',
+        exports: {
+          import: './src/index.js',
+        },
+        dependencies: {},
+      },
+      null,
+      2,
+    ),
+  );
+  await fsp.writeFile(
+    path.join(frameworkDir, 'src/index.js'),
+    `
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function start(options) {
+  await fs.writeFile(path.join(options.baseDir, 'framework-entry.txt'), import.meta.url);
+  return {
+    loader: {
+      generateManifest() {
+        return ${JSON.stringify(generatedManifest(), null, 10)};
+      },
+    },
+    async close() {
+      await fs.writeFile(path.join(options.baseDir, 'closed.txt'), 'true');
+    },
+  };
+}
+`,
+  );
+
+  return { appDir, frameworkDir };
 }
 
 afterEach(() => {
@@ -138,6 +210,30 @@ describe('ManifestLoader', () => {
     const loader = new ManifestLoader({ baseDir, manifestPath });
 
     await expect(loader.load()).rejects.toThrow(`manifest not found at ${manifestPath}`);
+  });
+
+  it('auto-generates a missing manifest and loads the exact generated data', async () => {
+    const { appDir, frameworkDir } = await createFrameworkFixture();
+    const manifestPath = path.join(appDir, '.egg/manifest.json');
+    const expected = generatedManifest();
+
+    const loader = new ManifestLoader({
+      baseDir: appDir,
+      framework: frameworkDir,
+      autoGenerate: true,
+      env: 'prod',
+      execArgv: [],
+    });
+    const loaded = await loader.load();
+    const written = JSON.parse(await fsp.readFile(manifestPath, 'utf-8'));
+
+    expect(written).toEqual(expected);
+    expect(loaded).toEqual(expected);
+    expect(loader.store.data).toBe(loaded);
+    await expect(fsp.readFile(path.join(appDir, 'closed.txt'), 'utf-8')).resolves.toBe('true');
+    await expect(fsp.readFile(path.join(appDir, 'framework-entry.txt'), 'utf-8')).resolves.toBe(
+      pathToFileURL(path.join(frameworkDir, 'src/index.js')).href,
+    );
   });
 
   it('includes the manifest path when JSON parsing fails', async () => {

--- a/tools/egg-bundler/test/ManifestLoader.test.ts
+++ b/tools/egg-bundler/test/ManifestLoader.test.ts
@@ -130,6 +130,16 @@ describe('ManifestLoader', () => {
     expect(loaded.extensions).toEqual({});
   });
 
+  it('does not auto-generate missing manifests by default', async () => {
+    const baseDir = createTempApp();
+    writeJson(path.join(baseDir, 'package.json'), {});
+    const manifestPath = path.join(baseDir, '.egg/manifest.json');
+
+    const loader = new ManifestLoader({ baseDir, manifestPath });
+
+    await expect(loader.load()).rejects.toThrow(`manifest not found at ${manifestPath}`);
+  });
+
   it('includes the manifest path when JSON parsing fails', async () => {
     const baseDir = createTempApp();
     const manifestPath = path.join(baseDir, '.egg/manifest.json');


### PR DESCRIPTION
Loads `.egg/manifest.json` and normalizes fileDiscovery/resolveCache/tegg keys from realpath form (workspace links, `.pnpm/`) into stable `node_modules/<pkg>/<sub>` form via longest-prefix matching against the app + framework dependency map.

Part of #5863 split. Tracking: #5871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)