### PR TITLE
test: send broken HTTP path over raw TCP

### DIFF
--- a/packages/egg/test/cluster1/app_worker.test.ts
+++ b/packages/egg/test/cluster1/app_worker.test.ts
@@ -33,7 +33,10 @@ describe('test/cluster1/app_worker.test.ts', () => {
     const responses = await Promise.all([rawRequest(app.port, '/foo bar'), rawRequest(app.port, '/foo baz')]);
 
     for (const response of responses) {
-      const [header, body] = response.split('\r\n\r\n');
+      const separatorIndex = response.indexOf('\r\n\r\n');
+      assert.notEqual(separatorIndex, -1);
+      const header = response.slice(0, separatorIndex);
+      const body = response.slice(separatorIndex + 4);
       assert.match(header, /^HTTP\/1\.1 400 Bad Request/);
       assert.equal(body, DEFAULT_BAD_REQUEST_HTML);
     }

--- a/packages/egg/test/cluster1/app_worker.test.ts
+++ b/packages/egg/test/cluster1/app_worker.test.ts
@@ -30,39 +30,13 @@ describe('test/cluster1/app_worker.test.ts', () => {
   });
 
   it('should response 400 bad request when HTTP request packet broken', async () => {
-    const test1 = app
-      .httpRequest()
-      // Node.js (http-parser) will occur an error while the raw URI in HTTP
-      // request packet containing space.
-      //
-      // Refs: https://zhuanlan.zhihu.com/p/31966196
-      .get('/foo bar');
-    const test2 = app.httpRequest().get('/foo baz');
+    const responses = await Promise.all([rawRequest(app.port, '/foo bar'), rawRequest(app.port, '/foo baz')]);
 
-    // app.httpRequest().expect() will encode the uri so that we cannot
-    // request the server with raw `/foo bar` to emit 400 status code.
-    //
-    // So we generate `test.req` via `test.request()` first and override the
-    // encoded uri.
-    //
-    // `test.req` will only generated once:
-    //
-    //   ```
-    //   function Request::request() {
-    //     if (this.req) return this.req;
-    //
-    //     // code to generate this.req
-    //
-    //     return this.req;
-    //   }
-    //   ```
-    (test1 as any).request().path = '/foo bar';
-    (test2 as any).request().path = '/foo baz';
-
-    await Promise.all([
-      test1.expect(DEFAULT_BAD_REQUEST_HTML).expect(400),
-      test2.expect(DEFAULT_BAD_REQUEST_HTML).expect(400),
-    ]);
+    for (const response of responses) {
+      const [header, body] = response.split('\r\n\r\n');
+      assert.match(header, /^HTTP\/1\.1 400 Bad Request/);
+      assert.equal(body, DEFAULT_BAD_REQUEST_HTML);
+    }
   });
 
   describe.skip('server timeout', () => {
@@ -156,6 +130,41 @@ function connect(port: number) {
         socket.destroy();
         resolve();
       });
+    });
+  });
+}
+
+function rawRequest(port: number, path: string) {
+  return new Promise<string>((resolve, reject) => {
+    const socket = net.createConnection(port, '127.0.0.1');
+    let response = '';
+    let settled = false;
+
+    function resolveOnce() {
+      if (!settled) {
+        settled = true;
+        resolve(response);
+      }
+    }
+
+    socket.setEncoding('utf8');
+    socket.on('connect', () => {
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nConnection: close\r\n\r\n`);
+    });
+    socket.on('data', (chunk) => {
+      response += chunk;
+    });
+    socket.on('end', resolveOnce);
+    socket.on('close', (hasError) => {
+      if (!hasError) {
+        resolveOnce();
+      }
+    });
+    socket.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- replace the app_worker broken-path supertest ClientRequest.path mutation with raw TCP HTTP packets
- assert the server returns the default 400 Bad Request response for invalid raw paths

## Verification
- pnpm exec vitest run packages/egg/test/cluster1/app_worker.test.ts --testTimeout 20000 --hookTimeout 20000
- pnpm exec oxfmt --check packages/egg/test/cluster1/app_worker.test.ts
- pnpm exec oxlint --type-aware --type-check --quiet packages/egg/test/cluster1/app_worker.test.ts
- pnpm --filter egg typecheck

Issue: EGG-13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing for broken HTTP request handling with more rigorous validation of 400 Bad Request error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->