### PR TITLE
feat(bundler): define BundlerConfig public API

### DIFF
--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -41,6 +41,13 @@ export interface BundleResult {
   readonly manifestPath: string;
 }
 
+/**
+ * Placeholder API for the future bundling implementation.
+ *
+ * This function is not implemented yet and always throws.
+ * The defaults described on {@link BundlerConfig} are planned behavior and
+ * are not currently applied at runtime.
+ */
 export async function bundle(_config: BundlerConfig): Promise<BundleResult> {
   throw new Error('@eggjs/egg-bundler: bundle() is not implemented yet');
 }

--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -1,1 +1,46 @@
-export {};
+export { ExternalsResolver, type ExternalsConfig, type ExternalsResolverOptions } from './lib/ExternalsResolver.ts';
+export { ManifestLoader, type ManifestLoaderOptions } from './lib/ManifestLoader.ts';
+
+export interface BundlerExternalsConfig {
+  /** Package names to always mark as external, in addition to auto-detected ones. */
+  readonly force?: readonly string[];
+  /** Package names to never mark as external (force inline), overriding auto-detection. */
+  readonly inline?: readonly string[];
+}
+
+export interface BundlerPackConfig {
+  /** Override for the monorepo workspace root. Defaults to auto-detection. */
+  readonly rootPath?: string;
+}
+
+export interface BundlerConfig {
+  /** Application root directory. Required. */
+  readonly baseDir: string;
+  /** Output directory for the bundled artifact. Required. */
+  readonly outputDir: string;
+  /** Path to manifest.json. Defaults to `<baseDir>/.egg/manifest.json`. */
+  readonly manifestPath?: string;
+  /** Framework name or absolute path. Defaults to `'egg'`. */
+  readonly framework?: string;
+  /** Build mode. Defaults to `'production'`. */
+  readonly mode?: 'production' | 'development';
+  /** External package overrides. */
+  readonly externals?: BundlerExternalsConfig;
+  /** @utoo/pack tuning. */
+  readonly pack?: BundlerPackConfig;
+  /** Enable tegg decoratedFile collection. Defaults to `true`. */
+  readonly tegg?: boolean;
+}
+
+export interface BundleResult {
+  /** Absolute path to the output directory. */
+  readonly outputDir: string;
+  /** All artifact files (absolute paths), sorted. */
+  readonly files: readonly string[];
+  /** Absolute path to the normalized bundled manifest. */
+  readonly manifestPath: string;
+}
+
+export async function bundle(_config: BundlerConfig): Promise<BundleResult> {
+  throw new Error('@eggjs/egg-bundler: bundle() is not implemented yet');
+}

--- a/tools/egg-bundler/test/index.test.ts
+++ b/tools/egg-bundler/test/index.test.ts
@@ -1,11 +1,26 @@
-import { strict as assert } from 'node:assert';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
-import { describe, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import * as bundler from '../src/index.js';
+import { bundle, type BundleResult, type BundlerConfig } from '../src/index.js';
 
-describe('test/index.test.ts', () => {
-  it('should load entrypoint', () => {
-    assert.deepEqual(Object.keys(bundler), []);
+describe('@eggjs/egg-bundler', () => {
+  it('exports the expected public API', () => {
+    expect(Object.keys(bundler).sort()).toEqual(['ExternalsResolver', 'ManifestLoader', 'bundle']);
+    expectTypeOf(bundle).toEqualTypeOf<(config: BundlerConfig) => Promise<BundleResult>>();
+  });
+
+  it('bundle() is a placeholder that throws until implemented', async () => {
+    const baseDir = await mkdtemp(path.join(tmpdir(), 'egg-bundler-'));
+    const outputDir = path.join(baseDir, 'out');
+
+    try {
+      await expect(bundle({ baseDir, outputDir })).rejects.toThrow(/not implemented/);
+    } finally {
+      await rm(baseDir, { force: true, recursive: true });
+    }
   });
 });


### PR DESCRIPTION
Exports `BundlerConfig` type and `bundle()` function from `src/index.ts`. `bundle()` currently throws 'Not yet implemented' — wired in C8 (Bundler orchestrator). Adds `test/index.test.ts` smoke test.

Part of #5863 split. Tracking: #5871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)