### PR TITLE
docs: document egg bundler tooling

### DIFF
--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -209,7 +209,8 @@ node worker.js
 - `--manifest` path to `manifest.json`, default to `<baseDir>/.egg/manifest.json`
 - `--framework` / `-f` framework name or absolute path
 - `--mode` build mode, `production` or `development`, default to `production`
-- `--no-tegg` disable tegg decorated file collection
+- `--no-tegg` accepted by the CLI, but not applied by the current bundler
+  implementation yet
 - `--force-external` package name to always keep external, supports multiple
 - `--inline-external` package name to force inline, supports multiple
 

--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -36,6 +36,7 @@ Add `egg-bin` to `package.json` scripts:
     "test-local": "egg-bin test",
     "test": "npm run lint -- --fix && npm run test-local",
     "cov": "egg-bin cov",
+    "bundle": "egg-bin bundle",
     "lint": "eslint .",
     "ci": "npm run lint && npm run cov"
   }
@@ -182,6 +183,38 @@ You can set `COV_EXCLUDES` env to add glob patterns to exclude from coverage (co
 ```bash
 COV_EXCLUDES="app/plugins/c*,app/autocreate/**" egg-bin cov
 ```
+
+### bundle
+
+Bundle an Egg application into a deployable artifact with `@eggjs/egg-bundler`.
+
+```bash
+egg-bin bundle
+egg-bin bundle --output ./dist-bundle
+egg-bin bundle --mode development
+egg-bin bundle --framework egg --output ./out
+```
+
+The command writes the bundle to `./dist-bundle` by default. The generated
+artifact can be started with Node from the output directory:
+
+```bash
+cd dist-bundle
+node worker.js
+```
+
+#### bundle options
+
+- `--output` / `-o` output directory, default to `./dist-bundle`
+- `--manifest` path to `manifest.json`, default to `<baseDir>/.egg/manifest.json`
+- `--framework` / `-f` framework name or absolute path
+- `--mode` build mode, `production` or `development`, default to `production`
+- `--no-tegg` disable tegg decorated file collection
+- `--force-external` package name to always keep external, supports multiple
+- `--inline-external` package name to force inline, supports multiple
+
+See [`@eggjs/egg-bundler`](../egg-bundler/README.md) for the programmatic API
+and output structure.
 
 ## Breaking Changes (v8)
 

--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -1,0 +1,60 @@
+# @eggjs/egg-bundler
+
+Bundle an Egg application into a deployable CommonJS artifact.
+
+The bundler is used by `egg-bin bundle` and is also available as a programmatic
+API for tooling that needs to build bundles directly.
+
+## Usage
+
+```ts
+import { bundle } from '@eggjs/egg-bundler';
+
+await bundle({
+  baseDir: '/path/to/app',
+  outputDir: './dist-bundle',
+  framework: 'egg',
+  mode: 'production',
+});
+```
+
+`outputDir` is resolved from `baseDir` when it is relative. The default manifest
+path is `<baseDir>/.egg/manifest.json`.
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `baseDir` | Application root directory. Required. |
+| `outputDir` | Output directory for the bundled artifact. Required. |
+| `manifestPath` | Path to `manifest.json`. Defaults to `<baseDir>/.egg/manifest.json`. |
+| `framework` | Framework name or absolute path. Defaults to `egg`. |
+| `mode` | Build mode, `production` or `development`. Defaults to `production`. |
+| `tegg` | Enable tegg decorated file collection. Defaults to `true`. |
+| `externals.force` | Package names to always keep external. |
+| `externals.inline` | Package names to force inline even if auto-detected as external. |
+| `pack.buildFunc` | Test hook for replacing the real `@utoo/pack` build entry. |
+| `pack.rootPath` | Override the monorepo workspace root used by `@utoo/pack`. |
+
+## Result
+
+`bundle()` resolves with:
+
+| Field | Description |
+| --- | --- |
+| `outputDir` | Absolute output directory. |
+| `files` | Sorted absolute paths for files written into the artifact. |
+| `manifestPath` | Absolute path to `bundle-manifest.json`. |
+
+## Running The Bundle
+
+```bash
+cd dist-bundle
+node worker.js
+```
+
+The generated worker entry runs the app in Egg's single-process mode and serves
+framework file discovery/module resolution from the inlined bundle map.
+
+See [output-structure.md](./docs/output-structure.md) for artifact layout,
+externals behavior, and current limitations.

--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -30,7 +30,7 @@ path is `<baseDir>/.egg/manifest.json`.
 | `manifestPath` | Path to `manifest.json`. Defaults to `<baseDir>/.egg/manifest.json`. |
 | `framework` | Framework name or absolute path. Defaults to `egg`. |
 | `mode` | Build mode, `production` or `development`. Defaults to `production`. |
-| `tegg` | Enable tegg decorated file collection. Defaults to `true`. |
+| `tegg` | Accepted by `BundlerConfig`, but not applied by the current implementation yet. |
 | `externals.force` | Package names to always keep external. |
 | `externals.inline` | Package names to force inline even if auto-detected as external. |
 | `pack.buildFunc` | Test hook for replacing the real `@utoo/pack` build entry. |

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -57,10 +57,11 @@ checks (T17).
 
 ## Externals
 
-Packages classified as external by `ExternalsResolver` (native addons,
-ESM-only packages, peer dependencies, `@eggjs/*`, and the user's
-`externals.force` list) are **not** inlined. They must be installed alongside
-the bundle — typically by copying the app's `package.json` next to
+Packages classified as external by `ExternalsResolver` are **not** inlined.
+This includes the user's `externals.force` list, root `peerDependencies`,
+always-external packages (`egg`, `@swc/helpers`, and `@eggjs/*`), native addons,
+and ESM-only packages. They must be installed alongside the bundle — typically
+by copying the app's `package.json` next to
 `worker.js` and running `npm ci --omit=dev`, or by deploying the bundle
 into an image that already has these dependencies on disk.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,6 +18,7 @@ Read this file before exploring raw sources.
 
 ## Packages
 
+- [Egg Bundler](./packages/egg-bundler.md) - Tooling package that bundles Egg applications and backs `egg-bin bundle`.
 - [Typings Package](./packages/typings.md) - Shared TypeScript type surface for cross-package Egg typings.
 
 ## Sources

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,11 @@
 # Wiki Log
 
+## [2026-05-02] package | document egg bundler tooling
+
+- sources touched: `tools/egg-bundler/src/index.ts`, `tools/egg-bundler/src/lib/Bundler.ts`, `tools/egg-bin/src/commands/bundle.ts`, `tools/egg-bundler/docs/output-structure.md`
+- pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/packages/egg-bundler.md`
+- note: Recorded the new `@eggjs/egg-bundler` package and its `egg-bin bundle` CLI surface after the bundler stack reached `next`.
+
 ## [2026-04-21] bootstrap | seed wiki schema and starter pages
 
 - sources touched: `CLAUDE.md`

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -1,0 +1,47 @@
+---
+title: Egg Bundler
+type: package
+summary: Bundles Egg applications into deployable CommonJS artifacts and powers the egg-bin bundle command.
+source_files:
+  - tools/egg-bundler/src/index.ts
+  - tools/egg-bundler/src/lib/Bundler.ts
+  - tools/egg-bin/src/commands/bundle.ts
+  - tools/egg-bundler/docs/output-structure.md
+updated_at: 2026-05-02
+status: active
+---
+
+# Egg Bundler
+
+`@eggjs/egg-bundler` is a developer tooling package under `tools/egg-bundler/`.
+It exposes `bundle(config)` and the `Bundler` class for producing a deployable
+CommonJS artifact from an Egg application.
+
+## Public Surfaces
+
+- `tools/egg-bundler/src/index.ts` exports `bundle`, `Bundler`, the helper
+  classes, and the public config/result types.
+- `tools/egg-bin/src/commands/bundle.ts` wires the package into
+  `egg-bin bundle`.
+
+## Bundle Flow
+
+1. `ManifestLoader` loads the app startup manifest, defaulting to
+   `<baseDir>/.egg/manifest.json`.
+2. `ExternalsResolver` classifies packages that should stay external.
+3. `EntryGenerator` writes a synthetic worker entry that installs the bundle
+   manifest/module loader before starting Egg.
+4. `PackRunner` invokes `@utoo/pack`.
+5. `Bundler` writes `bundle-manifest.json` and returns absolute output paths.
+
+## Current Behavior
+
+- Relative `outputDir` values are resolved from `baseDir`.
+- Default mode is `production`; `development` is also accepted.
+- The generated app runs in Egg single-process mode.
+- Native addons, ESM-only packages, peer dependencies, `@eggjs/*`, and
+  explicit `externals.force` entries are external.
+
+Inference: because `egg-bin bundle` is now a public CLI surface, user-facing
+tooling docs should mention the command and its key flags whenever this package
+changes materially.

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -39,9 +39,7 @@ CommonJS artifact from an Egg application.
 - Relative `outputDir` values are resolved from `baseDir`.
 - Default mode is `production`; `development` is also accepted.
 - The generated app runs in Egg single-process mode.
-- Native addons, ESM-only packages, peer dependencies, `@eggjs/*`, and
-  explicit `externals.force` entries are external.
-
-Inference: because `egg-bin bundle` is now a public CLI surface, user-facing
-tooling docs should mention the command and its key flags whenever this package
-changes materially.
+- Explicit `externals.force` entries, root `peerDependencies`, `egg`,
+  `@swc/helpers`, `@eggjs/*`, native addons, and ESM-only packages are external.
+- `BundlerConfig.tegg` is accepted but not applied by the current implementation
+  yet.


### PR DESCRIPTION
## Summary

- Document the new `egg-bin bundle` command in `tools/egg-bin/README.md`.
- Add a package README for `@eggjs/egg-bundler` with usage, options, result fields, and runtime notes.
- Record the bundler package in the LLM wiki index/log for future doc maintenance.

## Validation

- `git diff --cached --check` passed before commit.
- `pnpm exec oxfmt --check tools/egg-bin/README.md tools/egg-bundler/README.md wiki/index.md wiki/log.md wiki/packages/egg-bundler.md` could not run because this worktree has no installed dependencies and `oxfmt` was not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new Egg Bundler tool for packaging Egg applications.
  * Documented the `egg-bin bundle` CLI and programmatic API, options (mode, framework, externals control), output/resolution behavior, and how to run generated artifacts.
  * Expanded externals guidance and artifact layout details.
  * Updated wiki index and changelog with bundler references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->