### PR TITLE
docs(utils): document bundle module loader

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -42,6 +42,16 @@ npm i @eggjs/utils
 - {String} baseDir - the current directory of application
 - {String} framework - the directory of framework
 
+### `setBundleModuleLoader(loader)`
+
+Register a bundle module loader for `importModule()`.
+
+- {Function|undefined} loader - called with a POSIX-normalized filepath or virtual specifier before normal module resolution.
+
+Return `undefined` from the loader to fall back to the default import path. Any other return value is treated as a bundle hit and uses the same default export handling as `importModule()`, including `importDefaultOnly` and double-default `__esModule` compatibility.
+
+Pass `undefined` to clear the registered loader.
+
 ## License
 
 [MIT](LICENSE)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -44,11 +44,13 @@ npm i @eggjs/utils
 
 ### `setBundleModuleLoader(loader)`
 
-Register a bundle module loader for `importModule()`.
+Register a bundle module loader for `importModule()`. The loader is shared globally via `globalThis` across all instances of `@eggjs/utils` in the same process.
 
-- {Function|undefined} loader - called with a POSIX-normalized filepath or virtual specifier before normal module resolution.
+- {Function|undefined} loader - a synchronous hook called with a POSIX-normalized filepath or virtual specifier before normal module resolution.
 
-Return `undefined` from the loader to fall back to the default import path. Any other return value is treated as a bundle hit and uses the same default export handling as `importModule()`, including `importDefaultOnly` and double-default `__esModule` compatibility.
+Return `undefined` from the loader to fall back to standard module resolution. Otherwise, return the module exports synchronously; any non-`undefined` return value is treated as a bundle hit and uses the same default export handling as `importModule()`, including `importDefaultOnly` and double-default `__esModule` compatibility.
+
+The loader must not be an `async` function or return a `Promise`, because `importModule()` does not `await` the hook.
 
 Pass `undefined` to clear the registered loader.
 


### PR DESCRIPTION
## Summary
- document the new `setBundleModuleLoader(loader)` API in `@eggjs/utils`
- clarify loader fallback, default export handling, and clearing behavior

## Verification
- `pnpm exec oxfmt --check packages/utils/README.md`

Note: the normal pre-commit hook was not used for the final commit because `oxlint --type-aware --fix` fails on a Markdown-only staged set with `No files found to lint`; the targeted Markdown format check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing how to register and clear a globally shared, synchronous hook for customizing dynamic import resolution, including fallback behavior when the hook yields no result and guidance that the hook must not be asynchronous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->