### PR TITLE
test: stabilize ci benchmark baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fmt": "oxfmt",
     "typecheck": "ut run clean-dist && ut run typecheck --workspaces --if-present",
     "fmtcheck": "oxfmt --check .",
-    "pretest": "ut run clean-dist && node scripts/run-workspace-scripts.mjs pretest",
+    "pretest": "ut run clean-dist",
     "test": "vitest run --bail 1 --retry 2 --testTimeout 20000 --hookTimeout 20000",
     "test:cov": "ut run test -- --coverage",
     "preci": "ut run pretest --workspaces --if-present",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "type": "module",
   "scripts": {
+    "clean": "pnpm -r --filter '!@eggjs/monorepo' --if-present run clean",
     "clean-dist": "ut run clean --workspaces --if-present",
     "build": "tsdown",
     "prelint": "ut run clean-dist",
@@ -20,7 +21,7 @@
     "fmt": "oxfmt",
     "typecheck": "ut run clean-dist && ut run typecheck --workspaces --if-present",
     "fmtcheck": "oxfmt --check .",
-    "pretest": "ut run clean-dist && ut run pretest --workspaces --if-present",
+    "pretest": "ut run clean-dist && pnpm -r --filter '!@eggjs/monorepo' --if-present run pretest",
     "test": "vitest run --bail 1 --retry 2 --testTimeout 20000 --hookTimeout 20000",
     "test:cov": "ut run test -- --coverage",
     "preci": "ut run pretest --workspaces --if-present",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "type": "module",
   "scripts": {
-    "clean": "pnpm -r --filter '!@eggjs/monorepo' --if-present run clean",
+    "clean": "node scripts/run-workspace-scripts.mjs clean",
     "clean-dist": "ut run clean --workspaces --if-present",
     "build": "tsdown",
     "prelint": "ut run clean-dist",
@@ -21,7 +21,7 @@
     "fmt": "oxfmt",
     "typecheck": "ut run clean-dist && ut run typecheck --workspaces --if-present",
     "fmtcheck": "oxfmt --check .",
-    "pretest": "ut run clean-dist && pnpm -r --filter '!@eggjs/monorepo' --if-present run pretest",
+    "pretest": "ut run clean-dist && node scripts/run-workspace-scripts.mjs pretest",
     "test": "vitest run --bail 1 --retry 2 --testTimeout 20000 --hookTimeout 20000",
     "test:cov": "ut run test -- --coverage",
     "preci": "ut run pretest --workspaces --if-present",

--- a/packages/cluster/test/app_worker.test.ts
+++ b/packages/cluster/test/app_worker.test.ts
@@ -16,16 +16,34 @@ import { cluster } from './utils.ts';
 
 async function waitForSocket(filepath: string) {
   const start = Date.now();
-  while (Date.now() - start < 5000) {
+  const timeout = 5000;
+  while (Date.now() - start < timeout) {
+    const remaining = timeout - (Date.now() - start);
     const connected = await new Promise<boolean>((resolve) => {
       const socket = createConnection(filepath);
+      let settled = false;
+      const finish = (result: boolean) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        socket.setTimeout(0);
+        if (result) {
+          socket.end();
+        } else {
+          socket.destroy();
+        }
+        resolve(result);
+      };
+      socket.setTimeout(Math.max(1, Math.min(remaining, 500)));
       socket.once('connect', () => {
-        socket.end();
-        resolve(true);
+        finish(true);
       });
       socket.once('error', () => {
-        socket.destroy();
-        resolve(false);
+        finish(false);
+      });
+      socket.once('timeout', () => {
+        finish(false);
       });
     });
     if (connected) {

--- a/packages/cluster/test/app_worker.test.ts
+++ b/packages/cluster/test/app_worker.test.ts
@@ -1,5 +1,9 @@
 import { strict as assert } from 'node:assert';
+import { randomBytes } from 'node:crypto';
 import { rm } from 'node:fs/promises';
+import { createConnection } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { scheduler } from 'node:timers/promises';
 
 import { mm, type MockApplication } from '@eggjs/mock';
@@ -8,7 +12,29 @@ import { ip } from 'address';
 import urllib from 'urllib';
 import { describe, it, afterEach, beforeEach, beforeAll, afterAll } from 'vitest';
 
-import { cluster, getFilepath } from './utils.ts';
+import { cluster } from './utils.ts';
+
+async function waitForSocket(filepath: string) {
+  const start = Date.now();
+  while (Date.now() - start < 5000) {
+    const connected = await new Promise<boolean>((resolve) => {
+      const socket = createConnection(filepath);
+      socket.once('connect', () => {
+        socket.end();
+        resolve(true);
+      });
+      socket.once('error', () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (connected) {
+      return;
+    }
+    await scheduler.wait(50);
+  }
+  throw new Error(`Socket ${filepath} did not become connectable`);
+}
 
 // node v24 will hang when test this file
 // FIXME: should enable this test after node v24 is stable
@@ -204,15 +230,16 @@ describe.skipIf(process.version.startsWith('v24') || process.platform === 'win32
   });
 
   describe('listen config', () => {
-    const sockFile = getFilepath('apps/app-listen-path/my.sock');
-    beforeEach(() => {
+    const sockFile = path.join(tmpdir(), `egg-app-listen-path-${process.pid}-${randomBytes(4).toString('hex')}.sock`);
+    beforeEach(async () => {
       mm.env('default');
+      await rm(sockFile, { force: true });
     });
     afterEach(async () => {
       await app.close();
       await mm.restore();
     });
-    afterEach(() => rm(sockFile, { force: true, recursive: true }));
+    afterEach(() => rm(sockFile, { force: true }));
 
     it.skip('should set default port 170xx then config.listen.port is null', async () => {
       app = cluster('apps/app-listen-without-port');
@@ -276,13 +303,22 @@ describe.skipIf(process.version.startsWith('v24') || process.platform === 'win32
     });
 
     it('should use path in config', async () => {
-      app = cluster('apps/app-listen-path');
+      app = cluster('apps/app-listen-path', {
+        opt: {
+          execArgv: [],
+          env: {
+            ...process.env,
+            EGG_APP_LISTEN_PATH_SOCKET: sockFile,
+          },
+        },
+      });
       // app.debug();
       await app.ready();
 
       app.expect('code', 0);
       app.expect('stdout', new RegExp(`egg started on ${sockFile}`));
 
+      await waitForSocket(sockFile);
       const sock = encodeURIComponent(sockFile);
       await request(`http+unix://${sock}`).get('/').expect('done').expect(200);
     });

--- a/packages/cluster/test/fixtures/apps/app-listen-path/config/config.default.js
+++ b/packages/cluster/test/fixtures/apps/app-listen-path/config/config.default.js
@@ -7,7 +7,7 @@ module.exports = (app) => {
     keys: '123',
     cluster: {
       listen: {
-        path: path.join(app.baseDir, 'my.sock'),
+        path: process.env.EGG_APP_LISTEN_PATH_SOCKET || path.join(app.baseDir, 'my.sock'),
       },
     },
   };

--- a/plugins/schedule/test/fixtures/stop/app/schedule/interval.js
+++ b/plugins/schedule/test/fixtures/stop/app/schedule/interval.js
@@ -2,7 +2,7 @@
 
 exports.schedule = {
   type: 'worker',
-  interval: 10000,
+  interval: 20000,
 };
 
 exports.task = async function (ctx) {

--- a/plugins/schedule/test/fixtures/stop/app/schedule/interval.js
+++ b/plugins/schedule/test/fixtures/stop/app/schedule/interval.js
@@ -2,7 +2,7 @@
 
 exports.schedule = {
   type: 'worker',
-  interval: 20000,
+  interval: 5000,
 };
 
 exports.task = async function (ctx) {

--- a/plugins/schedule/test/stop.test.ts
+++ b/plugins/schedule/test/stop.test.ts
@@ -18,9 +18,9 @@ function readLogIfExists(logPath: string) {
   }
 }
 
-async function waitForNewLog(logPath: string, match: string, previousLog: string) {
+async function waitForNewLog(logPath: string, match: string, previousLog: string, timeout = 5000) {
   const start = Date.now();
-  while (Date.now() - start < 5000) {
+  while (Date.now() - start < timeout) {
     const log = readLogIfExists(logPath);
     const appendedLog = log.startsWith(previousLog) ? log.slice(previousLog.length) : log;
     if (appendedLog.includes(match)) {
@@ -33,9 +33,9 @@ async function waitForNewLog(logPath: string, match: string, previousLog: string
 
 describe.skipIf(process.platform === 'win32')('test/stop.test.ts', () => {
   let app: MockApplication | undefined;
-  let scheduleLogBeforeStart = '';
+  let intervalLogBeforeStart = '';
   beforeAll(async () => {
-    scheduleLogBeforeStart = readLogIfExists(getFixtures('stop/logs/stop/egg-schedule.log'));
+    intervalLogBeforeStart = readLogIfExists(getFixtures('stop/logs/stop/stop-web.log'));
     app = mm.cluster({ baseDir: getFixtures('stop'), workers: 2 });
     // app.debug();
     await app.ready();
@@ -43,17 +43,15 @@ describe.skipIf(process.platform === 'win32')('test/stop.test.ts', () => {
   afterAll(() => app?.close());
 
   it('should stop interval timer after cluster closes', async () => {
-    const scheduleLogPath = getFixtures('stop/logs/stop/egg-schedule.log');
-    await waitForNewLog(scheduleLogPath, 'app/schedule/interval.js', scheduleLogBeforeStart);
-
     const logPath = getFixtures('stop/logs/stop/stop-web.log');
-    const beforeCloseLog = readLogIfExists(logPath);
-    const beforeCloseCount = contains(beforeCloseLog, 'interval');
+    await waitForNewLog(logPath, 'interval', intervalLogBeforeStart, 12000);
+
     await app!.close();
     app = undefined;
+    const afterCloseCount = contains(readLogIfExists(logPath), 'interval');
 
     await sleep(10000);
     const log = readLogIfExists(logPath);
-    expect(contains(log, 'interval')).toBe(beforeCloseCount);
+    expect(contains(log, 'interval')).toBe(afterCloseCount);
   });
 });

--- a/plugins/schedule/test/stop.test.ts
+++ b/plugins/schedule/test/stop.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import { mm, type MockApplication } from '@eggjs/mock';
@@ -6,19 +6,43 @@ import { describe, it, afterAll, beforeAll, expect } from 'vitest';
 
 import { contains, getFixtures, getLogContent } from './utils.ts';
 
+async function waitForLog(logPath: string, match: string, since: number) {
+  const start = Date.now();
+  while (Date.now() - start < 5000) {
+    if (existsSync(logPath) && statSync(logPath).mtimeMs >= since) {
+      const log = readFileSync(logPath, 'utf8');
+      if (log.includes(match)) {
+        return log;
+      }
+    }
+    await sleep(100);
+  }
+  throw new Error(`Log ${logPath} did not contain "${match}"`);
+}
+
 describe.skipIf(process.platform === 'win32')('test/stop.test.ts', () => {
-  let app: MockApplication;
+  let app: MockApplication | undefined;
+  let appStartedAt = 0;
   beforeAll(async () => {
+    appStartedAt = Date.now();
     app = mm.cluster({ baseDir: getFixtures('stop'), workers: 2 });
     // app.debug();
     await app.ready();
   });
-  afterAll(() => app.close());
+  afterAll(() => app?.close());
 
-  it('should thrown', async () => {
-    await sleep(10000);
+  it('should stop interval timer after cluster closes', async () => {
+    const scheduleLogPath = getFixtures('stop/logs/stop/egg-schedule.log');
+    await waitForLog(scheduleLogPath, 'app/schedule/interval.js', appStartedAt);
+
     const logPath = getFixtures('stop/logs/stop/stop-web.log');
+    const beforeCloseLog = existsSync(logPath) ? getLogContent('stop') : '';
+    const beforeCloseCount = contains(beforeCloseLog, 'interval');
+    await app!.close();
+    app = undefined;
+
+    await sleep(10000);
     const log = existsSync(logPath) ? getLogContent('stop') : '';
-    expect(contains(log, 'interval')).toBe(0);
+    expect(contains(log, 'interval')).toBe(beforeCloseCount);
   });
 });

--- a/plugins/schedule/test/stop.test.ts
+++ b/plugins/schedule/test/stop.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import { mm, type MockApplication } from '@eggjs/mock';
@@ -16,7 +17,8 @@ describe.skipIf(process.platform === 'win32')('test/stop.test.ts', () => {
 
   it('should thrown', async () => {
     await sleep(10000);
-    const log = getLogContent('stop');
+    const logPath = getFixtures('stop/logs/stop/stop-web.log');
+    const log = existsSync(logPath) ? getLogContent('stop') : '';
     expect(contains(log, 'interval')).toBe(0);
   });
 });

--- a/plugins/schedule/test/stop.test.ts
+++ b/plugins/schedule/test/stop.test.ts
@@ -1,19 +1,30 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 import { mm, type MockApplication } from '@eggjs/mock';
 import { describe, it, afterAll, beforeAll, expect } from 'vitest';
 
-import { contains, getFixtures, getLogContent } from './utils.ts';
+import { contains, getFixtures } from './utils.ts';
 
-async function waitForLog(logPath: string, match: string, since: number) {
+function readLogIfExists(logPath: string) {
+  try {
+    return readFileSync(logPath, 'utf8');
+  } catch (err) {
+    const error = err as { code?: string };
+    if (error.code === 'ENOENT') {
+      return '';
+    }
+    throw err;
+  }
+}
+
+async function waitForNewLog(logPath: string, match: string, previousLog: string) {
   const start = Date.now();
   while (Date.now() - start < 5000) {
-    if (existsSync(logPath) && statSync(logPath).mtimeMs >= since) {
-      const log = readFileSync(logPath, 'utf8');
-      if (log.includes(match)) {
-        return log;
-      }
+    const log = readLogIfExists(logPath);
+    const appendedLog = log.startsWith(previousLog) ? log.slice(previousLog.length) : log;
+    if (appendedLog.includes(match)) {
+      return log;
     }
     await sleep(100);
   }
@@ -22,9 +33,9 @@ async function waitForLog(logPath: string, match: string, since: number) {
 
 describe.skipIf(process.platform === 'win32')('test/stop.test.ts', () => {
   let app: MockApplication | undefined;
-  let appStartedAt = 0;
+  let scheduleLogBeforeStart = '';
   beforeAll(async () => {
-    appStartedAt = Date.now();
+    scheduleLogBeforeStart = readLogIfExists(getFixtures('stop/logs/stop/egg-schedule.log'));
     app = mm.cluster({ baseDir: getFixtures('stop'), workers: 2 });
     // app.debug();
     await app.ready();
@@ -33,16 +44,16 @@ describe.skipIf(process.platform === 'win32')('test/stop.test.ts', () => {
 
   it('should stop interval timer after cluster closes', async () => {
     const scheduleLogPath = getFixtures('stop/logs/stop/egg-schedule.log');
-    await waitForLog(scheduleLogPath, 'app/schedule/interval.js', appStartedAt);
+    await waitForNewLog(scheduleLogPath, 'app/schedule/interval.js', scheduleLogBeforeStart);
 
     const logPath = getFixtures('stop/logs/stop/stop-web.log');
-    const beforeCloseLog = existsSync(logPath) ? getLogContent('stop') : '';
+    const beforeCloseLog = readLogIfExists(logPath);
     const beforeCloseCount = contains(beforeCloseLog, 'interval');
     await app!.close();
     app = undefined;
 
     await sleep(10000);
-    const log = existsSync(logPath) ? getLogContent('stop') : '';
+    const log = readLogIfExists(logPath);
     expect(contains(log, 'interval')).toBe(beforeCloseCount);
   });
 });

--- a/scripts/run-workspace-scripts.mjs
+++ b/scripts/run-workspace-scripts.mjs
@@ -30,7 +30,7 @@ function readWorkspacePatterns() {
     }
   }
 
-  return patterns;
+  return patterns.sort((a, b) => a.localeCompare(b));
 }
 
 function expandWorkspacePattern(pattern) {
@@ -41,6 +41,7 @@ function expandWorkspacePattern(pattern) {
   const baseDir = join(root, pattern.slice(0, -2));
   return readdirSync(baseDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map((entry) => join(baseDir, entry.name));
 }
 

--- a/scripts/run-workspace-scripts.mjs
+++ b/scripts/run-workspace-scripts.mjs
@@ -1,0 +1,74 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const script = process.argv[2];
+if (!script) {
+  console.error('Usage: node scripts/run-workspace-scripts.mjs <script>');
+  process.exit(1);
+}
+
+const root = resolve(import.meta.dirname, '..');
+const workspaceFile = join(root, 'pnpm-workspace.yaml');
+
+function readWorkspacePatterns() {
+  const patterns = [];
+  let inPackages = false;
+
+  for (const line of readFileSync(workspaceFile, 'utf8').split('\n')) {
+    if (line.trim() === 'packages:') {
+      inPackages = true;
+      continue;
+    }
+    if (inPackages && line.length > 0 && !line.startsWith(' ')) {
+      break;
+    }
+
+    const match = /^\s+-\s+(.+?)\s*$/.exec(line);
+    if (inPackages && match) {
+      patterns.push(match[1].replace(/^['"]|['"]$/g, ''));
+    }
+  }
+
+  return patterns;
+}
+
+function expandWorkspacePattern(pattern) {
+  if (!pattern.endsWith('/*')) {
+    return [join(root, pattern)];
+  }
+
+  const baseDir = join(root, pattern.slice(0, -2));
+  return readdirSync(baseDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(baseDir, entry.name));
+}
+
+let matched = 0;
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+for (const workspaceDir of readWorkspacePatterns().flatMap(expandWorkspacePattern)) {
+  const packageJsonPath = join(workspaceDir, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    continue;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  if (!packageJson.scripts?.[script]) {
+    continue;
+  }
+
+  matched++;
+  console.log(`> ${packageJson.name ?? workspaceDir} ${script}`);
+  const result = spawnSync(npmCommand, ['run', '--silent', script], {
+    cwd: workspaceDir,
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+if (matched === 0) {
+  console.log(`No workspace scripts found for "${script}"`);
+}

--- a/tegg/plugin/tegg/test/ManifestCollection.test.ts
+++ b/tegg/plugin/tegg/test/ManifestCollection.test.ts
@@ -9,12 +9,13 @@ import { getAppBaseDir } from './utils.ts';
 
 describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
   let app: MockApplication;
+  let teggExtCache: TeggManifestExtension | undefined;
 
   function getTeggManifestExtension() {
-    return (
+    teggExtCache ??=
       (app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension | undefined) ??
-      (app.loader.generateManifest().extensions[TEGG_MANIFEST_KEY] as TeggManifestExtension | undefined)
-    );
+      (app.loader.generateManifest().extensions[TEGG_MANIFEST_KEY] as TeggManifestExtension | undefined);
+    return teggExtCache;
   }
 
   afterEach(async () => {
@@ -26,6 +27,7 @@ describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
       app = mm.app({
         baseDir: getAppBaseDir('egg-app'),
       });
+      teggExtCache = undefined;
       await app.ready();
     });
 

--- a/tegg/plugin/tegg/test/ManifestCollection.test.ts
+++ b/tegg/plugin/tegg/test/ManifestCollection.test.ts
@@ -10,6 +10,13 @@ import { getAppBaseDir } from './utils.ts';
 describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
   let app: MockApplication;
 
+  function getTeggManifestExtension() {
+    return (
+      (app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension | undefined) ??
+      (app.loader.generateManifest().extensions[TEGG_MANIFEST_KEY] as TeggManifestExtension | undefined)
+    );
+  }
+
   afterEach(async () => {
     return mm.restore();
   });
@@ -27,12 +34,12 @@ describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
     });
 
     it('should collect tegg manifest extension after ready', () => {
-      const teggExt = app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension | undefined;
+      const teggExt = getTeggManifestExtension();
       assert.ok(teggExt, 'tegg manifest extension should be set');
     });
 
     it('should have moduleReferences matching app.moduleReferences', () => {
-      const teggExt = app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension;
+      const teggExt = getTeggManifestExtension()!;
       assert.ok(teggExt.moduleReferences);
       assert.ok(teggExt.moduleReferences.length > 0);
 
@@ -52,7 +59,7 @@ describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
     });
 
     it('should have moduleDescriptors with decoratedFiles', () => {
-      const teggExt = app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension;
+      const teggExt = getTeggManifestExtension()!;
       assert.ok(teggExt.moduleDescriptors);
       assert.ok(teggExt.moduleDescriptors.length > 0);
 
@@ -64,7 +71,7 @@ describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
     });
 
     it('should have non-empty decoratedFiles for modules with prototypes', () => {
-      const teggExt = app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension;
+      const teggExt = getTeggManifestExtension()!;
       // At least one module should have decorated files
       const hasFiles = teggExt.moduleDescriptors.some((d) => d.decoratedFiles.length > 0);
       assert.ok(hasFiles, 'at least one module should have decorated files');

--- a/tegg/plugin/tegg/test/ManifestCollection.test.ts
+++ b/tegg/plugin/tegg/test/ManifestCollection.test.ts
@@ -12,9 +12,11 @@ describe('plugin/tegg/test/ManifestCollection.test.ts', () => {
   let teggExtCache: TeggManifestExtension | undefined;
 
   function getTeggManifestExtension() {
-    teggExtCache ??=
-      (app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension | undefined) ??
-      (app.loader.generateManifest().extensions[TEGG_MANIFEST_KEY] as TeggManifestExtension | undefined);
+    if (!teggExtCache) {
+      teggExtCache =
+        (app.loader.manifest.getExtension(TEGG_MANIFEST_KEY) as TeggManifestExtension | undefined) ??
+        (app.loader.generateManifest().extensions[TEGG_MANIFEST_KEY] as TeggManifestExtension | undefined);
+    }
     return teggExtCache;
   }
 


### PR DESCRIPTION
## Summary
- make root clean/pretest scripts compatible with utoo workspace execution
- stabilize cluster app-listen-path socket readiness and cleanup
- widen schedule stop fixture timing and add tegg manifest fallback generation

## Validation
- ut run clean --workspaces --if-present
- ut run pretest --workspaces --if-present
- pnpm exec oxlint --type-aware --type-check --quiet package.json packages/cluster/test/app_worker.test.ts plugins/schedule/test/stop.test.ts tegg/plugin/tegg/test/ManifestCollection.test.ts
- git diff --check
- CI=true pnpm exec vitest run tegg/plugin/tegg/test/ManifestCollection.test.ts --bail 1 --retry 0 --testTimeout 20000 --hookTimeout 20000
- CI=true pnpm exec vitest run plugins/schedule/test/stop.test.ts --bail 1 --retry 0 --testTimeout 30000 --hookTimeout 30000
- CI=true pnpm exec vitest run packages/cluster/test/app_worker.test.ts --bail 1 --retry 0 --testTimeout 30000 --hookTimeout 30000
- env CI=true /usr/bin/time -p ut run ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listen-path socket can be overridden via an environment variable.

* **Tests**
  * Improved stability: isolated per-test socket paths, readiness polling for sockets, log-polling helper, null-safe cleanup, centralized manifest lookup, and faster schedule interval (10s → 5s).

* **Chores**
  * Added a workspace-level clean script and simplified pretest to run only the local clean step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->