### PR TITLE
docs(utils): document bundle module loader

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -47,9 +47,11 @@ npm i @eggjs/utils
 Register a module loader hook for bundled Egg apps. The hook runs before the
 normal `importModule()` resolution path.
 
-- {Function | undefined} loader - receives a POSIX-normalized filepath or
-  virtual specifier and returns module exports. Return `undefined` to fall back
-  to the normal import path.
+- {Function | undefined} loader - a synchronous function that receives the
+  original `filepath` argument passed to `importModule()` after POSIX separator
+  normalization, or a virtual specifier. It does not receive the resolved
+  absolute file path from `importResolve()`. Return `undefined` to fall back to
+  the normal import path.
 
 The bundle loader is stored on `globalThis`, so bundled and external copies of
 `@eggjs/utils` share the same loader. Non-`undefined` results follow the same

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -42,6 +42,20 @@ npm i @eggjs/utils
 - {String} baseDir - the current directory of application
 - {String} framework - the directory of framework
 
+### `setBundleModuleLoader(loader)`
+
+Register a module loader hook for bundled Egg apps. The hook runs before the
+normal `importModule()` resolution path.
+
+- {Function | undefined} loader - receives a POSIX-normalized filepath or
+  virtual specifier and returns module exports. Return `undefined` to fall back
+  to the normal import path.
+
+The bundle loader is stored on `globalThis`, so bundled and external copies of
+`@eggjs/utils` share the same loader. Non-`undefined` results follow the same
+default export unwrapping rules as `importModule()`, including
+`importDefaultOnly`.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Document `setBundleModuleLoader(loader)` in `packages/utils/README.md`
- Clarify loader input normalization, fallback behavior, shared `globalThis` storage, and default export unwrapping semantics

## Verification
- `pnpm exec oxfmt --check packages/utils/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an API to register a bundle-specific module loader hook that runs before normal module resolution. The hook receives normalized filepaths or virtual specifiers, may defer to default import behavior, and its results follow the same default-export unwrapping rules. The registered loader is shared across bundled copies so it applies consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->