### PR TITLE
test(bundler): verify no-fs-scan contract and bundle determinism

### DIFF
--- a/tools/egg-bundler/test/deterministic.test.ts
+++ b/tools/egg-bundler/test/deterministic.test.ts
@@ -27,11 +27,10 @@ const FIXTURE_SOURCE = path.join(__dirname, 'fixtures/apps/minimal-app');
 //   * The outputDir absolute path must NOT leak into any artifact (two tmpdirs
 //     with different names would cause drift if it did).
 //
-// Isolation note: T17 clones the fixture into its own per-test tmp dirs rather
-// than writing into `fixtures/apps/minimal-app/.egg/`, because T12's
-// integration.test.ts also uses that fixture and vitest runs test files in
-// parallel threads. Sharing the fixture would produce flaky ENOENT on
-// `.egg/manifest.json` when one file's `afterAll` races the other's `beforeAll`.
+// Isolation note: T17 clones only source fixture files into per-test tmp dirs,
+// then owns the generated `.egg/` and `.egg-bundle/` state inside each clone.
+// Determinism should not depend on stale generated metadata from prior runs or
+// shared fixture output.
 //
 // Real @utoo/pack determinism is a separate concern, deferred to T16/T20.
 
@@ -58,10 +57,8 @@ const FIXTURE_MANIFEST = {
 
 async function cloneFixture(destParent: string): Promise<string> {
   const dest = path.join(destParent, 'app');
-  // Skip .egg/ and .egg-bundle/ during copy. Other test files (notably
-  // integration.test.ts) write into the shared fixture's .egg/ and rm it in
-  // afterAll(), which races with the recursive walk here. Filtering at copy
-  // time means we never read those dirs and the race is impossible.
+  // Skip generated metadata dirs during copy; this test creates the exact
+  // generated state it needs inside the cloned fixture.
   await fs.cp(FIXTURE_SOURCE, dest, {
     recursive: true,
     filter: (src) => {
@@ -104,10 +101,14 @@ async function sha256(filepath: string): Promise<string> {
     .digest('hex');
 }
 
-async function hashByBasename(files: readonly string[]): Promise<Record<string, string>> {
+function outputRel(outputDir: string, filepath: string): string {
+  return path.relative(outputDir, filepath);
+}
+
+async function hashByOutputRel(files: readonly string[], outputDir: string): Promise<Record<string, string>> {
   const hashes: Record<string, string> = {};
   for (const f of files) {
-    hashes[path.basename(f)] = await sha256(f);
+    hashes[outputRel(outputDir, f)] = await sha256(f);
   }
   return hashes;
 }
@@ -160,13 +161,13 @@ describe('bundle() is deterministic (T17)', () => {
       pack: { buildFunc: makeDeterministicMockBuild(outB) },
     });
 
-    // File sets must match by basename.
-    const basenamesA = resultA.files.map((f) => path.basename(f)).sort();
-    const basenamesB = resultB.files.map((f) => path.basename(f)).sort();
-    expect(basenamesA).toEqual(basenamesB);
+    // File sets must match by output-relative path.
+    const pathsA = resultA.files.map((f) => outputRel(outA, f)).sort();
+    const pathsB = resultB.files.map((f) => outputRel(outB, f)).sort();
+    expect(pathsA).toEqual(pathsB);
 
-    const hashesA = await hashByBasename(resultA.files);
-    const hashesB = await hashByBasename(resultB.files);
+    const hashesA = await hashByOutputRel(resultA.files, outA);
+    const hashesB = await hashByOutputRel(resultB.files, outB);
 
     const drift: string[] = [];
     for (const name of Object.keys(hashesA)) {

--- a/tools/egg-bundler/test/deterministic.test.ts
+++ b/tools/egg-bundler/test/deterministic.test.ts
@@ -204,12 +204,12 @@ describe('bundle() is deterministic (T17)', () => {
     const { baseDir: baseDirB, outputDir: outB } = await makeWorkspace('diff-b');
     expect(baseDirA).not.toBe(baseDirB);
 
-    await bundle({
+    const resultA = await bundle({
       baseDir: baseDirA,
       outputDir: outA,
       pack: { buildFunc: makeDeterministicMockBuild(outA) },
     });
-    await bundle({
+    const resultB = await bundle({
       baseDir: baseDirB,
       outputDir: outB,
       pack: { buildFunc: makeDeterministicMockBuild(outB) },
@@ -223,16 +223,18 @@ describe('bundle() is deterministic (T17)', () => {
     expect(entryA).not.toContain(baseDirA);
     expect(entryA).not.toContain(baseDirB);
 
-    // Same for worker.js / tsconfig.json / package.json — everything in outA
-    // should be byte-identical to its outB counterpart.
+    // Same for every produced artifact — everything in outA should be
+    // byte-identical to its outB counterpart, including nested files.
     const drift: string[] = [];
-    const namesInA = (await fs.readdir(outA)).sort();
-    const namesInB = (await fs.readdir(outB)).sort();
+    const hashesA = await hashByOutputRel(resultA.files, outA);
+    const hashesB = await hashByOutputRel(resultB.files, outB);
+    const namesInA = Object.keys(hashesA).sort();
+    const namesInB = Object.keys(hashesB).sort();
     expect(namesInA).toEqual(namesInB);
     for (const name of namesInA) {
       if (name === 'bundle-manifest.json') continue; // carries baseDir + generatedAt
-      const hashA = await sha256(path.join(outA, name));
-      const hashB = await sha256(path.join(outB, name));
+      const hashA = hashesA[name];
+      const hashB = hashesB[name];
       if (hashA !== hashB) drift.push(name);
     }
     expect(drift, `non-deterministic files across clones: ${drift.join(', ')}`).toEqual([]);

--- a/tools/egg-bundler/test/deterministic.test.ts
+++ b/tools/egg-bundler/test/deterministic.test.ts
@@ -188,6 +188,8 @@ describe('bundle() is deterministic (T17)', () => {
     const bmB = JSON.parse(await fs.readFile(resultB.manifestPath, 'utf8')) as LooseManifest;
     expect(typeof bmA.generatedAt).toBe('string');
     expect(new Date(bmA.generatedAt as string).toString()).not.toBe('Invalid Date');
+    expect(typeof bmB.generatedAt).toBe('string');
+    expect(new Date(bmB.generatedAt as string).toString()).not.toBe('Invalid Date');
     delete bmA.generatedAt;
     delete bmB.generatedAt;
     expect(bmA).toEqual(bmB);

--- a/tools/egg-bundler/test/deterministic.test.ts
+++ b/tools/egg-bundler/test/deterministic.test.ts
@@ -66,7 +66,9 @@ async function cloneFixture(destParent: string): Promise<string> {
     recursive: true,
     filter: (src) => {
       const rel = path.relative(FIXTURE_SOURCE, src);
-      return !rel.startsWith('.egg-bundle') && !rel.startsWith('.egg');
+      if (!rel) return true;
+      const firstSegment = rel.split(path.sep)[0];
+      return firstSegment !== '.egg-bundle' && firstSegment !== '.egg';
     },
   });
   // Pre-write the fixture manifest so ManifestLoader short-circuits the

--- a/tools/egg-bundler/test/deterministic.test.ts
+++ b/tools/egg-bundler/test/deterministic.test.ts
@@ -1,0 +1,263 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { bundle, type BuildFunc } from '../src/index.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_SOURCE = path.join(__dirname, 'fixtures/apps/minimal-app');
+
+// T17 verifies that bundling the same app twice produces byte-identical
+// artifacts, modulo documented exceptions:
+//   - bundle-manifest.json.generatedAt is always `new Date().toISOString()`
+//   - bundle-manifest.json.baseDir reflects the caller's baseDir input
+//
+// Determinism sources exercised:
+//   * EntryGenerator sorts fileDiscovery / resolveCache / tegg decoratedFiles
+//     by relKey (T9 pins this at the unit level, we re-validate here through
+//     the full bundle() orchestration).
+//   * Bundler sorts externals and chunks in the bundle-manifest.
+//   * Bundler writes bundle-manifest.json with JSON.stringify(_, null, 2) —
+//     stable key order because the object is constructed as a literal.
+//   * PackRunner pre-writes tsconfig.json and package.json with stable content.
+//   * The outputDir absolute path must NOT leak into any artifact (two tmpdirs
+//     with different names would cause drift if it did).
+//
+// Isolation note: T17 clones the fixture into its own per-test tmp dirs rather
+// than writing into `fixtures/apps/minimal-app/.egg/`, because T12's
+// integration.test.ts also uses that fixture and vitest runs test files in
+// parallel threads. Sharing the fixture would produce flaky ENOENT on
+// `.egg/manifest.json` when one file's `afterAll` races the other's `beforeAll`.
+//
+// Real @utoo/pack determinism is a separate concern, deferred to T16/T20.
+
+const FIXTURE_MANIFEST = {
+  version: 1,
+  generatedAt: '2026-01-01T00:00:00.000Z',
+  invalidation: {
+    lockfileFingerprint: 't17-fixture',
+    configFingerprint: 't17-fixture',
+    serverEnv: 'prod',
+    serverScope: '',
+    typescriptEnabled: true,
+  },
+  extensions: {},
+  resolveCache: {},
+  fileDiscovery: {
+    'app/controller': ['home.ts'],
+    'app/service': ['user.ts'],
+    'app/middleware': ['timing.ts'],
+    'app/extend': ['context.ts'],
+    app: ['router.ts'],
+  },
+};
+
+async function cloneFixture(destParent: string): Promise<string> {
+  const dest = path.join(destParent, 'app');
+  // Skip .egg/ and .egg-bundle/ during copy. Other test files (notably
+  // integration.test.ts) write into the shared fixture's .egg/ and rm it in
+  // afterAll(), which races with the recursive walk here. Filtering at copy
+  // time means we never read those dirs and the race is impossible.
+  await fs.cp(FIXTURE_SOURCE, dest, {
+    recursive: true,
+    filter: (src) => {
+      const rel = path.relative(FIXTURE_SOURCE, src);
+      return !rel.startsWith('.egg-bundle') && !rel.startsWith('.egg');
+    },
+  });
+  // Pre-write the fixture manifest so ManifestLoader short-circuits the
+  // broken `generate-manifest.mjs` subprocess path (documented under T0/T8.1).
+  const manifestDir = path.join(dest, '.egg');
+  await fs.mkdir(manifestDir, { recursive: true });
+  await fs.writeFile(path.join(manifestDir, 'manifest.json'), JSON.stringify(FIXTURE_MANIFEST, null, 2));
+  return dest;
+}
+
+// The mock build must be deterministic itself — two invocations must write
+// identical content. Otherwise we'd be measuring pack variance, not bundler
+// variance. Every byte is hard-coded.
+function makeDeterministicMockBuild(outputDir: string): BuildFunc {
+  return async () => {
+    const artifacts: Array<[string, string]> = [
+      ['worker.js', '// deterministic worker chunk\nmodule.exports = { marker: "worker" };\n'],
+      ['worker.js.map', '{"version":3,"sources":[],"mappings":""}'],
+      ['_turbopack__runtime.js', '// deterministic runtime shim\n'],
+      ['_turbopack__runtime.js.map', '{}'],
+      ['_root-of-the-server___abc123.js', '// deterministic root chunk\n'],
+      ['_root-of-the-server___abc123.js.map', '{}'],
+    ];
+    for (const [name, body] of artifacts) {
+      await fs.writeFile(path.join(outputDir, name), body);
+    }
+  };
+}
+
+async function sha256(filepath: string): Promise<string> {
+  return createHash('sha256')
+    .update(await fs.readFile(filepath))
+    .digest('hex');
+}
+
+async function hashByBasename(files: readonly string[]): Promise<Record<string, string>> {
+  const hashes: Record<string, string> = {};
+  for (const f of files) {
+    hashes[path.basename(f)] = await sha256(f);
+  }
+  return hashes;
+}
+
+describe('bundle() is deterministic (T17)', () => {
+  const tmpDirs: string[] = [];
+
+  beforeEach(() => {
+    tmpDirs.length = 0;
+  });
+
+  afterEach(async () => {
+    for (const dir of tmpDirs) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  async function mkTmp(suffix: string): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), `egg-bundler-det-${suffix}-`));
+    const real = await fs.realpath(dir);
+    tmpDirs.push(real);
+    return real;
+  }
+
+  async function makeWorkspace(suffix: string): Promise<{ baseDir: string; outputDir: string }> {
+    const workspace = await mkTmp(suffix);
+    const baseDir = await cloneFixture(workspace);
+    const outputDir = path.join(workspace, 'out');
+    await fs.mkdir(outputDir, { recursive: true });
+    return { baseDir, outputDir };
+  }
+
+  it('same baseDir, two outputDirs → every produced artifact is byte-identical except bundle-manifest.generatedAt', async () => {
+    // Single baseDir, two output dirs. This is the primary "idempotent given
+    // same input" contract. worker.entry.ts is written to
+    // <baseDir>/.egg-bundle/entries/ — two runs will overwrite it with the same
+    // bytes (we also read it out directly to double-check).
+    const { baseDir, outputDir: outA } = await makeWorkspace('same-a');
+    const outB = path.join(path.dirname(outA), 'out-b');
+    await fs.mkdir(outB, { recursive: true });
+
+    const resultA = await bundle({
+      baseDir,
+      outputDir: outA,
+      pack: { buildFunc: makeDeterministicMockBuild(outA) },
+    });
+    const resultB = await bundle({
+      baseDir,
+      outputDir: outB,
+      pack: { buildFunc: makeDeterministicMockBuild(outB) },
+    });
+
+    // File sets must match by basename.
+    const basenamesA = resultA.files.map((f) => path.basename(f)).sort();
+    const basenamesB = resultB.files.map((f) => path.basename(f)).sort();
+    expect(basenamesA).toEqual(basenamesB);
+
+    const hashesA = await hashByBasename(resultA.files);
+    const hashesB = await hashByBasename(resultB.files);
+
+    const drift: string[] = [];
+    for (const name of Object.keys(hashesA)) {
+      if (name === 'bundle-manifest.json') continue;
+      if (hashesA[name] !== hashesB[name]) drift.push(name);
+    }
+    // Drift diagnostic: if this fails, typical culprits (descending likelihood):
+    //   - Map iteration order (Object.keys in EntryGenerator not sorted)
+    //   - Date.now / new Date() snuck into an artifact besides bundle-manifest
+    //   - outputDir absolute path leaked into a chunk (also caught by test 3)
+    //   - tmpdir pollution (previous run's artifacts not cleaned)
+    //   - New dependency accidentally introducing randomness
+    expect(drift, `non-deterministic files: ${drift.join(', ')}`).toEqual([]);
+
+    // Bundle-manifest: filter out the known-variable field, deepEqual the rest.
+    type LooseManifest = Record<string, unknown>;
+    const bmA = JSON.parse(await fs.readFile(resultA.manifestPath, 'utf8')) as LooseManifest;
+    const bmB = JSON.parse(await fs.readFile(resultB.manifestPath, 'utf8')) as LooseManifest;
+    expect(typeof bmA.generatedAt).toBe('string');
+    expect(new Date(bmA.generatedAt as string).toString()).not.toBe('Invalid Date');
+    delete bmA.generatedAt;
+    delete bmB.generatedAt;
+    expect(bmA).toEqual(bmB);
+  });
+
+  it('different baseDir clones produce byte-identical worker.entry.ts (relative specifier guarantee)', async () => {
+    // Two independent workspace clones, bundled to each own output. Because
+    // EntryGenerator emits relative specifiers (`../../app/...`) keyed on
+    // manifest relKeys, the two entry files must be byte-identical even
+    // though the absolute baseDirs differ entirely.
+    const { baseDir: baseDirA, outputDir: outA } = await makeWorkspace('diff-a');
+    const { baseDir: baseDirB, outputDir: outB } = await makeWorkspace('diff-b');
+    expect(baseDirA).not.toBe(baseDirB);
+
+    await bundle({
+      baseDir: baseDirA,
+      outputDir: outA,
+      pack: { buildFunc: makeDeterministicMockBuild(outA) },
+    });
+    await bundle({
+      baseDir: baseDirB,
+      outputDir: outB,
+      pack: { buildFunc: makeDeterministicMockBuild(outB) },
+    });
+
+    const entryA = await fs.readFile(path.join(baseDirA, '.egg-bundle', 'entries', 'worker.entry.ts'), 'utf8');
+    const entryB = await fs.readFile(path.join(baseDirB, '.egg-bundle', 'entries', 'worker.entry.ts'), 'utf8');
+    expect(entryA).toBe(entryB);
+    // Sanity: the entry must actually NOT contain either absolute baseDir,
+    // otherwise byte-equality would be accidental.
+    expect(entryA).not.toContain(baseDirA);
+    expect(entryA).not.toContain(baseDirB);
+
+    // Same for worker.js / tsconfig.json / package.json — everything in outA
+    // should be byte-identical to its outB counterpart.
+    const drift: string[] = [];
+    const namesInA = (await fs.readdir(outA)).sort();
+    const namesInB = (await fs.readdir(outB)).sort();
+    expect(namesInA).toEqual(namesInB);
+    for (const name of namesInA) {
+      if (name === 'bundle-manifest.json') continue; // carries baseDir + generatedAt
+      const hashA = await sha256(path.join(outA, name));
+      const hashB = await sha256(path.join(outB, name));
+      if (hashA !== hashB) drift.push(name);
+    }
+    expect(drift, `non-deterministic files across clones: ${drift.join(', ')}`).toEqual([]);
+  });
+
+  it('no artifact leaks the outputDir absolute path (tmpdir difference is invisible to consumers)', async () => {
+    const { baseDir, outputDir: outA } = await makeWorkspace('leak-a');
+    const outB = path.join(path.dirname(outA), 'out-b');
+    await fs.mkdir(outB, { recursive: true });
+
+    const resultA = await bundle({
+      baseDir,
+      outputDir: outA,
+      pack: { buildFunc: makeDeterministicMockBuild(outA) },
+    });
+    const resultB = await bundle({
+      baseDir,
+      outputDir: outB,
+      pack: { buildFunc: makeDeterministicMockBuild(outB) },
+    });
+
+    // bundle-manifest.json intentionally carries `baseDir` but NOT `outputDir`,
+    // so no emitted file should reference either tmp output path. The
+    // worker.entry.ts (under baseDir/.egg-bundle/entries/) uses relative
+    // imports — it never touches the outputDir.
+    const allFiles = [...resultA.files, ...resultB.files];
+    for (const file of allFiles) {
+      const content = await fs.readFile(file, 'utf8');
+      expect(content, `${path.basename(file)} leaks outA`).not.toContain(outA);
+      expect(content, `${path.basename(file)} leaks outB`).not.toContain(outB);
+    }
+  });
+});

--- a/tools/egg-bundler/test/no-filesystem-scan.test.ts
+++ b/tools/egg-bundler/test/no-filesystem-scan.test.ts
@@ -1,0 +1,162 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { FileLoader, ManifestStore, type StartupManifest } from '@eggjs/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// T13 verifies the core contract that egg-bundler's deployment story rests on:
+// a bundled app that registered a StartupManifest via `ManifestStore.setBundleStore`
+// must NOT perform directory scans at boot. We validate this at two layers:
+//
+//   1. ManifestStore.load short-circuits to the registered bundle store, bypassing
+//      disk reads entirely (positive evidence).
+//   2. ManifestStore.globFiles and FileLoader both skip their fallback globber
+//      whenever the directory is present in `fileDiscovery` (negative evidence).
+//
+// Full end-to-end verification inside a spawned bundled worker is deferred to T16
+// (cnpmcore E2E), since spawning egg with workspace dev links hits the strip-types
+// blocker documented in T0.
+
+const FROZEN_INVALIDATION = {
+  lockfileFingerprint: 't13-fixture',
+  configFingerprint: 't13-fixture',
+  serverEnv: 'prod',
+  serverScope: '',
+  typescriptEnabled: true,
+} as const;
+
+function makeManifest(fileDiscovery: Record<string, string[]>): StartupManifest {
+  return {
+    version: 1,
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    invalidation: { ...FROZEN_INVALIDATION },
+    extensions: {},
+    resolveCache: {},
+    fileDiscovery,
+  };
+}
+
+describe('no filesystem scan contract (T13)', () => {
+  let tmpDir: string;
+  let controllerDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-no-scan-'));
+    // macOS tmpdir is a symlink (/var → /private/var). Resolve so the path
+    // the test uses matches the path FileLoader sees when it computes
+    // path.relative(baseDir, directory).
+    tmpDir = await fs.realpath(tmpDir);
+    controllerDir = path.join(tmpDir, 'app', 'controller');
+    await fs.mkdir(controllerDir, { recursive: true });
+    // Two files on disk: only `home.js` is in the manifest.
+    // If anything scans the directory we'll see `extra.js` leak through.
+    await fs.writeFile(path.join(controllerDir, 'home.js'), 'module.exports = class Home {};\n');
+    await fs.writeFile(path.join(controllerDir, 'extra.js'), 'module.exports = class Extra {};\n');
+    ManifestStore.setBundleStore(undefined);
+  });
+
+  afterEach(async () => {
+    ManifestStore.setBundleStore(undefined);
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('ManifestStore.setBundleStore (positive — registered bundle store wins)', () => {
+    it('ManifestStore.load returns the registered bundle store without any disk read', () => {
+      const store = ManifestStore.fromBundle(makeManifest({ 'app/controller': ['home.js'] }), tmpDir);
+      ManifestStore.setBundleStore(store);
+
+      // `tmpDir` has no `.egg/manifest.json`. Without the bundle store, load()
+      // would return null. With the bundle store, it returns the exact instance
+      // we registered — proving the load path never touched fs.
+      const loaded = ManifestStore.load(tmpDir, 'prod', '');
+      expect(loaded).toBe(store);
+      expect(ManifestStore.getBundleStore()).toBe(store);
+    });
+
+    it('ManifestStore.load without a registered bundle store returns null in prod when no .egg/manifest.json exists (control)', () => {
+      // Baseline: fresh tmp dir, no bundle store, no disk manifest → null.
+      // This is what proves the previous test is actually exercising the short-circuit.
+      expect(ManifestStore.getBundleStore()).toBeUndefined();
+      expect(ManifestStore.load(tmpDir, 'prod', '')).toBeNull();
+    });
+  });
+
+  describe('ManifestStore.globFiles (contract — fallback only runs on cache miss)', () => {
+    it('skips the fallback globber when fileDiscovery has the directory cached', () => {
+      const store = ManifestStore.fromBundle(makeManifest({ 'app/controller': ['home.js'] }), tmpDir);
+      const fallback = vi.fn<() => string[]>(() => {
+        throw new Error('fallback must not be called when manifest hits cache');
+      });
+
+      const result = store.globFiles(controllerDir, fallback);
+
+      expect(fallback).not.toHaveBeenCalled();
+      expect(result).toEqual(['home.js']);
+    });
+
+    it('invokes the fallback globber on cache miss (control — proves the test is discriminating)', () => {
+      const store = ManifestStore.fromBundle(makeManifest({}), tmpDir);
+      const fallback = vi.fn<() => string[]>(() => ['home.js']);
+
+      const result = store.globFiles(controllerDir, fallback);
+
+      expect(fallback).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(['home.js']);
+    });
+  });
+
+  describe('FileLoader end-to-end (bundled manifest really replaces disk scan)', () => {
+    it('loads only files listed in fileDiscovery, ignoring extras on disk', async () => {
+      const store = ManifestStore.fromBundle(makeManifest({ 'app/controller': ['home.js'] }), tmpDir);
+      const target: Record<string, unknown> = {};
+      const loader = new FileLoader({
+        directory: controllerDir,
+        target,
+        manifest: store,
+      });
+      await loader.load();
+
+      // `home.js` is loaded because it's in fileDiscovery.
+      // `extra.js` exists on disk but is NOT in fileDiscovery, so if the loader
+      // short-circuits globby correctly, it will never appear on `target`.
+      expect(Object.keys(target)).toEqual(['home']);
+      expect(target.home).toBeTypeOf('function');
+    });
+
+    it('without a manifest, FileLoader scans the directory and picks up both files (control)', async () => {
+      const target: Record<string, unknown> = {};
+      const loader = new FileLoader({
+        directory: controllerDir,
+        target,
+      });
+      await loader.load();
+
+      // No manifest → globby scan → both files loaded. This proves the previous
+      // test's exclusion of `extra.js` is due to the manifest, not a bug in the
+      // fixture.
+      expect(Object.keys(target).sort()).toEqual(['extra', 'home']);
+    });
+
+    it('still uses the manifest cache even when an unrelated directory on disk would also match', async () => {
+      // Defense-in-depth: add a second directory the fileDiscovery does NOT
+      // mention. The loader should quietly ignore it — the only directory it
+      // asks globFiles about is `controllerDir`, and that one is cached.
+      const orphanDir = path.join(tmpDir, 'app', 'orphan');
+      await fs.mkdir(orphanDir, { recursive: true });
+      await fs.writeFile(path.join(orphanDir, 'ghost.js'), 'module.exports = class Ghost {};\n');
+
+      const store = ManifestStore.fromBundle(makeManifest({ 'app/controller': ['home.js'] }), tmpDir);
+      const target: Record<string, unknown> = {};
+      const loader = new FileLoader({
+        directory: controllerDir,
+        target,
+        manifest: store,
+      });
+      await loader.load();
+
+      expect(Object.keys(target)).toEqual(['home']);
+    });
+  });
+});

--- a/tools/egg-bundler/tsdown.config.ts
+++ b/tools/egg-bundler/tsdown.config.ts
@@ -1,15 +1,13 @@
-import { defineConfig, type UserConfig } from 'tsdown';
+import { defineConfig } from 'tsdown';
 
-const config: UserConfig = defineConfig({
+export default defineConfig({
   entry: 'src/**/*.ts',
   unbundle: true,
   fixedExtension: false,
   external: [/^@eggjs\//, 'egg', '@utoo/pack', /\.node$/],
   copy: [{ from: 'src/scripts/generate-manifest.mjs', to: 'dist/scripts/' }],
   unused: {
-    level: 'warn',
+    level: 'warning',
     ignore: ['@utoo/pack', 'egg', 'tsx', '@eggjs/core'],
   },
 });
-
-export default config;


### PR DESCRIPTION
Adds `no-filesystem-scan.test.ts` (7 tests: setBundleStore short-circuits disk, globFiles skips on cache hit, FileLoader ignores extra on-disk files) and `deterministic.test.ts` (3 tests: byte-identical across runs, independent clones, no outputDir path leaks). Fixes the ~60% deterministic test flake from #5863 by filtering `.egg/` at `fs.cp` time.

Part of #5863 split. Tracking: #5871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added deterministic bundling tests to ensure repeated builds produce byte-identical outputs (aside from a validated timestamp) and to prevent absolute-path leakage; per-test temporary workspaces are created and cleaned up.
  * Added tests verifying manifest-backed deployments skip on-disk scanning and only load files listed in the manifest, with fallback behavior validated.
* **Chores**
  * Simplified tsdown config export and changed unused.level from "warn" to "warning".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->