### PR TITLE
feat(egg-bin): add bundle subcommand

### DIFF
--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -28,6 +28,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./baseCommand": "./src/baseCommand.ts",
+    "./commands/bundle": "./src/commands/bundle.ts",
     "./commands/cov": "./src/commands/cov.ts",
     "./commands/dev": "./src/commands/dev.ts",
     "./commands/manifest": "./src/commands/manifest.ts",
@@ -41,6 +42,7 @@
     "exports": {
       ".": "./dist/index.js",
       "./baseCommand": "./dist/baseCommand.js",
+      "./commands/bundle": "./dist/commands/bundle.js",
       "./commands/cov": "./dist/commands/cov.js",
       "./commands/dev": "./dist/commands/dev.js",
       "./commands/manifest": "./dist/commands/manifest.js",
@@ -59,6 +61,7 @@
   },
   "dependencies": {
     "@eggjs/core": "workspace:*",
+    "@eggjs/egg-bundler": "workspace:*",
     "@eggjs/tegg-vitest": "workspace:*",
     "@eggjs/utils": "workspace:*",
     "@oclif/core": "catalog:",

--- a/tools/egg-bin/src/commands/bundle.ts
+++ b/tools/egg-bin/src/commands/bundle.ts
@@ -1,0 +1,89 @@
+import path from 'node:path';
+import { debuglog } from 'node:util';
+
+import { Flags } from '@oclif/core';
+
+import { BaseCommand } from '../baseCommand.ts';
+
+const debug = debuglog('egg/bin/commands/bundle');
+
+export default class Bundle<T extends typeof Bundle> extends BaseCommand<T> {
+  static override description = 'Bundle an egg app into a deployable artifact using @eggjs/egg-bundler';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --output ./dist-bundle',
+    '<%= config.bin %> <%= command.id %> --mode development',
+    '<%= config.bin %> <%= command.id %> --framework egg --output ./out',
+  ];
+
+  static override flags = {
+    output: Flags.string({
+      char: 'o',
+      description: 'output directory for the bundled artifact',
+      default: './dist-bundle',
+    }),
+    manifest: Flags.string({
+      description: 'path to manifest.json (defaults to <baseDir>/.egg/manifest.json)',
+    }),
+    framework: Flags.string({
+      char: 'f',
+      description: 'framework name or absolute path',
+      default: 'egg',
+    }),
+    mode: Flags.string({
+      description: 'build mode',
+      options: ['production', 'development'],
+      default: 'production',
+    }),
+    'no-tegg': Flags.boolean({
+      description: 'disable tegg decoratedFile collection',
+      default: false,
+    }),
+    'force-external': Flags.string({
+      description: 'package name to always mark as external (repeatable)',
+      multiple: true,
+    }),
+    'inline-external': Flags.string({
+      description: 'package name to force-inline even if auto-detected as external (repeatable)',
+      multiple: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { flags } = this;
+    const baseDir = flags.base;
+    const outputDir = path.isAbsolute(flags.output) ? flags.output : path.join(baseDir, flags.output);
+    const manifestPath = flags.manifest
+      ? path.isAbsolute(flags.manifest)
+        ? flags.manifest
+        : path.join(baseDir, flags.manifest)
+      : undefined;
+
+    debug(
+      'bundle: baseDir=%s, outputDir=%s, framework=%s, mode=%s, tegg=%s',
+      baseDir,
+      outputDir,
+      flags.framework,
+      flags.mode,
+      !flags['no-tegg'],
+    );
+
+    const { bundle } = await import('@eggjs/egg-bundler');
+    const result = await bundle({
+      baseDir,
+      outputDir,
+      manifestPath,
+      framework: flags.framework,
+      mode: flags.mode as 'production' | 'development',
+      tegg: !flags['no-tegg'],
+      externals: {
+        force: flags['force-external'],
+        inline: flags['inline-external'],
+      },
+    });
+
+    this.log(`bundled to ${result.outputDir} (${result.files.length} files)`);
+    this.log(`manifest: ${result.manifestPath}`);
+  }
+}

--- a/tools/egg-bin/src/commands/bundle.ts
+++ b/tools/egg-bin/src/commands/bundle.ts
@@ -39,7 +39,6 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
     framework: Flags.string({
       char: 'f',
       description: 'framework name or absolute path',
-      default: 'egg',
     }),
     mode: Flags.string({
       description: 'build mode',

--- a/tools/egg-bin/src/commands/bundle.ts
+++ b/tools/egg-bin/src/commands/bundle.ts
@@ -1,13 +1,23 @@
 import path from 'node:path';
 import { debuglog } from 'node:util';
 
+import { getFrameworkPath } from '@eggjs/utils';
 import { Flags } from '@oclif/core';
 
 import { BaseCommand } from '../baseCommand.ts';
 
 const debug = debuglog('egg/bin/commands/bundle');
+const bundleModes = ['production', 'development'] as const;
+type BundleMode = (typeof bundleModes)[number];
 
-export default class Bundle<T extends typeof Bundle> extends BaseCommand<T> {
+function getBundleMode(mode: string): BundleMode {
+  if (mode === 'production' || mode === 'development') {
+    return mode;
+  }
+  throw new Error(`Unsupported bundle mode: ${mode}`);
+}
+
+export default class Bundle extends BaseCommand<typeof Bundle> {
   static override description = 'Bundle an egg app into a deployable artifact using @eggjs/egg-bundler';
 
   static override examples = [
@@ -33,7 +43,7 @@ export default class Bundle<T extends typeof Bundle> extends BaseCommand<T> {
     }),
     mode: Flags.string({
       description: 'build mode',
-      options: ['production', 'development'],
+      options: [...bundleModes],
       default: 'production',
     }),
     'no-tegg': Flags.boolean({
@@ -43,10 +53,12 @@ export default class Bundle<T extends typeof Bundle> extends BaseCommand<T> {
     'force-external': Flags.string({
       description: 'package name to always mark as external (repeatable)',
       multiple: true,
+      default: [],
     }),
     'inline-external': Flags.string({
       description: 'package name to force-inline even if auto-detected as external (repeatable)',
       multiple: true,
+      default: [],
     }),
   };
 
@@ -74,8 +86,8 @@ export default class Bundle<T extends typeof Bundle> extends BaseCommand<T> {
       baseDir,
       outputDir,
       manifestPath,
-      framework: flags.framework,
-      mode: flags.mode as 'production' | 'development',
+      framework: getFrameworkPath({ framework: flags.framework, baseDir }),
+      mode: getBundleMode(flags.mode),
       tegg: !flags['no-tegg'],
       externals: {
         force: flags['force-external'],

--- a/tools/egg-bin/src/index.ts
+++ b/tools/egg-bin/src/index.ts
@@ -1,9 +1,10 @@
+import Bundle from './commands/bundle.ts';
 import Cov from './commands/cov.ts';
 import Dev from './commands/dev.ts';
 import Manifest from './commands/manifest.ts';
 import Test from './commands/test.ts';
 
-export { Test, Cov, Dev, Manifest };
+export { Test, Cov, Dev, Manifest, Bundle };
 
 export * from './baseCommand.ts';
 export * from './types.ts';

--- a/tools/egg-bin/test/commands/bundle.test.ts
+++ b/tools/egg-bin/test/commands/bundle.test.ts
@@ -32,7 +32,7 @@ describe('test/commands/bundle.test.ts', () => {
       baseDir,
       outputDir: path.join(baseDir, 'dist-bundle'),
       manifestPath: undefined,
-      framework: getFrameworkPath({ framework: 'egg', baseDir }),
+      framework: getFrameworkPath({ baseDir }),
       mode: 'production',
       tegg: true,
       externals: {
@@ -66,7 +66,7 @@ describe('test/commands/bundle.test.ts', () => {
       baseDir,
       outputDir: path.join(baseDir, 'bundle-output'),
       manifestPath: path.join(baseDir, '.egg/custom-manifest.json'),
-      framework: getFrameworkPath({ framework: 'egg', baseDir }),
+      framework: getFrameworkPath({ baseDir }),
       mode: 'development',
       tegg: false,
       externals: {

--- a/tools/egg-bin/test/commands/bundle.test.ts
+++ b/tools/egg-bin/test/commands/bundle.test.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+
+import { getFrameworkPath } from '@eggjs/utils';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import Bundle from '../../src/commands/bundle.ts';
+import { getFixtures } from '../helper.ts';
+
+const bundleMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@eggjs/egg-bundler', () => ({
+  bundle: bundleMock,
+}));
+
+describe('test/commands/bundle.test.ts', () => {
+  const baseDir = getFixtures('demo-app');
+
+  beforeEach(() => {
+    bundleMock.mockReset();
+    bundleMock.mockResolvedValue({
+      outputDir: path.join(baseDir, 'dist-bundle'),
+      manifestPath: path.join(baseDir, '.egg/manifest.json'),
+      files: ['server.js'],
+    });
+  });
+
+  it('should pass default options to egg-bundler', async () => {
+    await Bundle.run(['--base', baseDir]);
+
+    expect(bundleMock).toHaveBeenCalledTimes(1);
+    expect(bundleMock).toHaveBeenCalledWith({
+      baseDir,
+      outputDir: path.join(baseDir, 'dist-bundle'),
+      manifestPath: undefined,
+      framework: getFrameworkPath({ framework: 'egg', baseDir }),
+      mode: 'production',
+      tegg: true,
+      externals: {
+        force: [],
+        inline: [],
+      },
+    });
+  });
+
+  it('should pass resolved flag options to egg-bundler', async () => {
+    await Bundle.run([
+      '--base',
+      baseDir,
+      '--output',
+      'bundle-output',
+      '--manifest',
+      '.egg/custom-manifest.json',
+      '--mode',
+      'development',
+      '--no-tegg',
+      '--force-external',
+      '@scope/foo',
+      '--force-external',
+      'bar',
+      '--inline-external',
+      'baz',
+    ]);
+
+    expect(bundleMock).toHaveBeenCalledTimes(1);
+    expect(bundleMock).toHaveBeenCalledWith({
+      baseDir,
+      outputDir: path.join(baseDir, 'bundle-output'),
+      manifestPath: path.join(baseDir, '.egg/custom-manifest.json'),
+      framework: getFrameworkPath({ framework: 'egg', baseDir }),
+      mode: 'development',
+      tegg: false,
+      externals: {
+        force: ['@scope/foo', 'bar'],
+        inline: ['baz'],
+      },
+    });
+  });
+});

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@eggjs/egg-bundler",
   "version": "0.0.0",
-  "private": true,
   "description": "Bundle an Egg.js application into a deployable artifact using @utoo/pack",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bundler",
   "bugs": {

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@eggjs/core": "workspace:*",
+    "@eggjs/utils": "workspace:*",
     "@utoo/pack": "catalog:",
     "tsx": "catalog:"
   },


### PR DESCRIPTION
Thin wrapper over `@eggjs/egg-bundler.bundle()` using @oclif/core. Exposes `--output/--manifest/--framework/--mode/--no-tegg/--force-external/--inline-external`. Re-exports from `src/index.ts` so tsdown's unused-dep check sees the `@eggjs/egg-bundler` dependency.

Part of #5863 split. Tracking: #5871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new bundle command to package Egg applications with configurable output, manifest, framework selection, build mode (production/development), externals handling, and optional tegg-decorated file collection. Displays bundled file count and manifest path.

* **Tests**
  * Added unit tests validating default and flag-driven bundle behaviors.

* **Chores**
  * Made the bundler package publishable and added runtime dependencies to support the bundle command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->