### PR TITLE
fix(bundler): resolve cnpmcore pack blockers

### DIFF
--- a/packages/egg/src/index.ts
+++ b/packages/egg/src/index.ts
@@ -51,7 +51,8 @@ export { Singleton, type SingletonCreateMethod, type SingletonOptions } from '@e
 export * from './lib/error/index.ts';
 
 // export loggers
-export type { LoggerLevel, EggLogger, EggLogger as Logger } from 'egg-logger';
+export { EggLogger as Logger } from 'egg-logger';
+export type { LoggerLevel, EggLogger } from 'egg-logger';
 
 // export httpClients
 export * from './lib/core/httpclient.ts';

--- a/packages/egg/src/index.ts
+++ b/packages/egg/src/index.ts
@@ -17,7 +17,7 @@ export * from './lib/types.ts';
 export * from './lib/define.ts';
 
 // alias EggAppConfig to Config
-export const Config: ObjectConstructor = EggAppConfig;
+export const Config: typeof EggAppConfig = EggAppConfig;
 /**
  * Egg Application Config, can be injected into Proto, e.g. SingletonProto/ContextProto/HttpController.
  *

--- a/packages/egg/src/index.ts
+++ b/packages/egg/src/index.ts
@@ -17,7 +17,7 @@ export * from './lib/types.ts';
 export * from './lib/define.ts';
 
 // alias EggAppConfig to Config
-export const Config = EggAppConfig;
+export const Config: ObjectConstructor = EggAppConfig;
 /**
  * Egg Application Config, can be injected into Proto, e.g. SingletonProto/ContextProto/HttpController.
  *

--- a/packages/egg/src/index.ts
+++ b/packages/egg/src/index.ts
@@ -1,6 +1,7 @@
 import Helper from './app/extend/helper.ts';
 import { BaseContextClass } from './lib/core/base_context_class.ts';
 import { startEgg, type SingleModeApplication, type SingleModeAgent } from './lib/start.ts';
+import { EggAppConfig, type EggAppConfig as EggAppConfigType } from './lib/types.ts';
 
 // export extends
 export { Helper };
@@ -16,28 +17,27 @@ export * from './lib/types.ts';
 export * from './lib/define.ts';
 
 // alias EggAppConfig to Config
-export type {
-  /**
-   * Egg Application Config, can be injected into Proto, e.g. SingletonProto/ContextProto/HttpController.
-   *
-   * Usage:
-   * ```ts
-   * import { Inject, Config } from 'egg';
-   *
-   * @SingletonProto()
-   * class FooService {
-   *   @Inject()
-   *   config: Config;
-   *
-   *   async bar() {
-   *     console.log(this.config.env);
-   *   }
-   * }
-   * ```
-   * @since 4.1.0
-   */
-  EggAppConfig as Config,
-} from './lib/types.ts';
+export const Config = EggAppConfig;
+/**
+ * Egg Application Config, can be injected into Proto, e.g. SingletonProto/ContextProto/HttpController.
+ *
+ * Usage:
+ * ```ts
+ * import { Inject, Config } from 'egg';
+ *
+ * @SingletonProto()
+ * class FooService {
+ *   @Inject()
+ *   config: Config;
+ *
+ *   async bar() {
+ *     console.log(this.config.env);
+ *   }
+ * }
+ * ```
+ * @since 4.1.0
+ */
+export type Config = EggAppConfigType;
 
 export * from './lib/start.ts';
 

--- a/packages/egg/src/lib/types.ts
+++ b/packages/egg/src/lib/types.ts
@@ -100,6 +100,11 @@ export interface HttpClientConfig {
  */
 export type PowerPartial<T> = PartialDeep<T>;
 
+// Some applications use this framework type name in decorated fields without
+// `import type`; keep a runtime export available for decorator metadata and
+// bundler static export validation while the interface below remains the type.
+export const EggAppConfig: ObjectConstructor = Object;
+
 export interface EggAppConfig extends EggCoreAppConfig {
   workerStartTimeout: number;
   baseDir: string;

--- a/packages/egg/test/__snapshots__/index.test.ts.snap
+++ b/packages/egg/test/__snapshots__/index.test.ts.snap
@@ -22,6 +22,7 @@ exports[`should expose properties 1`] = `
   "Controller": [Function],
   "CookieLimitExceedError": [Function],
   "Cookies": [Function],
+  "EggAppConfig": [Function],
   "EggApplicationCore": [Function],
   "EggQualifier": [Function],
   "EggType": {
@@ -70,6 +71,7 @@ exports[`should expose properties 1`] = `
   "LifecyclePreDestroy": [Function],
   "LifecyclePreInject": [Function],
   "LifecyclePreLoad": [Function],
+  "Logger": [Function],
   "Master": [Function],
   "MessageUnhandledRejectionError": [Function],
   "MetadataUtil": [Function],

--- a/packages/egg/test/__snapshots__/index.test.ts.snap
+++ b/packages/egg/test/__snapshots__/index.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should expose properties 1`] = `
   "Boot": [Function],
   "ClusterAgentWorkerError": [Function],
   "ClusterWorkerExceptionError": [Function],
+  "Config": [Function],
   "Context": [Function],
   "ContextHttpClient": [Function],
   "ContextProto": [Function],

--- a/packages/egg/test/index.test.ts
+++ b/packages/egg/test/index.test.ts
@@ -1,10 +1,13 @@
+import assert from 'node:assert/strict';
+
 import { test, expect } from 'vitest';
 
 import * as egg from '../src/index.ts';
 
 test('should expose properties', () => {
   expect(egg).toMatchSnapshot();
-  expect(egg.Context).toBeDefined();
-  expect(egg.EggAppConfig).toBe(Object);
-  expect(egg.Logger).toBeDefined();
+  assert.ok(egg.Context);
+  assert.strictEqual(egg.Config, Object);
+  assert.strictEqual(egg.EggAppConfig, Object);
+  assert.ok(egg.Logger);
 });

--- a/packages/egg/test/index.test.ts
+++ b/packages/egg/test/index.test.ts
@@ -5,4 +5,6 @@ import * as egg from '../src/index.ts';
 test('should expose properties', () => {
   expect(egg).toMatchSnapshot();
   expect(egg.Context).toBeDefined();
+  expect(egg.EggAppConfig).toBe(Object);
+  expect(egg.Logger).toBeDefined();
 });

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -32,9 +32,10 @@ node worker.js
 
 The worker entry installs `ManifestStore.setBundleStore(...)` and
 `globalThis.__EGG_BUNDLE_MODULE_LOADER__` before calling
-`startEgg({ baseDir, mode: 'single' })`, so all framework file discovery and
-module resolution is served from the inlined bundle map — no `fs.readdir`
-scanning at runtime.
+`startEgg({ baseDir, mode: 'single' })`, so framework module resolution for
+bundled files is served from the inlined bundle map, avoiding `fs.readdir` for
+bundled framework file discovery. Application code and plugins may still use
+`fs` for resources such as config, views, or assets.
 
 ## `bundle-manifest.json`
 

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -31,9 +31,10 @@ node worker.js
 ```
 
 The worker entry installs `ManifestStore.setBundleStore(...)` and
-`setBundleModuleLoader(...)` before calling `startEgg({ baseDir, mode: 'single' })`,
-so all framework file discovery and module resolution is served from the
-inlined bundle map — no `fs.readdir` scanning at runtime.
+`globalThis.__EGG_BUNDLE_MODULE_LOADER__` before calling
+`startEgg({ baseDir, mode: 'single' })`, so all framework file discovery and
+module resolution is served from the inlined bundle map — no `fs.readdir`
+scanning at runtime.
 
 ## `bundle-manifest.json`
 

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -87,7 +87,6 @@
   },
   "dependencies": {
     "@eggjs/core": "workspace:*",
-    "@eggjs/utils": "workspace:*",
     "@utoo/pack": "catalog:",
     "execa": "catalog:",
     "tsx": "catalog:"

--- a/tools/egg-bundler/src/lib/EntryGenerator.ts
+++ b/tools/egg-bundler/src/lib/EntryGenerator.ts
@@ -194,7 +194,7 @@ export class EntryGenerator {
     }
 
     const manifestJson = JSON.stringify(manifest, null, 2);
-    const frameworkSpec = JSON.stringify(this.#framework);
+    const frameworkSpec = JSON.stringify(this.#toFrameworkImportSpecifier());
 
     const externalBlock =
       externalSpecs.length > 0
@@ -215,7 +215,6 @@ for (const [key, spec] of __EXTERNAL_SPECS) {
 import path from 'node:path';
 
 import { ManifestStore } from '@eggjs/core';
-import { setBundleModuleLoader } from '@eggjs/utils';
 import { startEgg } from ${frameworkSpec};
 
 ${importLines.join('\n')}
@@ -239,11 +238,14 @@ for (const [rel, mod] of Object.entries(__BUNDLE_MAP_REL)) {
   __BUNDLE_MAP[rel] = mod;
 }
 
+const __bundleGlobalThis = globalThis as typeof globalThis & {
+  __EGG_BUNDLE_MODULE_LOADER__?: (filepath: string) => unknown;
+};
 ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA as any, __baseDir));
-setBundleModuleLoader((filepath) => {
+__bundleGlobalThis.__EGG_BUNDLE_MODULE_LOADER__ = (filepath) => {
   const key = filepath.split(path.sep).join('/');
   return __BUNDLE_MAP[key];
-});
+};
 
 startEgg({ baseDir: __baseDir, mode: 'single' }).then((app) => {
   const port = process.env.PORT || app.config.cluster?.listen?.port || 7001;
@@ -257,6 +259,22 @@ startEgg({ baseDir: __baseDir, mode: 'single' }).then((app) => {
   process.exit(1);
 });
 `;
+  }
+
+  #toFrameworkImportSpecifier(): string {
+    if (!path.isAbsolute(this.#framework)) return this.#framework;
+    const packageName = this.#packageNameFromDir(this.#framework);
+    return packageName ?? this.#toImportSpecifier(this.#framework);
+  }
+
+  #packageNameFromDir(dir: string): string | undefined {
+    try {
+      const req = createRequire(path.join(dir, 'package.json'));
+      const pkg = req(path.join(dir, 'package.json')) as { name?: unknown };
+      return typeof pkg.name === 'string' && pkg.name ? pkg.name : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   #toImportSpecifier(absPath: string): string {

--- a/tools/egg-bundler/src/lib/EntryGenerator.ts
+++ b/tools/egg-bundler/src/lib/EntryGenerator.ts
@@ -264,7 +264,10 @@ startEgg({ baseDir: __baseDir, mode: 'single' }).then((app) => {
   #toFrameworkImportSpecifier(): string {
     if (!path.isAbsolute(this.#framework)) return this.#framework;
     const packageName = this.#packageNameFromDir(this.#framework);
-    return packageName ?? this.#toImportSpecifier(this.#framework);
+    if (packageName && this.#canUseFrameworkPackageName(packageName, this.#framework)) {
+      return packageName;
+    }
+    return this.#toImportSpecifier(this.#framework);
   }
 
   #packageNameFromDir(dir: string): string | undefined {
@@ -275,6 +278,27 @@ startEgg({ baseDir: __baseDir, mode: 'single' }).then((app) => {
     } catch {
       return undefined;
     }
+  }
+
+  #canUseFrameworkPackageName(packageName: string, dir: string): boolean {
+    if (this.#isInsideDir(path.join(this.#baseDir, 'node_modules'), dir)) return true;
+
+    try {
+      const req = createRequire(path.join(this.#baseDir, 'package.json'));
+      const resolvedPackageJson = req.resolve(`${packageName}/package.json`);
+      return this.#samePath(path.dirname(resolvedPackageJson), dir);
+    } catch {
+      return false;
+    }
+  }
+
+  #isInsideDir(parent: string, dir: string): boolean {
+    const rel = path.relative(path.resolve(parent), path.resolve(dir));
+    return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  }
+
+  #samePath(left: string, right: string): boolean {
+    return path.resolve(left) === path.resolve(right);
   }
 
   #toImportSpecifier(absPath: string): string {

--- a/tools/egg-bundler/src/lib/ExternalsResolver.ts
+++ b/tools/egg-bundler/src/lib/ExternalsResolver.ts
@@ -52,11 +52,11 @@ export class ExternalsResolver {
 
     for (const name of deps) {
       if (this.#inline.has(name) && !this.#force.has(name)) continue;
+      await this.#addMissingOptionalPeerExternals(name, result);
       if (result[name]) continue;
       if (await this.#shouldExternalize(name, optionalDeps, peerDeps)) {
         result[name] = name;
       }
-      await this.#addMissingOptionalPeerExternals(name, result);
     }
 
     for (const name of peerDeps) {

--- a/tools/egg-bundler/src/lib/ExternalsResolver.ts
+++ b/tools/egg-bundler/src/lib/ExternalsResolver.ts
@@ -15,6 +15,7 @@ interface PackageJson {
   readonly dependencies?: Record<string, string>;
   readonly optionalDependencies?: Record<string, string>;
   readonly peerDependencies?: Record<string, string>;
+  readonly peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   readonly scripts?: Record<string, string>;
   readonly exports?: unknown;
 }
@@ -55,6 +56,7 @@ export class ExternalsResolver {
       if (await this.#shouldExternalize(name, optionalDeps, peerDeps)) {
         result[name] = name;
       }
+      await this.#addMissingOptionalPeerExternals(name, result);
     }
 
     for (const name of peerDeps) {
@@ -63,6 +65,21 @@ export class ExternalsResolver {
     }
 
     return result;
+  }
+
+  async #addMissingOptionalPeerExternals(name: string, result: Record<string, string>): Promise<void> {
+    const pkgDir = await this.#findPackageDir(name);
+    if (!pkgDir) return;
+    const pkg = await this.#readPackageJson(pkgDir);
+    const peerDependencies = pkg.peerDependencies ?? {};
+    const peerDependenciesMeta = pkg.peerDependenciesMeta ?? {};
+    for (const peerName of Object.keys(peerDependencies)) {
+      if (result[peerName]) continue;
+      if (this.#inline.has(peerName) && !this.#force.has(peerName)) continue;
+      if (!peerDependenciesMeta[peerName]?.optional) continue;
+      if (await this.#findPackageDir(peerName)) continue;
+      result[peerName] = peerName;
+    }
   }
 
   async #shouldExternalize(
@@ -76,7 +93,18 @@ export class ExternalsResolver {
     const pkgDir = await this.#findPackageDir(name);
     if (!pkgDir) return false;
     const pkg = await this.#readPackageJson(pkgDir);
+    if (await this.#hasMissingOptionalPeerDependencies(pkg)) return true;
     if (await this.#hasNativeBinary(pkgDir, pkg)) return true;
+    return false;
+  }
+
+  async #hasMissingOptionalPeerDependencies(pkg: PackageJson): Promise<boolean> {
+    const peerDependencies = pkg.peerDependencies ?? {};
+    const peerDependenciesMeta = pkg.peerDependenciesMeta ?? {};
+    for (const peerName of Object.keys(peerDependencies)) {
+      if (!peerDependenciesMeta[peerName]?.optional) continue;
+      if (!(await this.#findPackageDir(peerName))) return true;
+    }
     return false;
   }
 

--- a/tools/egg-bundler/src/lib/ExternalsResolver.ts
+++ b/tools/egg-bundler/src/lib/ExternalsResolver.ts
@@ -77,7 +77,7 @@ export class ExternalsResolver {
       if (result[peerName]) continue;
       if (this.#inline.has(peerName) && !this.#force.has(peerName)) continue;
       if (!peerDependenciesMeta[peerName]?.optional) continue;
-      if (await this.#findPackageDir(peerName)) continue;
+      if (await this.#findPackageDir(peerName, pkgDir)) continue;
       result[peerName] = peerName;
     }
   }
@@ -93,31 +93,32 @@ export class ExternalsResolver {
     const pkgDir = await this.#findPackageDir(name);
     if (!pkgDir) return false;
     const pkg = await this.#readPackageJson(pkgDir);
-    if (await this.#hasMissingOptionalPeerDependencies(pkg)) return true;
+    if (await this.#hasMissingOptionalPeerDependencies(pkgDir, pkg)) return true;
     if (await this.#hasNativeBinary(pkgDir, pkg)) return true;
     return false;
   }
 
-  async #hasMissingOptionalPeerDependencies(pkg: PackageJson): Promise<boolean> {
+  async #hasMissingOptionalPeerDependencies(pkgDir: string, pkg: PackageJson): Promise<boolean> {
     const peerDependencies = pkg.peerDependencies ?? {};
     const peerDependenciesMeta = pkg.peerDependenciesMeta ?? {};
     for (const peerName of Object.keys(peerDependencies)) {
       if (!peerDependenciesMeta[peerName]?.optional) continue;
-      if (!(await this.#findPackageDir(peerName))) return true;
+      if (!(await this.#findPackageDir(peerName, pkgDir))) return true;
     }
     return false;
   }
 
-  async #findPackageDir(name: string): Promise<string | undefined> {
-    const cached = this.#packageDirCache.get(name);
+  async #findPackageDir(name: string, fromDir = this.#baseDir): Promise<string | undefined> {
+    const cacheKey = `${fromDir}\0${name}`;
+    const cached = this.#packageDirCache.get(cacheKey);
     if (cached) return cached;
-    const result = this.#findPackageDirUncached(name);
-    this.#packageDirCache.set(name, result);
+    const result = this.#findPackageDirUncached(name, fromDir);
+    this.#packageDirCache.set(cacheKey, result);
     return result;
   }
 
-  async #findPackageDirUncached(name: string): Promise<string | undefined> {
-    let dir = this.#baseDir;
+  async #findPackageDirUncached(name: string, fromDir: string): Promise<string | undefined> {
+    let dir = fromDir;
     while (true) {
       const candidate = path.join(dir, 'node_modules', name);
       try {

--- a/tools/egg-bundler/test/EntryGenerator.test.ts
+++ b/tools/egg-bundler/test/EntryGenerator.test.ts
@@ -171,10 +171,9 @@ describe('EntryGenerator', () => {
     const worker = await fs.readFile(result.workerEntry, 'utf8');
 
     expect(worker).toContain("import { ManifestStore } from '@eggjs/core'");
-    expect(worker).toContain("import { setBundleModuleLoader } from '@eggjs/utils'");
     expect(worker).toContain('import { startEgg } from "egg"');
     expect(worker).toContain('ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA');
-    expect(worker).toContain('setBundleModuleLoader(');
+    expect(worker).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(worker).toContain("startEgg({ baseDir: __baseDir, mode: 'single' })");
   });
 
@@ -244,7 +243,7 @@ describe('EntryGenerator', () => {
 
     expect(extractImports(worker).length).toBe(0);
     expect(worker).toContain("startEgg({ baseDir: __baseDir, mode: 'single' })");
-    expect(worker).toContain('setBundleModuleLoader(');
+    expect(worker).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(worker).toContain('ManifestStore.setBundleStore');
   });
 
@@ -282,6 +281,23 @@ describe('EntryGenerator', () => {
 
     expect(worker).toContain('import { startEgg } from "@my-org/framework"');
     expect(worker).not.toContain('import { startEgg } from "egg"');
+  });
+
+  it('uses the package name for an absolute framework directory with package metadata', async () => {
+    const frameworkDir = path.join(tmpDir, 'node_modules/custom-egg');
+    await fs.mkdir(frameworkDir, { recursive: true });
+    await fs.writeFile(path.join(frameworkDir, 'package.json'), JSON.stringify({ name: 'custom-egg' }));
+
+    const gen = new EntryGenerator({
+      baseDir: tmpDir,
+      framework: frameworkDir,
+      manifestLoader: createFakeLoader(makeManifest()),
+    });
+    const result = await gen.generate();
+    const worker = await fs.readFile(result.workerEntry, 'utf8');
+
+    expect(worker).toContain('import { startEgg } from "custom-egg"');
+    expect(worker).not.toContain(frameworkDir);
   });
 
   it('produces byte-identical worker output across independent baseDir runs (T17 determinism baseline)', async () => {

--- a/tools/egg-bundler/test/EntryGenerator.test.ts
+++ b/tools/egg-bundler/test/EntryGenerator.test.ts
@@ -300,6 +300,25 @@ describe('EntryGenerator', () => {
     expect(worker).not.toContain(frameworkDir);
   });
 
+  it('keeps an absolute framework checkout relative when the app cannot resolve its package name', async () => {
+    const frameworkDir = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-framework-'));
+    createdDirs.push(frameworkDir);
+    await fs.writeFile(path.join(frameworkDir, 'package.json'), JSON.stringify({ name: 'custom-egg' }));
+
+    const gen = new EntryGenerator({
+      baseDir: tmpDir,
+      framework: frameworkDir,
+      manifestLoader: createFakeLoader(makeManifest()),
+    });
+    const result = await gen.generate();
+    const worker = await fs.readFile(result.workerEntry, 'utf8');
+    const relFramework = path.relative(result.entryDir, frameworkDir).replaceAll(path.sep, '/');
+
+    expect(worker).toContain(`import { startEgg } from "${relFramework}"`);
+    expect(worker).not.toContain('import { startEgg } from "custom-egg"');
+    expect(worker).not.toContain(frameworkDir);
+  });
+
   it('produces byte-identical worker output across independent baseDir runs (T17 determinism baseline)', async () => {
     const manifest = makeManifest({
       extensions: {

--- a/tools/egg-bundler/test/ExternalsResolver.test.ts
+++ b/tools/egg-bundler/test/ExternalsResolver.test.ts
@@ -67,6 +67,14 @@ describe('ExternalsResolver', () => {
       const result = await new ExternalsResolver({ baseDir: basicApp }).resolve();
       expect(result['optional-only']).toBe('optional-only');
     });
+
+    it('externalizes missing optional peerDependencies declared by installed dependencies', async () => {
+      const result = await new ExternalsResolver({ baseDir: basicApp }).resolve();
+      expect(result['optional-peer-host']).toBe('optional-peer-host');
+      expect(result['missing-optional-peer']).toBe('missing-optional-peer');
+      expect(result['required-peer']).toBeUndefined();
+      expect(result['normal-js']).toBeUndefined();
+    });
   });
 
   describe('negative cases', () => {
@@ -152,6 +160,14 @@ describe('ExternalsResolver', () => {
         inline: ['optional-only'],
       }).resolve();
       expect(result['optional-only']).toBeUndefined();
+    });
+
+    it('inline removes a missing optional peerDependency from externals', async () => {
+      const result = await new ExternalsResolver({
+        baseDir: basicApp,
+        inline: ['missing-optional-peer'],
+      }).resolve();
+      expect(result['missing-optional-peer']).toBeUndefined();
     });
 
     it('force can still externalize framework and helper packages explicitly', async () => {

--- a/tools/egg-bundler/test/ExternalsResolver.test.ts
+++ b/tools/egg-bundler/test/ExternalsResolver.test.ts
@@ -75,6 +75,54 @@ describe('ExternalsResolver', () => {
       expect(result['required-peer']).toBeUndefined();
       expect(result['normal-js']).toBeUndefined();
     });
+
+    it('resolves optional peers from the dependent package directory', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-externals-'));
+      try {
+        await fs.mkdir(path.join(tempDir, 'node_modules/nested-peer-host/node_modules/present-optional-peer'), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          path.join(tempDir, 'package.json'),
+          JSON.stringify({
+            name: 'nested-peer-app',
+            version: '1.0.0',
+            private: true,
+            dependencies: {
+              'nested-peer-host': '1.0.0',
+            },
+          }),
+        );
+        await fs.writeFile(
+          path.join(tempDir, 'node_modules/nested-peer-host/package.json'),
+          JSON.stringify({
+            name: 'nested-peer-host',
+            version: '1.0.0',
+            peerDependencies: {
+              'present-optional-peer': '^1.0.0',
+            },
+            peerDependenciesMeta: {
+              'present-optional-peer': {
+                optional: true,
+              },
+            },
+          }),
+        );
+        await fs.writeFile(
+          path.join(tempDir, 'node_modules/nested-peer-host/node_modules/present-optional-peer/package.json'),
+          JSON.stringify({
+            name: 'present-optional-peer',
+            version: '1.0.0',
+          }),
+        );
+
+        const result = await new ExternalsResolver({ baseDir: tempDir }).resolve();
+        expect(result['nested-peer-host']).toBeUndefined();
+        expect(result['present-optional-peer']).toBeUndefined();
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('negative cases', () => {

--- a/tools/egg-bundler/test/ExternalsResolver.test.ts
+++ b/tools/egg-bundler/test/ExternalsResolver.test.ts
@@ -146,6 +146,15 @@ describe('ExternalsResolver', () => {
       expect(result['normal-js']).toBe('normal-js');
     });
 
+    it('adds missing optional peerDependencies for force-listed packages', async () => {
+      const result = await new ExternalsResolver({
+        baseDir: basicApp,
+        force: ['optional-peer-host'],
+      }).resolve();
+      expect(result['optional-peer-host']).toBe('optional-peer-host');
+      expect(result['missing-optional-peer']).toBe('missing-optional-peer');
+    });
+
     it('inline removes a peerDependency from externals', async () => {
       const result = await new ExternalsResolver({
         baseDir: basicApp,

--- a/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
+++ b/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
@@ -3,7 +3,6 @@
 import path from 'node:path';
 
 import { ManifestStore } from '@eggjs/core';
-import { setBundleModuleLoader } from '@eggjs/utils';
 import { startEgg } from "egg";
 
 import * as __m0 from "../../app/controller/home.ts";
@@ -67,11 +66,14 @@ for (const [rel, mod] of Object.entries(__BUNDLE_MAP_REL)) {
   __BUNDLE_MAP[rel] = mod;
 }
 
+const __bundleGlobalThis = globalThis as typeof globalThis & {
+  __EGG_BUNDLE_MODULE_LOADER__?: (filepath: string) => unknown;
+};
 ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA as any, __baseDir));
-setBundleModuleLoader((filepath) => {
+__bundleGlobalThis.__EGG_BUNDLE_MODULE_LOADER__ = (filepath) => {
   const key = filepath.split(path.sep).join('/');
   return __BUNDLE_MAP[key];
-});
+};
 
 startEgg({ baseDir: __baseDir, mode: 'single' }).then((app) => {
   const port = process.env.PORT || app.config.cluster?.listen?.port || 7001;

--- a/tools/egg-bundler/test/fixtures/externals/basic-app/node_modules/optional-peer-host/package.json
+++ b/tools/egg-bundler/test/fixtures/externals/basic-app/node_modules/optional-peer-host/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "optional-peer-host",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "missing-optional-peer": "1.0.0",
+    "normal-js": "1.0.0",
+    "required-peer": "1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "missing-optional-peer": {
+      "optional": true
+    },
+    "normal-js": {
+      "optional": true
+    }
+  }
+}

--- a/tools/egg-bundler/test/fixtures/externals/basic-app/package.json
+++ b/tools/egg-bundler/test/fixtures/externals/basic-app/package.json
@@ -14,7 +14,8 @@
     "native-dotnode": "1.0.0",
     "native-prebuilds": "1.0.0",
     "native-scripts": "1.0.0",
-    "normal-js": "1.0.0"
+    "normal-js": "1.0.0",
+    "optional-peer-host": "1.0.0"
   },
   "peerDependencies": {
     "peer-only": "1.0.0"

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -383,7 +383,7 @@ globalThis.__patchedMeta = {
     // Spot-check: the generated entry contains the runtime hook calls
     const entrySource = await fs.readFile(workerSource, 'utf8');
     expect(entrySource).toContain('ManifestStore.setBundleStore');
-    expect(entrySource).toContain('setBundleModuleLoader');
+    expect(entrySource).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(entrySource).toContain('startEgg');
   });
 });


### PR DESCRIPTION
## Summary

Fixes the current cnpmcore production bundle blockers seen on next after #5910:

- generate worker entries with a portable framework import instead of an absolute node_modules/egg path
- inline the bundle module loader registration so the generated worker does not depend on @eggjs/utils
- provide runtime exports for EggAppConfig and Logger so non-import type app code survives static export validation
- externalize packages that have missing optional peer dependencies, and add the missing optional peers as externals, covering leoric optional sql.js / mysql / sqlite3 paths

## Validation

- pnpm vitest run test/EntryGenerator.test.ts test/ExternalsResolver.test.ts in tools/egg-bundler
- pnpm vitest run packages/egg/test/index.test.ts
- pnpm --filter egg run typecheck
- pnpm --filter @eggjs/egg-bundler run typecheck
- full pnpm run build was run during verification after the implementation changes
- cnpmcore validation with local egg CLI/dist shim: node ../egg/tools/egg-bin/bin/run.js bundle --mode production --output dist-bundle generated dist-bundle successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundler now externalizes missing optional peer dependencies for more correct builds.

* **Bug Fixes**
  * Configuration and logger exports are exposed at runtime so apps start reliably.

* **Chores**
  * Removed an unused dependency.
  * Standardized the bundler’s runtime module-loader approach.

* **Documentation**
  * Updated bundling docs to reflect new module-loader and startup behavior.

* **Tests**
  * Added/updated tests covering externals resolution and generated runtime hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->