### PR TITLE
docs: document setBundleModuleLoader API

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -42,6 +42,27 @@ npm i @eggjs/utils
 - {String} baseDir - the current directory of application
 - {String} framework - the directory of framework
 
+### `setBundleModuleLoader(loader)`
+
+Register a custom module loader for bundled Egg applications.
+
+- {Function|undefined} loader - receives a POSIX-normalized filepath or virtual specifier before normal module resolution
+- Return `undefined` from the loader to fall through to the default `importModule()` behavior
+- Non-`undefined` return values are treated as module exports and keep the same `importDefaultOnly` and `__esModule` compatibility handling as normal imports
+- Pass `undefined` to clear the registered loader
+
+```ts
+import { importModule, setBundleModuleLoader } from '@eggjs/utils';
+
+setBundleModuleLoader((filepath) => {
+  if (filepath === 'virtual/config') {
+    return { default: { name: 'egg' } };
+  }
+});
+
+const config = await importModule('virtual/config', { importDefaultOnly: true });
+```
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Document setBundleModuleLoader(loader) in packages/utils/README.md
- Note loader input normalization, undefined fallthrough behavior, default export compatibility, and clearing the loader
- Add a short TypeScript usage example with importModule()

## Validation
- npm_config_store_dir=/tmp/pnpm-store pnpm dlx oxfmt packages/utils/README.md
- npm_config_store_dir=/tmp/pnpm-store pnpm dlx oxfmt --check packages/utils/README.md
- git diff --check

Note: pnpm install --frozen-lockfile --store-dir /tmp/pnpm-store was not used for full workspace validation because the current pnpm config does not match the checked-in lockfile (ERR_PNPM_LOCKFILE_CONFIG_MISMATCH). This PR is docs-only.