### PR TITLE
feat(bundler): remove @eggjs/* from auto-externals

### DIFF
--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -58,12 +58,14 @@ checks (T17).
 ## Externals
 
 Packages classified as external by `ExternalsResolver` are **not** inlined.
-This includes the user's `externals.force` list, root `peerDependencies`,
-always-external packages (`egg`, `@swc/helpers`, and `@eggjs/*`), native addons,
-and ESM-only packages. They must be installed alongside the bundle — typically
-by copying the app's `package.json` next to
-`worker.js` and running `npm ci --omit=dev`, or by deploying the bundle
-into an image that already has these dependencies on disk.
+This includes the user's `externals.force` list, root `peerDependencies`, root
+`optionalDependencies`, and native addons/native binaries. They must be
+installed alongside the bundle — typically by copying the app's `package.json`
+next to `worker.js` and running `npm ci --omit=dev`, or by deploying into an
+environment where these dependencies are already installed. ESM-only packages,
+`egg`, `@swc/helpers`, and `@eggjs/*` packages are bundled by default unless
+`ExternalsResolver` externalizes them through `externals.force`, dependency
+metadata, or native addon detection.
 
 ## Known limitations
 


### PR DESCRIPTION
Removes `@eggjs/*` from `ExternalsResolver`'s always-external list and the `startsWith('@eggjs/')` check. Keeps native addon/peerDeps detection intact. ESM-only packages are now bundled instead of externalized, because Turbopack can bundle ESM natively while emitting CJS `require()` for external ESM-only packages would fail.

Also cleans up the dead `#isEsmOnly` and `#hasRequireCondition` private methods (fixes typecheck error present in #5863). Flips ExternalsResolver test assertions accordingly.

Result: framework packages can now be bundled. cnpmcore E2E externals 76 -> 12.

Part of #5863 split. Tracking: #5871.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the bundler's external dependencies classification, including how `peerDependencies`, `optionalDependencies`, native addons, and forced externals are handled in the build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->