### PR TITLE
feat(bundler): add PackRunner wrapper over @utoo/pack

### DIFF
--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -28,6 +28,10 @@
       "types": "./src/lib/EntryGenerator.ts",
       "import": "./src/lib/EntryGenerator.ts"
     },
+    "./lib/PackRunner": {
+      "types": "./src/lib/PackRunner.ts",
+      "import": "./src/lib/PackRunner.ts"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -40,6 +44,10 @@
       "./lib/EntryGenerator": {
         "types": "./dist/lib/EntryGenerator.d.ts",
         "import": "./dist/lib/EntryGenerator.js"
+      },
+      "./lib/PackRunner": {
+        "types": "./dist/lib/PackRunner.d.ts",
+        "import": "./dist/lib/PackRunner.js"
       },
       "./package.json": "./package.json"
     }

--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -1,5 +1,14 @@
 export { ExternalsResolver, type ExternalsConfig, type ExternalsResolverOptions } from './lib/ExternalsResolver.ts';
 export { ManifestLoader, type ManifestLoaderOptions } from './lib/ManifestLoader.ts';
+export {
+  PackRunner,
+  type BuildFunc,
+  type PackEntry,
+  type PackRunnerOptions,
+  type PackRunnerResult,
+} from './lib/PackRunner.ts';
+
+import type { BuildFunc } from './lib/PackRunner.ts';
 
 export interface BundlerExternalsConfig {
   /** Package names to always mark as external, in addition to auto-detected ones. */
@@ -9,6 +18,8 @@ export interface BundlerExternalsConfig {
 }
 
 export interface BundlerPackConfig {
+  /** Injection point for tests (T11) to replace the real @utoo/pack build entry. */
+  readonly buildFunc?: BuildFunc;
   /** Override for the monorepo workspace root. Defaults to auto-detection. */
   readonly rootPath?: string;
 }

--- a/tools/egg-bundler/src/lib/PackRunner.ts
+++ b/tools/egg-bundler/src/lib/PackRunner.ts
@@ -1,0 +1,123 @@
+import { promises as fs } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+export interface PackEntry {
+  readonly name: string;
+  readonly filepath: string;
+}
+
+export type BuildFunc = (config: { config: unknown }, projectPath: string, rootPath: string) => Promise<void>;
+
+export interface PackRunnerOptions {
+  readonly entries: readonly PackEntry[];
+  readonly outputDir: string;
+  readonly externals: Readonly<Record<string, string>>;
+  readonly projectPath: string;
+  readonly rootPath?: string;
+  readonly mode?: 'production' | 'development';
+  readonly buildFunc?: BuildFunc;
+}
+
+export interface PackRunnerResult {
+  readonly outputDir: string;
+  readonly files: readonly string[];
+}
+
+// SWC decorator compilation picks up tsconfig from the OUTPUT dir, not the
+// project. Without this, tegg decorator metadata silently drops. (T0 blocker.)
+const OUTPUT_TSCONFIG = {
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    target: 'es2022',
+  },
+};
+
+// @utoo/pack emits CJS files; a nested `type: commonjs` package.json
+// prevents the parent ESM package from forcing these into ESM parse mode.
+const OUTPUT_PACKAGE_JSON = { type: 'commonjs' };
+
+const require = createRequire(import.meta.url);
+
+// Use CJS entry explicitly: under pnpm workspace links the ESM build's
+// extensionless relative imports fail to resolve.
+const DEFAULT_BUILD_FUNC: BuildFunc = async (wrapped, projectPath, rootPath) => {
+  const mod = require('@utoo/pack/cjs/commands/build.js') as {
+    build: (options: unknown, projectPath?: string, rootPath?: string) => Promise<void>;
+  };
+  await mod.build(wrapped, projectPath, rootPath);
+};
+
+export class PackRunner {
+  readonly #options: PackRunnerOptions;
+
+  constructor(options: PackRunnerOptions) {
+    this.#options = options;
+  }
+
+  async run(): Promise<PackRunnerResult> {
+    const {
+      entries,
+      outputDir,
+      externals,
+      projectPath,
+      rootPath = projectPath,
+      mode = 'production',
+      buildFunc = DEFAULT_BUILD_FUNC,
+    } = this.#options;
+
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(path.join(outputDir, 'tsconfig.json'), JSON.stringify(OUTPUT_TSCONFIG, null, 2));
+    await fs.writeFile(path.join(outputDir, 'package.json'), JSON.stringify(OUTPUT_PACKAGE_JSON, null, 2));
+
+    // UMD-form externals ({ commonjs, root }) make @utoo/pack's standalone
+    // output emit a `require(name)` branch under `typeof exports === 'object'`,
+    // which is what node picks. Plain string externals only emit the
+    // `globalThis[name]` branch, unusable for direct node execution.
+    const umdExternals: Record<string, { commonjs: string; root: string }> = {};
+    for (const [k, v] of Object.entries(externals)) {
+      umdExternals[k] = { commonjs: v, root: v };
+    }
+
+    const config = {
+      entry: entries.map((e) => ({ name: e.name, import: e.filepath })),
+      target: 'node 22',
+      platform: 'node',
+      mode,
+      output: {
+        path: outputDir,
+        type: 'standalone',
+      },
+      externals: umdExternals,
+      optimization: {
+        treeShaking: false,
+        minify: false,
+      },
+    };
+
+    try {
+      await buildFunc({ config }, projectPath, rootPath);
+    } catch (err) {
+      const names = entries.map((e) => e.name).join(', ');
+      throw new Error(`PackRunner failed to build ${names}: ${(err as Error).message}`, { cause: err });
+    }
+
+    const files = await this.#collectFiles(outputDir);
+    return { outputDir, files };
+  }
+
+  async #collectFiles(dir: string): Promise<readonly string[]> {
+    const entries = await fs.readdir(dir, {
+      recursive: true,
+      withFileTypes: true,
+    });
+    return entries
+      .filter((d) => d.isFile())
+      .map((d) => {
+        const parent = d.parentPath ?? dir;
+        return path.relative(dir, path.join(parent, d.name));
+      })
+      .sort();
+  }
+}

--- a/tools/egg-bundler/src/lib/PackRunner.ts
+++ b/tools/egg-bundler/src/lib/PackRunner.ts
@@ -100,7 +100,8 @@ export class PackRunner {
       await buildFunc({ config }, projectPath, rootPath);
     } catch (err) {
       const names = entries.map((e) => e.name).join(', ');
-      throw new Error(`PackRunner failed to build ${names}: ${(err as Error).message}`, { cause: err });
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`PackRunner failed to build ${names}: ${message}`, { cause: err });
     }
 
     const files = await this.#collectFiles(outputDir);
@@ -108,16 +109,22 @@ export class PackRunner {
   }
 
   async #collectFiles(dir: string): Promise<readonly string[]> {
-    const entries = await fs.readdir(dir, {
-      recursive: true,
-      withFileTypes: true,
-    });
-    return entries
-      .filter((d) => d.isFile())
-      .map((d) => {
-        const parent = d.parentPath ?? dir;
-        return path.relative(dir, path.join(parent, d.name));
-      })
-      .sort();
+    const files: string[] = [];
+    await this.#collectFilesInDir(dir, dir, files);
+    return files.sort();
+  }
+
+  async #collectFilesInDir(rootDir: string, currentDir: string, files: string[]): Promise<void> {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    await Promise.all(
+      entries.map(async (entry) => {
+        const filepath = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          await this.#collectFilesInDir(rootDir, filepath, files);
+        } else if (entry.isFile()) {
+          files.push(path.relative(rootDir, filepath));
+        }
+      }),
+    );
   }
 }

--- a/tools/egg-bundler/test/PackRunner.default-build.test.ts
+++ b/tools/egg-bundler/test/PackRunner.default-build.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PackRunner } from '../src/lib/PackRunner.ts';
+
+// PackRunner's DEFAULT_BUILD_FUNC uses `createRequire(import.meta.url).require('@utoo/pack/cjs/commands/build.js')`,
+// which bypasses vitest's ESM module interception. Poison the CJS require cache
+// instead so the real `@utoo/pack` code never runs.
+const requireFromPackRunner = createRequire(new URL('../src/lib/PackRunner.ts', import.meta.url));
+const buildModulePath = requireFromPackRunner.resolve('@utoo/pack/cjs/commands/build.js');
+
+describe('PackRunner.DEFAULT_BUILD_FUNC', () => {
+  const originalCacheEntry = requireFromPackRunner.cache[buildModulePath];
+  const mockBuild = vi.fn(async () => undefined);
+
+  beforeEach(() => {
+    mockBuild.mockClear();
+    requireFromPackRunner.cache[buildModulePath] = {
+      id: buildModulePath,
+      filename: buildModulePath,
+      loaded: true,
+      exports: { build: mockBuild },
+    } as unknown as NodeJS.Require['cache'][string];
+  });
+
+  afterEach(() => {
+    if (originalCacheEntry) {
+      requireFromPackRunner.cache[buildModulePath] = originalCacheEntry;
+    } else {
+      delete requireFromPackRunner.cache[buildModulePath];
+    }
+  });
+
+  it('passes wrapped { config } to @utoo/pack build with projectPath and rootPath', async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pack-runner-default-'));
+    try {
+      const runner = new PackRunner({
+        entries: [{ name: 'worker', filepath: '/tmp/entry.ts' }],
+        outputDir,
+        externals: { egg: 'egg' },
+        projectPath: '/tmp/proj',
+        rootPath: '/tmp/root',
+      });
+
+      await runner.run();
+
+      expect(mockBuild).toHaveBeenCalledTimes(1);
+      const call = mockBuild.mock.calls[0] as unknown as [
+        { config: { entry: unknown[]; target: string } },
+        string,
+        string,
+      ];
+      const [firstArg, projectArg, rootArg] = call;
+      expect(firstArg).toHaveProperty('config');
+      expect(firstArg.config.entry).toHaveLength(1);
+      expect(firstArg.config.target).toBe('node 22');
+      expect(projectArg).toBe('/tmp/proj');
+      expect(rootArg).toBe('/tmp/root');
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/egg-bundler/test/PackRunner.test.ts
+++ b/tools/egg-bundler/test/PackRunner.test.ts
@@ -182,4 +182,14 @@ describe('PackRunner', () => {
       expect((err as Error).cause).toBe(original);
     }
   });
+
+  it('wraps non-Error buildFunc failures with a useful message', async () => {
+    const buildFunc: BuildFunc = async () => {
+      throw 'pack crashed as string';
+    };
+
+    await expect(makeRunner({ buildFunc }).run()).rejects.toThrowError(
+      /PackRunner failed to build worker: pack crashed as string/,
+    );
+  });
 });

--- a/tools/egg-bundler/test/PackRunner.test.ts
+++ b/tools/egg-bundler/test/PackRunner.test.ts
@@ -1,0 +1,185 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PackRunner, type BuildFunc, type PackEntry } from '../src/lib/PackRunner.ts';
+
+describe('PackRunner', () => {
+  let tmpDir: string;
+  const createdDirs: string[] = [];
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-pack-runner-'));
+    createdDirs.push(tmpDir);
+  });
+
+  afterEach(async () => {
+    while (createdDirs.length) {
+      const dir = createdDirs.pop()!;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeRunner(
+    overrides: {
+      entries?: readonly PackEntry[];
+      outputDir?: string;
+      externals?: Record<string, string>;
+      projectPath?: string;
+      rootPath?: string;
+      mode?: 'production' | 'development';
+      buildFunc?: BuildFunc;
+    } = {},
+  ): PackRunner {
+    const outputDir = overrides.outputDir ?? path.join(tmpDir, 'out');
+    const projectPath = overrides.projectPath ?? tmpDir;
+    return new PackRunner({
+      entries: overrides.entries ?? [{ name: 'worker', filepath: path.join(tmpDir, 'worker.entry.ts') }],
+      outputDir,
+      externals: overrides.externals ?? {},
+      projectPath,
+      ...(overrides.rootPath !== undefined ? { rootPath: overrides.rootPath } : {}),
+      ...(overrides.mode !== undefined ? { mode: overrides.mode } : {}),
+      buildFunc: overrides.buildFunc ?? (async () => {}),
+    });
+  }
+
+  it('writes the output tsconfig.json with decorator metadata flags set before invoking the build', async () => {
+    let tsconfigAtBuildTime: string | undefined;
+    const buildFunc: BuildFunc = async () => {
+      tsconfigAtBuildTime = await fs.readFile(path.join(tmpDir, 'out', 'tsconfig.json'), 'utf8');
+    };
+
+    await makeRunner({ buildFunc }).run();
+
+    expect(tsconfigAtBuildTime).toBeDefined();
+    const parsed = JSON.parse(tsconfigAtBuildTime!);
+    expect(parsed.compilerOptions.experimentalDecorators).toBe(true);
+    expect(parsed.compilerOptions.emitDecoratorMetadata).toBe(true);
+    expect(parsed.compilerOptions.target).toBe('es2022');
+  });
+
+  it('writes package.json { "type": "commonjs" } into the output dir so @utoo/pack CJS output parses correctly', async () => {
+    let pkgAtBuildTime: string | undefined;
+    const buildFunc: BuildFunc = async () => {
+      pkgAtBuildTime = await fs.readFile(path.join(tmpDir, 'out', 'package.json'), 'utf8');
+    };
+
+    await makeRunner({ buildFunc }).run();
+
+    expect(pkgAtBuildTime).toBeDefined();
+    expect(JSON.parse(pkgAtBuildTime!)).toEqual({ type: 'commonjs' });
+  });
+
+  it('creates the output directory recursively even when intermediate dirs do not exist', async () => {
+    const deepOut = path.join(tmpDir, 'a', 'b', 'c', 'out');
+    await makeRunner({ outputDir: deepOut }).run();
+    await expect(fs.stat(deepOut)).resolves.toBeTruthy();
+  });
+
+  it('passes a pack config with entry[], target node 22, platform node, standalone output, and UMD-form externals through to buildFunc', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    const entries: PackEntry[] = [
+      { name: 'worker', filepath: '/abs/worker.entry.ts' },
+      { name: 'agent', filepath: '/abs/agent.entry.ts' },
+    ];
+    const externals = { '@eggjs/core': '@eggjs/core' };
+
+    await makeRunner({ entries, externals, buildFunc }).run();
+
+    expect(buildFunc).toHaveBeenCalledTimes(1);
+    const [wrapped, projectPath, rootPath] = buildFunc.mock.calls[0]!;
+    const config = (wrapped as { config: Record<string, unknown> }).config;
+    expect(config.entry).toEqual([
+      { name: 'worker', import: '/abs/worker.entry.ts' },
+      { name: 'agent', import: '/abs/agent.entry.ts' },
+    ]);
+    expect(config.target).toBe('node 22');
+    expect(config.platform).toBe('node');
+    expect(config.output).toEqual({ path: path.join(tmpDir, 'out'), type: 'standalone' });
+    // Externals must be UMD-form ({ commonjs, root }) so @utoo/pack standalone
+    // output emits `require(name)` for CJS runtime (not globalThis[name]).
+    expect(config.externals).toEqual({
+      '@eggjs/core': { commonjs: '@eggjs/core', root: '@eggjs/core' },
+    });
+    expect(projectPath).toBe(tmpDir);
+    expect(rootPath).toBe(tmpDir);
+  });
+
+  it('disables treeShaking and minify in the pack config (tegg runtime requires the full graph)', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    await makeRunner({ buildFunc }).run();
+    const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
+    expect(config.optimization).toEqual({ treeShaking: false, minify: false });
+  });
+
+  it('defaults mode to production when no mode is provided', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    await makeRunner({ buildFunc }).run();
+    const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
+    expect(config.mode).toBe('production');
+  });
+
+  it('forwards a custom mode (development) to the pack config when the caller sets it', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    await makeRunner({ buildFunc, mode: 'development' }).run();
+    const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
+    expect(config.mode).toBe('development');
+  });
+
+  it('defaults rootPath to projectPath when the caller omits rootPath', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    await makeRunner({ buildFunc, projectPath: '/custom/project' }).run();
+    const [, projectPath, rootPath] = buildFunc.mock.calls[0]!;
+    expect(projectPath).toBe('/custom/project');
+    expect(rootPath).toBe('/custom/project');
+  });
+
+  it('forwards a distinct rootPath when the caller provides it', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    await makeRunner({ buildFunc, projectPath: '/proj', rootPath: '/monorepo/root' }).run();
+    const [, projectPath, rootPath] = buildFunc.mock.calls[0]!;
+    expect(projectPath).toBe('/proj');
+    expect(rootPath).toBe('/monorepo/root');
+  });
+
+  it('returns the outputDir and a sorted list of files that @utoo/pack produced', async () => {
+    const outputDir = path.join(tmpDir, 'out');
+    const buildFunc: BuildFunc = async () => {
+      await fs.mkdir(path.join(outputDir, 'nested'), { recursive: true });
+      await fs.writeFile(path.join(outputDir, 'worker.js'), 'worker;');
+      await fs.writeFile(path.join(outputDir, 'agent.js'), 'agent;');
+      await fs.writeFile(path.join(outputDir, 'nested', 'chunk.js'), 'chunk;');
+    };
+
+    const result = await makeRunner({ buildFunc }).run();
+
+    expect(result.outputDir).toBe(outputDir);
+    // tsconfig.json + package.json are pre-written, then buildFunc adds worker/agent/nested/chunk
+    const expected = ['agent.js', path.join('nested', 'chunk.js'), 'package.json', 'tsconfig.json', 'worker.js'].sort();
+    expect([...result.files]).toEqual(expected);
+  });
+
+  it('wraps buildFunc failures in an Error that names every entry and preserves the cause', async () => {
+    const original = new Error('pack crashed');
+    const buildFunc: BuildFunc = async () => {
+      throw original;
+    };
+    const runner = makeRunner({
+      entries: [
+        { name: 'worker', filepath: '/a.ts' },
+        { name: 'agent', filepath: '/b.ts' },
+      ],
+      buildFunc,
+    });
+
+    await expect(runner.run()).rejects.toThrowError(/PackRunner failed to build worker, agent: pack crashed/);
+    try {
+      await runner.run();
+    } catch (err) {
+      expect((err as Error).cause).toBe(original);
+    }
+  });
+});

--- a/tools/egg-bundler/test/index.test.ts
+++ b/tools/egg-bundler/test/index.test.ts
@@ -9,7 +9,7 @@ import { bundle, type BundleResult, type BundlerConfig } from '../src/index.js';
 
 describe('@eggjs/egg-bundler', () => {
   it('exports the expected public API', () => {
-    expect(Object.keys(bundler).sort()).toEqual(['ExternalsResolver', 'ManifestLoader', 'bundle']);
+    expect(Object.keys(bundler).sort()).toEqual(['ExternalsResolver', 'ManifestLoader', 'PackRunner', 'bundle']);
     expectTypeOf(bundle).toEqualTypeOf<(config: BundlerConfig) => Promise<BundleResult>>();
   });
 


### PR DESCRIPTION
Thin wrapper over `@utoo/pack/cjs/commands/build.js`. Pre-writes `tsconfig.json` (decorators) + `package.json {type:'commonjs'}`. UMD-shaped externals as `{commonjs, root}`. Passes wrapped `{config}` arg unchanged per DEFAULT_BUILD_FUNC fix. 12 unit tests + regression test.

Part of #5863 split. Tracking: #5871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)