### PR TITLE
feat(bundler): support app-supplied pack aliases

### DIFF
--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -215,8 +215,8 @@ node worker.js
 - `--force-external` package name to always keep external, supports multiple
 - `--inline-external` package name to force inline, supports multiple
 - `--pack-alias` `@utoo/pack` resolve alias in `<specifier>=<target>` form,
-  supports multiple. Relative targets are resolved from the application base
-  directory
+  supports multiple. Dot-relative targets such as `./target.js` and
+  `../target.js` are resolved from the application base directory
 
 See [`@eggjs/egg-bundler`](../egg-bundler/README.md) for the programmatic API
 and output structure.

--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -193,6 +193,7 @@ egg-bin bundle
 egg-bin bundle --output ./dist-bundle
 egg-bin bundle --mode development
 egg-bin bundle --framework egg --output ./out
+egg-bin bundle --pack-alias some-package=./node_modules/some-package/index.js
 ```
 
 The command writes the bundle to `./dist-bundle` by default. The generated
@@ -213,6 +214,9 @@ node worker.js
   implementation yet
 - `--force-external` package name to always keep external, supports multiple
 - `--inline-external` package name to force inline, supports multiple
+- `--pack-alias` `@utoo/pack` resolve alias in `<specifier>=<target>` form,
+  supports multiple. Relative targets are resolved from the application base
+  directory
 
 See [`@eggjs/egg-bundler`](../egg-bundler/README.md) for the programmatic API
 and output structure.

--- a/tools/egg-bin/src/commands/bundle.ts
+++ b/tools/egg-bin/src/commands/bundle.ts
@@ -17,6 +17,24 @@ function getBundleMode(mode: string): BundleMode {
   throw new Error(`Unsupported bundle mode: ${mode}`);
 }
 
+function parsePackAliases(values: readonly string[], baseDir: string): Record<string, string> | undefined {
+  if (values.length === 0) return undefined;
+
+  const alias: Record<string, string> = {};
+  for (const value of values) {
+    const separator = value.indexOf('=');
+    if (separator <= 0 || separator === value.length - 1) {
+      throw new Error(`Invalid --pack-alias value: ${value}. Expected <specifier>=<target>.`);
+    }
+
+    const specifier = value.slice(0, separator);
+    const target = value.slice(separator + 1);
+    alias[specifier] = target.startsWith('.') ? path.resolve(baseDir, target) : target;
+  }
+
+  return alias;
+}
+
 export default class Bundle extends BaseCommand<typeof Bundle> {
   static override description = 'Bundle an egg app into a deployable artifact using @eggjs/egg-bundler';
 
@@ -25,6 +43,7 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
     '<%= config.bin %> <%= command.id %> --output ./dist-bundle',
     '<%= config.bin %> <%= command.id %> --mode development',
     '<%= config.bin %> <%= command.id %> --framework egg --output ./out',
+    '<%= config.bin %> <%= command.id %> --pack-alias some-package=./node_modules/some-package/index.js',
   ];
 
   static override flags = {
@@ -59,6 +78,11 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
       multiple: true,
       default: [],
     }),
+    'pack-alias': Flags.string({
+      description: '@utoo/pack resolve alias in <specifier>=<target> form, supports multiple',
+      multiple: true,
+      default: [],
+    }),
   };
 
   public async run(): Promise<void> {
@@ -81,6 +105,7 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
     );
 
     const { bundle } = await import('@eggjs/egg-bundler');
+    const packAlias = parsePackAliases(flags['pack-alias'], baseDir);
     const result = await bundle({
       baseDir,
       outputDir,
@@ -92,6 +117,7 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
         force: flags['force-external'],
         inline: flags['inline-external'],
       },
+      ...(packAlias ? { pack: { resolve: { alias: packAlias } } } : {}),
     });
 
     this.log(`bundled to ${result.outputDir} (${result.files.length} files)`);

--- a/tools/egg-bin/src/commands/bundle.ts
+++ b/tools/egg-bin/src/commands/bundle.ts
@@ -79,7 +79,7 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
       default: [],
     }),
     'pack-alias': Flags.string({
-      description: '@utoo/pack resolve alias in <specifier>=<target> form, supports multiple',
+      description: '@utoo/pack resolve alias in <specifier>=<target> form, dot-relative targets resolve from --base',
       multiple: true,
       default: [],
     }),

--- a/tools/egg-bin/test/commands/bundle.test.ts
+++ b/tools/egg-bin/test/commands/bundle.test.ts
@@ -75,4 +75,37 @@ describe('test/commands/bundle.test.ts', () => {
       },
     });
   });
+
+  it('should pass pack aliases to egg-bundler with relative targets resolved from baseDir', async () => {
+    await Bundle.run([
+      '--base',
+      baseDir,
+      '--pack-alias',
+      'some-package=./node_modules/some-package/index.js',
+      '--pack-alias',
+      'virtual-module=/abs/virtual-module.js',
+    ]);
+
+    expect(bundleMock).toHaveBeenCalledTimes(1);
+    expect(bundleMock).toHaveBeenCalledWith({
+      baseDir,
+      outputDir: path.join(baseDir, 'dist-bundle'),
+      manifestPath: undefined,
+      framework: getFrameworkPath({ baseDir }),
+      mode: 'production',
+      tegg: true,
+      externals: {
+        force: [],
+        inline: [],
+      },
+      pack: {
+        resolve: {
+          alias: {
+            'some-package': path.join(baseDir, 'node_modules/some-package/index.js'),
+            'virtual-module': '/abs/virtual-module.js',
+          },
+        },
+      },
+    });
+  });
 });

--- a/tools/egg-bin/test/commands/bundle.test.ts
+++ b/tools/egg-bin/test/commands/bundle.test.ts
@@ -76,7 +76,7 @@ describe('test/commands/bundle.test.ts', () => {
     });
   });
 
-  it('should pass pack aliases to egg-bundler with relative targets resolved from baseDir', async () => {
+  it('should pass pack aliases to egg-bundler with dot-relative targets resolved from baseDir', async () => {
     await Bundle.run([
       '--base',
       baseDir,

--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -15,6 +15,13 @@ await bundle({
   outputDir: './dist-bundle',
   framework: 'egg',
   mode: 'production',
+  pack: {
+    resolve: {
+      alias: {
+        'some-package': '/path/to/app/node_modules/some-package/index.js',
+      },
+    },
+  },
 });
 ```
 
@@ -23,18 +30,19 @@ path is `<baseDir>/.egg/manifest.json`.
 
 ## Options
 
-| Option             | Description                                                                     |
-| ------------------ | ------------------------------------------------------------------------------- |
-| `baseDir`          | Application root directory. Required.                                           |
-| `outputDir`        | Output directory for the bundled artifact. Required.                            |
-| `manifestPath`     | Path to `manifest.json`. Defaults to `<baseDir>/.egg/manifest.json`.            |
-| `framework`        | Framework name or absolute path. Defaults to `egg`.                             |
-| `mode`             | Build mode, `production` or `development`. Defaults to `production`.            |
-| `tegg`             | Accepted by `BundlerConfig`, but not applied by the current implementation yet. |
-| `externals.force`  | Package names to always keep external.                                          |
-| `externals.inline` | Package names to force inline even if auto-detected as external.                |
-| `pack.buildFunc`   | Test hook for replacing the real `@utoo/pack` build entry.                      |
-| `pack.rootPath`    | Override the monorepo workspace root used by `@utoo/pack`.                      |
+| Option               | Description                                                                     |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `baseDir`            | Application root directory. Required.                                           |
+| `outputDir`          | Output directory for the bundled artifact. Required.                            |
+| `manifestPath`       | Path to `manifest.json`. Defaults to `<baseDir>/.egg/manifest.json`.            |
+| `framework`          | Framework name or absolute path. Defaults to `egg`.                             |
+| `mode`               | Build mode, `production` or `development`. Defaults to `production`.            |
+| `tegg`               | Accepted by `BundlerConfig`, but not applied by the current implementation yet. |
+| `externals.force`    | Package names to always keep external.                                          |
+| `externals.inline`   | Package names to force inline even if auto-detected as external.                |
+| `pack.buildFunc`     | Test hook for replacing the real `@utoo/pack` build entry.                      |
+| `pack.rootPath`      | Override the monorepo workspace root used by `@utoo/pack`.                      |
+| `pack.resolve.alias` | Application-supplied `@utoo/pack` resolve aliases.                              |
 
 ## Result
 

--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -8,10 +8,11 @@ export {
   type PackEntry,
   type PackRunnerOptions,
   type PackRunnerResult,
+  type PackRunnerResolveConfig,
 } from './lib/PackRunner.ts';
 
 import { Bundler } from './lib/Bundler.ts';
-import type { BuildFunc } from './lib/PackRunner.ts';
+import type { BuildFunc, PackRunnerResolveConfig } from './lib/PackRunner.ts';
 
 export interface BundlerExternalsConfig {
   /** Package names to always mark as external, in addition to auto-detected ones. */
@@ -25,6 +26,8 @@ export interface BundlerPackConfig {
   readonly buildFunc?: BuildFunc;
   /** Override for the monorepo workspace root. Defaults to auto-detection. */
   readonly rootPath?: string;
+  /** @utoo/pack resolve tuning supplied by the application. */
+  readonly resolve?: PackRunnerResolveConfig;
 }
 
 export interface BundlerConfig {

--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -126,6 +126,7 @@ export class Bundler {
       rootPath: pack?.rootPath,
       mode,
       buildFunc: pack?.buildFunc,
+      resolve: pack?.resolve,
     });
     const packResult = await wrapStep('pack build', () => packRunner.run());
     debug('pack produced %d files', packResult.files.length);

--- a/tools/egg-bundler/src/lib/PackRunner.ts
+++ b/tools/egg-bundler/src/lib/PackRunner.ts
@@ -24,6 +24,10 @@ export interface PackRunnerResult {
   readonly files: readonly string[];
 }
 
+interface PackageJson {
+  readonly exports?: unknown;
+}
+
 // SWC decorator compilation picks up tsconfig from the OUTPUT dir, not the
 // project. Without this, tegg decorator metadata silently drops. (T0 blocker.)
 const OUTPUT_TSCONFIG = {
@@ -39,6 +43,15 @@ const OUTPUT_TSCONFIG = {
 const OUTPUT_PACKAGE_JSON = { type: 'commonjs' };
 
 const require = createRequire(import.meta.url);
+
+// @utoo/pack 1.4.1 resolves this package's browser/default export even for
+// node builds, which drops the named createSupportsColor export.
+const NODE_CONDITION_ALIAS_DEPS = [
+  {
+    issuerPackage: 'supports-hyperlinks',
+    dependency: 'supports-color',
+  },
+] as const;
 
 // Use CJS entry explicitly: under pnpm workspace links the ESM build's
 // extensionless relative imports fail to resolve.
@@ -80,6 +93,8 @@ export class PackRunner {
       umdExternals[k] = { commonjs: v, root: v };
     }
 
+    const nodeConditionAliases = await this.#resolveNodeConditionAliases(projectPath);
+
     const config = {
       entry: entries.map((e) => ({ name: e.name, import: e.filepath })),
       target: 'node 22',
@@ -90,6 +105,7 @@ export class PackRunner {
         type: 'standalone',
       },
       externals: umdExternals,
+      ...(Object.keys(nodeConditionAliases).length > 0 ? { resolve: { alias: nodeConditionAliases } } : {}),
       optimization: {
         treeShaking: false,
         minify: false,
@@ -106,6 +122,94 @@ export class PackRunner {
 
     const files = await this.#collectFiles(outputDir);
     return { outputDir, files };
+  }
+
+  async #resolveNodeConditionAliases(projectPath: string): Promise<Record<string, string>> {
+    const aliases: Record<string, string> = {};
+
+    for (const { issuerPackage, dependency } of NODE_CONDITION_ALIAS_DEPS) {
+      const issuerDir = await this.#findPackageDir(issuerPackage, projectPath);
+      if (!issuerDir) continue;
+
+      const dependencyDir = await this.#findPackageDir(dependency, issuerDir);
+      if (!dependencyDir) continue;
+
+      const pkg = await this.#readPackageJson(dependencyDir);
+      const nodeEntry = this.#resolveExportsNodeEntry(pkg.exports);
+      if (!nodeEntry) continue;
+
+      aliases[dependency] = this.#resolvePackageEntryPath(dependencyDir, nodeEntry);
+    }
+
+    return aliases;
+  }
+
+  async #findPackageDir(name: string, fromDir: string): Promise<string | undefined> {
+    const nameParts = name.split('/');
+    let dir = fromDir;
+    while (true) {
+      const candidate = path.join(dir, 'node_modules', ...nameParts);
+      try {
+        const stat = await fs.stat(candidate);
+        if (stat.isDirectory()) return candidate;
+      } catch {
+        // continue walking upward
+      }
+
+      const parent = path.dirname(dir);
+      if (parent === dir) return undefined;
+      dir = parent;
+    }
+  }
+
+  async #readPackageJson(packageDir: string): Promise<PackageJson> {
+    const packageJsonPath = path.join(packageDir, 'package.json');
+    try {
+      return JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as PackageJson;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+      throw new Error(`[@eggjs/egg-bundler] failed to read ${packageJsonPath}`, { cause: error });
+    }
+  }
+
+  #resolveExportsNodeEntry(exportsField: unknown): string | undefined {
+    if (typeof exportsField === 'string') return exportsField;
+    if (!exportsField || typeof exportsField !== 'object' || Array.isArray(exportsField)) return undefined;
+
+    const map = exportsField as Record<string, unknown>;
+    const keys = Object.keys(map);
+    const rootTarget = keys.length > 0 && !keys.some((key) => key.startsWith('.')) ? map : map['.'];
+    return this.#resolvePackageTarget(rootTarget);
+  }
+
+  #resolvePackageTarget(target: unknown): string | undefined {
+    if (typeof target === 'string') return target;
+    if (Array.isArray(target)) {
+      for (const item of target) {
+        const resolved = this.#resolvePackageTarget(item);
+        if (resolved) return resolved;
+      }
+      return undefined;
+    }
+    if (!target || typeof target !== 'object') return undefined;
+
+    const map = target as Record<string, unknown>;
+    if (!Object.hasOwn(map, 'node')) return undefined;
+    return this.#resolvePackageTarget(map.node);
+  }
+
+  #resolvePackageEntryPath(packageDir: string, entry: string): string {
+    if (path.isAbsolute(entry) || /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(entry)) {
+      throw new Error(`[@eggjs/egg-bundler] package export entry must be relative: ${entry}`);
+    }
+
+    const resolved = path.resolve(packageDir, entry);
+    const rel = path.relative(packageDir, resolved);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new Error(`[@eggjs/egg-bundler] package export entry escapes package root: ${entry}`);
+    }
+
+    return resolved;
   }
 
   async #collectFiles(dir: string): Promise<readonly string[]> {

--- a/tools/egg-bundler/src/lib/PackRunner.ts
+++ b/tools/egg-bundler/src/lib/PackRunner.ts
@@ -182,11 +182,11 @@ export class PackRunner {
     return this.#resolvePackageTarget(rootTarget);
   }
 
-  #resolvePackageTarget(target: unknown): string | undefined {
+  #resolvePackageTarget(target: unknown, inNodeCondition = false): string | undefined {
     if (typeof target === 'string') return target;
     if (Array.isArray(target)) {
       for (const item of target) {
-        const resolved = this.#resolvePackageTarget(item);
+        const resolved = this.#resolvePackageTarget(item, inNodeCondition);
         if (resolved) return resolved;
       }
       return undefined;
@@ -194,8 +194,16 @@ export class PackRunner {
     if (!target || typeof target !== 'object') return undefined;
 
     const map = target as Record<string, unknown>;
-    if (!Object.hasOwn(map, 'node')) return undefined;
-    return this.#resolvePackageTarget(map.node);
+    if (Object.hasOwn(map, 'node')) return this.#resolvePackageTarget(map.node, true);
+
+    if (inNodeCondition) {
+      for (const condition of ['import', 'default', 'require'] as const) {
+        const resolved = this.#resolvePackageTarget(map[condition], true);
+        if (resolved) return resolved;
+      }
+    }
+
+    return undefined;
   }
 
   #resolvePackageEntryPath(packageDir: string, entry: string): string {

--- a/tools/egg-bundler/src/lib/PackRunner.ts
+++ b/tools/egg-bundler/src/lib/PackRunner.ts
@@ -9,6 +9,10 @@ export interface PackEntry {
 
 export type BuildFunc = (config: { config: unknown }, projectPath: string, rootPath: string) => Promise<void>;
 
+export interface PackRunnerResolveConfig {
+  readonly alias?: Readonly<Record<string, string>>;
+}
+
 export interface PackRunnerOptions {
   readonly entries: readonly PackEntry[];
   readonly outputDir: string;
@@ -17,15 +21,12 @@ export interface PackRunnerOptions {
   readonly rootPath?: string;
   readonly mode?: 'production' | 'development';
   readonly buildFunc?: BuildFunc;
+  readonly resolve?: PackRunnerResolveConfig;
 }
 
 export interface PackRunnerResult {
   readonly outputDir: string;
   readonly files: readonly string[];
-}
-
-interface PackageJson {
-  readonly exports?: unknown;
 }
 
 // SWC decorator compilation picks up tsconfig from the OUTPUT dir, not the
@@ -43,15 +44,6 @@ const OUTPUT_TSCONFIG = {
 const OUTPUT_PACKAGE_JSON = { type: 'commonjs' };
 
 const require = createRequire(import.meta.url);
-
-// @utoo/pack 1.4.1 resolves this package's browser/default export even for
-// node builds, which drops the named createSupportsColor export.
-const NODE_CONDITION_ALIAS_DEPS = [
-  {
-    issuerPackage: 'supports-hyperlinks',
-    dependency: 'supports-color',
-  },
-] as const;
 
 // Use CJS entry explicitly: under pnpm workspace links the ESM build's
 // extensionless relative imports fail to resolve.
@@ -78,6 +70,7 @@ export class PackRunner {
       rootPath = projectPath,
       mode = 'production',
       buildFunc = DEFAULT_BUILD_FUNC,
+      resolve,
     } = this.#options;
 
     await fs.mkdir(outputDir, { recursive: true });
@@ -93,7 +86,7 @@ export class PackRunner {
       umdExternals[k] = { commonjs: v, root: v };
     }
 
-    const nodeConditionAliases = await this.#resolveNodeConditionAliases(projectPath);
+    const resolveConfig = this.#buildResolveConfig(resolve);
 
     const config = {
       entry: entries.map((e) => ({ name: e.name, import: e.filepath })),
@@ -105,7 +98,7 @@ export class PackRunner {
         type: 'standalone',
       },
       externals: umdExternals,
-      ...(Object.keys(nodeConditionAliases).length > 0 ? { resolve: { alias: nodeConditionAliases } } : {}),
+      ...(resolveConfig ? { resolve: resolveConfig } : {}),
       optimization: {
         treeShaking: false,
         minify: false,
@@ -124,100 +117,9 @@ export class PackRunner {
     return { outputDir, files };
   }
 
-  async #resolveNodeConditionAliases(projectPath: string): Promise<Record<string, string>> {
-    const aliases: Record<string, string> = {};
-
-    for (const { issuerPackage, dependency } of NODE_CONDITION_ALIAS_DEPS) {
-      const issuerDir = await this.#findPackageDir(issuerPackage, projectPath);
-      if (!issuerDir) continue;
-
-      const dependencyDir = await this.#findPackageDir(dependency, issuerDir);
-      if (!dependencyDir) continue;
-
-      const pkg = await this.#readPackageJson(dependencyDir);
-      const nodeEntry = this.#resolveExportsNodeEntry(pkg.exports);
-      if (!nodeEntry) continue;
-
-      aliases[dependency] = this.#resolvePackageEntryPath(dependencyDir, nodeEntry);
-    }
-
-    return aliases;
-  }
-
-  async #findPackageDir(name: string, fromDir: string): Promise<string | undefined> {
-    const nameParts = name.split('/');
-    let dir = fromDir;
-    while (true) {
-      const candidate = path.join(dir, 'node_modules', ...nameParts);
-      try {
-        const stat = await fs.stat(candidate);
-        if (stat.isDirectory()) return candidate;
-      } catch {
-        // continue walking upward
-      }
-
-      const parent = path.dirname(dir);
-      if (parent === dir) return undefined;
-      dir = parent;
-    }
-  }
-
-  async #readPackageJson(packageDir: string): Promise<PackageJson> {
-    const packageJsonPath = path.join(packageDir, 'package.json');
-    try {
-      return JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as PackageJson;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
-      throw new Error(`[@eggjs/egg-bundler] failed to read ${packageJsonPath}`, { cause: error });
-    }
-  }
-
-  #resolveExportsNodeEntry(exportsField: unknown): string | undefined {
-    if (typeof exportsField === 'string') return exportsField;
-    if (!exportsField || typeof exportsField !== 'object' || Array.isArray(exportsField)) return undefined;
-
-    const map = exportsField as Record<string, unknown>;
-    const keys = Object.keys(map);
-    const rootTarget = keys.length > 0 && !keys.some((key) => key.startsWith('.')) ? map : map['.'];
-    return this.#resolvePackageTarget(rootTarget);
-  }
-
-  #resolvePackageTarget(target: unknown, inNodeCondition = false): string | undefined {
-    if (typeof target === 'string') return target;
-    if (Array.isArray(target)) {
-      for (const item of target) {
-        const resolved = this.#resolvePackageTarget(item, inNodeCondition);
-        if (resolved) return resolved;
-      }
-      return undefined;
-    }
-    if (!target || typeof target !== 'object') return undefined;
-
-    const map = target as Record<string, unknown>;
-    if (Object.hasOwn(map, 'node')) return this.#resolvePackageTarget(map.node, true);
-
-    if (inNodeCondition) {
-      for (const condition of ['import', 'default', 'require'] as const) {
-        const resolved = this.#resolvePackageTarget(map[condition], true);
-        if (resolved) return resolved;
-      }
-    }
-
-    return undefined;
-  }
-
-  #resolvePackageEntryPath(packageDir: string, entry: string): string {
-    if (path.isAbsolute(entry) || /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(entry)) {
-      throw new Error(`[@eggjs/egg-bundler] package export entry must be relative: ${entry}`);
-    }
-
-    const resolved = path.resolve(packageDir, entry);
-    const rel = path.relative(packageDir, resolved);
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
-      throw new Error(`[@eggjs/egg-bundler] package export entry escapes package root: ${entry}`);
-    }
-
-    return resolved;
+  #buildResolveConfig(resolve: PackRunnerResolveConfig | undefined): PackRunnerResolveConfig | undefined {
+    if (!resolve?.alias || Object.keys(resolve.alias).length === 0) return undefined;
+    return { alias: { ...resolve.alias } };
   }
 
   async #collectFiles(dir: string): Promise<readonly string[]> {

--- a/tools/egg-bundler/test/Bundler.test.ts
+++ b/tools/egg-bundler/test/Bundler.test.ts
@@ -97,4 +97,25 @@ describe('Bundler', () => {
       autoGenerate: true,
     });
   });
+
+  it('passes application supplied pack resolve aliases into the pack build config', async () => {
+    let packResolve: unknown;
+    const alias = {
+      'some-package': path.join(tmpApp, 'node_modules/some-package/index.js'),
+    };
+
+    await bundle({
+      baseDir: tmpApp,
+      outputDir: tmpOutput,
+      pack: {
+        resolve: { alias },
+        buildFunc: async (wrapped) => {
+          packResolve = (wrapped.config as { resolve?: unknown }).resolve;
+          await fs.writeFile(path.join(tmpOutput, 'worker.js'), '// worker\n');
+        },
+      },
+    });
+
+    expect(packResolve).toEqual({ alias });
+  });
 });

--- a/tools/egg-bundler/test/PackRunner.test.ts
+++ b/tools/egg-bundler/test/PackRunner.test.ts
@@ -140,6 +140,41 @@ describe('PackRunner', () => {
     });
   });
 
+  it('finds hoisted supports-color and resolves nested node condition exports', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    const supportsHyperlinksDir = path.join(tmpDir, 'node_modules', 'supports-hyperlinks');
+    const supportsColorDir = path.join(tmpDir, 'node_modules', 'supports-color');
+    await fs.mkdir(supportsColorDir, { recursive: true });
+    await fs.mkdir(supportsHyperlinksDir, { recursive: true });
+    await fs.writeFile(
+      path.join(supportsHyperlinksDir, 'package.json'),
+      JSON.stringify({ name: 'supports-hyperlinks' }),
+    );
+    await fs.writeFile(
+      path.join(supportsColorDir, 'package.json'),
+      JSON.stringify({
+        name: 'supports-color',
+        exports: {
+          types: './index.d.ts',
+          node: {
+            import: './index.js',
+            default: './browser.js',
+          },
+          default: './browser.js',
+        },
+      }),
+    );
+
+    await makeRunner({ buildFunc }).run();
+
+    const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
+    expect(config.resolve).toEqual({
+      alias: {
+        'supports-color': path.join(supportsColorDir, 'index.js'),
+      },
+    });
+  });
+
   it('disables treeShaking and minify in the pack config (tegg runtime requires the full graph)', async () => {
     const buildFunc = vi.fn<BuildFunc>(async () => {});
     await makeRunner({ buildFunc }).run();

--- a/tools/egg-bundler/test/PackRunner.test.ts
+++ b/tools/egg-bundler/test/PackRunner.test.ts
@@ -104,8 +104,40 @@ describe('PackRunner', () => {
     expect(config.externals).toEqual({
       '@eggjs/core': { commonjs: '@eggjs/core', root: '@eggjs/core' },
     });
+    expect(config.resolve).toBeUndefined();
     expect(projectPath).toBe(tmpDir);
     expect(rootPath).toBe(tmpDir);
+  });
+
+  it('aliases supports-color to its node export when bundled through supports-hyperlinks', async () => {
+    const buildFunc = vi.fn<BuildFunc>(async () => {});
+    const supportsHyperlinksDir = path.join(tmpDir, 'node_modules', 'supports-hyperlinks');
+    const supportsColorDir = path.join(supportsHyperlinksDir, 'node_modules', 'supports-color');
+    await fs.mkdir(supportsColorDir, { recursive: true });
+    await fs.writeFile(
+      path.join(supportsHyperlinksDir, 'package.json'),
+      JSON.stringify({ name: 'supports-hyperlinks' }),
+    );
+    await fs.writeFile(
+      path.join(supportsColorDir, 'package.json'),
+      JSON.stringify({
+        name: 'supports-color',
+        exports: {
+          types: './index.d.ts',
+          node: './index.js',
+          default: './browser.js',
+        },
+      }),
+    );
+
+    await makeRunner({ buildFunc }).run();
+
+    const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
+    expect(config.resolve).toEqual({
+      alias: {
+        'supports-color': path.join(supportsColorDir, 'index.js'),
+      },
+    });
   });
 
   it('disables treeShaking and minify in the pack config (tegg runtime requires the full graph)', async () => {

--- a/tools/egg-bundler/test/PackRunner.test.ts
+++ b/tools/egg-bundler/test/PackRunner.test.ts
@@ -31,6 +31,9 @@ describe('PackRunner', () => {
       rootPath?: string;
       mode?: 'production' | 'development';
       buildFunc?: BuildFunc;
+      resolve?: {
+        alias?: Record<string, string>;
+      };
     } = {},
   ): PackRunner {
     const outputDir = overrides.outputDir ?? path.join(tmpDir, 'out');
@@ -42,6 +45,7 @@ describe('PackRunner', () => {
       projectPath,
       ...(overrides.rootPath !== undefined ? { rootPath: overrides.rootPath } : {}),
       ...(overrides.mode !== undefined ? { mode: overrides.mode } : {}),
+      ...(overrides.resolve !== undefined ? { resolve: overrides.resolve } : {}),
       buildFunc: overrides.buildFunc ?? (async () => {}),
     });
   }
@@ -109,70 +113,16 @@ describe('PackRunner', () => {
     expect(rootPath).toBe(tmpDir);
   });
 
-  it('aliases supports-color to its node export when bundled through supports-hyperlinks', async () => {
+  it('passes application supplied resolve aliases through to the pack config', async () => {
     const buildFunc = vi.fn<BuildFunc>(async () => {});
-    const supportsHyperlinksDir = path.join(tmpDir, 'node_modules', 'supports-hyperlinks');
-    const supportsColorDir = path.join(supportsHyperlinksDir, 'node_modules', 'supports-color');
-    await fs.mkdir(supportsColorDir, { recursive: true });
-    await fs.writeFile(
-      path.join(supportsHyperlinksDir, 'package.json'),
-      JSON.stringify({ name: 'supports-hyperlinks' }),
-    );
-    await fs.writeFile(
-      path.join(supportsColorDir, 'package.json'),
-      JSON.stringify({
-        name: 'supports-color',
-        exports: {
-          types: './index.d.ts',
-          node: './index.js',
-          default: './browser.js',
-        },
-      }),
-    );
+    const alias = {
+      'some-package': path.join(tmpDir, 'node_modules', 'some-package', 'index.js'),
+    };
 
-    await makeRunner({ buildFunc }).run();
+    await makeRunner({ buildFunc, resolve: { alias } }).run();
 
     const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
-    expect(config.resolve).toEqual({
-      alias: {
-        'supports-color': path.join(supportsColorDir, 'index.js'),
-      },
-    });
-  });
-
-  it('finds hoisted supports-color and resolves nested node condition exports', async () => {
-    const buildFunc = vi.fn<BuildFunc>(async () => {});
-    const supportsHyperlinksDir = path.join(tmpDir, 'node_modules', 'supports-hyperlinks');
-    const supportsColorDir = path.join(tmpDir, 'node_modules', 'supports-color');
-    await fs.mkdir(supportsColorDir, { recursive: true });
-    await fs.mkdir(supportsHyperlinksDir, { recursive: true });
-    await fs.writeFile(
-      path.join(supportsHyperlinksDir, 'package.json'),
-      JSON.stringify({ name: 'supports-hyperlinks' }),
-    );
-    await fs.writeFile(
-      path.join(supportsColorDir, 'package.json'),
-      JSON.stringify({
-        name: 'supports-color',
-        exports: {
-          types: './index.d.ts',
-          node: {
-            import: './index.js',
-            default: './browser.js',
-          },
-          default: './browser.js',
-        },
-      }),
-    );
-
-    await makeRunner({ buildFunc }).run();
-
-    const config = (buildFunc.mock.calls[0]![0] as { config: Record<string, unknown> }).config;
-    expect(config.resolve).toEqual({
-      alias: {
-        'supports-color': path.join(supportsColorDir, 'index.js'),
-      },
-    });
+    expect(config.resolve).toEqual({ alias });
   });
 
   it('disables treeShaking and minify in the pack config (tegg runtime requires the full graph)', async () => {


### PR DESCRIPTION
## Summary

- Replace the framework-specific supports-hyperlinks/supports-color workaround with generic app-supplied `pack.resolve.alias` support.
- Add repeatable `egg-bin bundle --pack-alias <specifier>=<target>` wiring so applications can provide dependency-specific pack aliases at the app layer.
- Resolve dot-relative alias targets from the application base directory, and document both CLI and programmatic configuration.
- Cover CLI -> Bundler -> PackRunner alias forwarding with tests.

## Verification

- `pnpm vitest run test/Bundler.test.ts test/PackRunner.test.ts` from `tools/egg-bundler`
- `pnpm vitest run test/commands/bundle.test.ts` from `tools/egg-bin`
- `pnpm --filter @eggjs/egg-bundler typecheck`
- `pnpm --filter @eggjs/bin typecheck`
- `pnpm --filter @eggjs/egg-bundler lint`
- `pnpm --filter @eggjs/egg-bundler test`

## Notes

- The dependency-specific alias now belongs to the application command/config layer instead of being hardcoded in the framework bundler.
- `--pack-alias` keeps package-style targets as-is; only dot-relative targets such as `./target.js` and `../target.js` are resolved from the application base directory.
