### PR TITLE
test: stabilize cluster unix socket fixture

### DIFF
--- a/packages/cluster/test/app_worker.test.ts
+++ b/packages/cluster/test/app_worker.test.ts
@@ -1,5 +1,8 @@
 import { strict as assert } from 'node:assert';
+import { randomBytes } from 'node:crypto';
 import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { scheduler } from 'node:timers/promises';
 
 import { mm, type MockApplication } from '@eggjs/mock';
@@ -8,7 +11,7 @@ import { ip } from 'address';
 import urllib from 'urllib';
 import { describe, it, afterEach, beforeEach, beforeAll, afterAll } from 'vitest';
 
-import { cluster, getFilepath } from './utils.ts';
+import { cluster } from './utils.ts';
 
 // node v24 will hang when test this file
 // FIXME: should enable this test after node v24 is stable
@@ -204,15 +207,16 @@ describe.skipIf(process.version.startsWith('v24') || process.platform === 'win32
   });
 
   describe('listen config', () => {
-    const sockFile = getFilepath('apps/app-listen-path/my.sock');
-    beforeEach(() => {
+    const sockFile = path.join(tmpdir(), `egg-app-listen-path-${process.pid}-${randomBytes(4).toString('hex')}.sock`);
+    beforeEach(async () => {
       mm.env('default');
+      await rm(sockFile, { force: true });
     });
     afterEach(async () => {
       await app.close();
       await mm.restore();
     });
-    afterEach(() => rm(sockFile, { force: true, recursive: true }));
+    afterEach(() => rm(sockFile, { force: true }));
 
     it.skip('should set default port 170xx then config.listen.port is null', async () => {
       app = cluster('apps/app-listen-without-port');
@@ -276,7 +280,15 @@ describe.skipIf(process.version.startsWith('v24') || process.platform === 'win32
     });
 
     it('should use path in config', async () => {
-      app = cluster('apps/app-listen-path');
+      app = cluster('apps/app-listen-path', {
+        opt: {
+          execArgv: [],
+          env: {
+            ...process.env,
+            EGG_APP_LISTEN_PATH_SOCKET: sockFile,
+          },
+        },
+      });
       // app.debug();
       await app.ready();
 

--- a/packages/cluster/test/fixtures/apps/app-listen-path/config/config.default.js
+++ b/packages/cluster/test/fixtures/apps/app-listen-path/config/config.default.js
@@ -7,7 +7,7 @@ module.exports = (app) => {
     keys: '123',
     cluster: {
       listen: {
-        path: path.join(app.baseDir, 'my.sock'),
+        path: process.env.EGG_APP_LISTEN_PATH_SOCKET || path.join(app.baseDir, 'my.sock'),
       },
     },
   };


### PR DESCRIPTION
## Summary
- move the app-listen-path Unix socket test to a short tmpdir socket path provided through fixture env
- clean the socket before startup and after teardown to avoid stale retry state

## Verification
- env HOME=/tmp EGG_HOME=/tmp corepack pnpm exec vitest run packages/cluster/test/app_worker.test.ts --testNamePattern "should use path in config" --retry 0 --testTimeout 30000 --hookTimeout 30000
- env HOME=/tmp EGG_HOME=/tmp corepack pnpm exec vitest run packages/cluster/test/app_worker.test.ts --retry 0 --testTimeout 30000 --hookTimeout 30000 (twice)
- corepack pnpm exec oxlint packages/cluster/test/app_worker.test.ts packages/cluster/test/fixtures/apps/app-listen-path/config/config.default.js
- corepack pnpm --filter @eggjs/cluster run typecheck

## Notes
- Root CI command `env HOME=/tmp EGG_HOME=/tmp CI=true corepack pnpm exec ut run ci` exits before tests because `ut run clean-dist` calls a missing `clean` script.
- Package coverage command `env HOME=/tmp EGG_HOME=/tmp CI=true corepack pnpm --filter @eggjs/cluster run test -- --coverage` reaches unrelated local runner failures from direct loading of tegg decorator syntax in `tegg/core/background-task/src/BackgroundTaskHelper.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Socket listening path can be overridden via the EGG_APP_LISTEN_PATH_SOCKET environment variable, with fallback to the default path.

* **Tests**
  * Tests now use per-process temporary socket paths and ensure proper setup/teardown cleanup so parallel runs are isolated and deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->