### PR TITLE
fix(bin): skip manifest app close hooks

### DIFF
--- a/tools/egg-bin/scripts/manifest-generate.mjs
+++ b/tools/egg-bin/scripts/manifest-generate.mjs
@@ -48,8 +48,8 @@ async function main() {
   console.log('[manifest]   extension entries: %d', extensionCount);
   console.log('[manifest] Written to %s/.egg/manifest.json', options.baseDir);
 
-  // Clean up and exit
-  await app.close();
+  // The manifest subprocess is metadata-only. Exiting directly avoids running
+  // real application beforeClose hooks that may depend on full runtime state.
   process.exit(0);
 }
 

--- a/tools/egg-bin/test/commands/manifest.test.ts
+++ b/tools/egg-bin/test/commands/manifest.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, it } from 'vitest';
+
+import coffee from '../coffee.js';
+import { getRootDirname, getFixtures } from '../helper.js';
+
+describe('test/commands/manifest.test.ts', () => {
+  const eggBin = path.join(getRootDirname(), 'bin/run.js');
+  const cwd = getFixtures('manifest-skip-close');
+  const manifestPath = path.join(cwd, '.egg/manifest.json');
+  const beforeCloseMarker = path.join(cwd, 'before-close-called');
+
+  function cleanGeneratedFiles() {
+    fs.rmSync(path.dirname(manifestPath), { recursive: true, force: true });
+    fs.rmSync(path.join(cwd, 'logs'), { recursive: true, force: true });
+    fs.rmSync(path.join(cwd, 'run'), { recursive: true, force: true });
+    fs.rmSync(beforeCloseMarker, { force: true });
+  }
+
+  beforeEach(cleanGeneratedFiles);
+  afterEach(cleanGeneratedFiles);
+
+  it('should not trigger application beforeClose hooks after writing manifest', async () => {
+    await coffee.fork(eggBin, ['manifest', 'generate', '--base', cwd, '--env=prod'], { cwd }).expect('code', 0).end();
+
+    assert.ok(fs.existsSync(manifestPath));
+    assert.ok(!fs.existsSync(beforeCloseMarker));
+  });
+});

--- a/tools/egg-bin/test/fixtures/manifest-skip-close/app.js
+++ b/tools/egg-bin/test/fixtures/manifest-skip-close/app.js
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export default class ManifestSkipCloseBoot {
+  constructor(app) {
+    this.app = app;
+  }
+
+  async loadMetadata() {
+    const marker = path.join(this.app.baseDir, 'before-close-called');
+    this.app.beforeClose(async () => {
+      fs.writeFileSync(marker, 'called');
+      throw new Error('beforeClose should not run during manifest generation');
+    });
+  }
+}

--- a/tools/egg-bin/test/fixtures/manifest-skip-close/config/config.default.js
+++ b/tools/egg-bin/test/fixtures/manifest-skip-close/config/config.default.js
@@ -1,0 +1,9 @@
+import path from 'node:path';
+
+export default (appInfo) => {
+  return {
+    logger: {
+      dir: path.join(appInfo.baseDir, 'logs'),
+    },
+  };
+};

--- a/tools/egg-bin/test/fixtures/manifest-skip-close/package.json
+++ b/tools/egg-bin/test/fixtures/manifest-skip-close/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "manifest-skip-close",
+  "type": "module",
+  "devDependencies": {
+    "typescript": "*"
+  }
+}


### PR DESCRIPTION
## Summary
- skip app.close() in the metadata-only manifest subprocess after manifest write succeeds
- add an egg-bin manifest regression fixture that registers a failing beforeClose hook during loadMetadata and verifies manifest generation still succeeds

## Tests
- pnpm --filter @eggjs/bin exec vitest run test/commands/manifest.test.ts
- pnpm --filter @eggjs/bin run typecheck
- pnpm exec oxfmt --check tools/egg-bin/scripts/manifest-generate.mjs tools/egg-bin/test/commands/manifest.test.ts tools/egg-bin/test/fixtures/manifest-skip-close/app.js tools/egg-bin/test/fixtures/manifest-skip-close/config/config.default.js tools/egg-bin/test/fixtures/manifest-skip-close/package.json
- pnpm exec oxlint --type-aware tools/egg-bin/scripts/manifest-generate.mjs tools/egg-bin/test/commands/manifest.test.ts tools/egg-bin/test/fixtures/manifest-skip-close/app.js tools/egg-bin/test/fixtures/manifest-skip-close/config/config.default.js

Refs EGG-18.