### PR TITLE
fix(bundler): avoid shadowed __dirname in import.meta patch

### DIFF
--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -230,7 +230,13 @@ export class Bundler {
   #renderImportMetaObject(declarationKind: string, metaName: string): string {
     return `${declarationKind} ${metaName} = (() => {
     const filename = ${IMPORT_META_FILENAME_EXPR};
-    const dirname = typeof __dirname === "string" ? __dirname : filename.replace(/[\\\\/][^\\\\/]*$/, "");
+    const dirname = (() => {
+        const slashIndex = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\\\"));
+        if (slashIndex > 2 || (slashIndex > 0 && !/^[A-Za-z]:[\\\\/]/.test(filename))) return filename.slice(0, slashIndex);
+        if (slashIndex === 2 && /^[A-Za-z]:[\\\\/]/.test(filename)) return filename.slice(0, 3);
+        if (slashIndex === 0) return filename[0];
+        return ".";
+    })();
     const url = (() => { const u = new URL("file:///"); u.pathname = filename.replace(/\\\\/g, "/"); return u.href; })();
     return {
     get url () {

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -335,6 +335,53 @@ globalThis.__patchedMeta = {
     expect(bm.chunks).not.toEqual(expect.arrayContaining([expect.stringContaining('.js.map')]));
   });
 
+  it('patches import.meta chunks without touching a shadowed __dirname binding', async () => {
+    const shadowedDirnameMeta = `const __TURBOPACK__import$2e$meta__ = { get url () { return "file:///already-patched.js"; } };
+globalThis.__patchedMeta = {
+    dirname: __TURBOPACK__import$2e$meta__.dirname
+};
+const __dirname = "/generated/shadow";
+`;
+
+    const buildFunc: BuildFunc = async () => {
+      await fs.writeFile(path.join(tmpOutput, 'worker.js'), '// mock worker entry\n');
+      await fs.writeFile(path.join(tmpOutput, 'shadowed-dirname.js'), shadowedDirnameMeta);
+    };
+
+    await bundle({
+      baseDir: tmpApp,
+      outputDir: tmpOutput,
+      pack: { buildFunc },
+    });
+
+    interface Sandbox {
+      URL: typeof URL;
+      process: { argv: string[]; cwd: () => string };
+      globalThis: Sandbox;
+      __dirname: string;
+      __filename: string;
+      __patchedMeta?: { dirname: string };
+    }
+
+    const content = await fs.readFile(path.join(tmpOutput, 'shadowed-dirname.js'), 'utf8');
+    function runWithFilename(filename: string): { dirname: string } {
+      const sandbox = {
+        URL,
+        process: { argv: ['node', 'worker.js'], cwd: () => tmpOutput },
+        __filename: filename,
+        __dirname: path.dirname(filename),
+      } as Sandbox;
+      sandbox.globalThis = sandbox;
+      runInNewContext(content, sandbox);
+      return sandbox.__patchedMeta!;
+    }
+
+    const filename = path.join(tmpOutput, 'shadowed-dirname.js');
+    expect(runWithFilename(filename)).toEqual({ dirname: path.dirname(filename) });
+    expect(runWithFilename('/worker.js')).toEqual({ dirname: '/' });
+    expect(runWithFilename('C:\\worker.js')).toEqual({ dirname: 'C:\\' });
+  });
+
   it('rejects Windows drive-absolute output paths before resolving bundle files', () => {
     expect(() => sanitizeBundleOutputRelativePath('C:/foo.js')).toThrow(/Unsafe bundle output path/);
     expect(() => sanitizeBundleOutputRelativePath('C:\\foo.js')).toThrow(/Unsafe bundle output path/);


### PR DESCRIPTION
## Summary

- Avoid reading `__dirname` inside the generated Turbopack `import.meta` replacement.
- Derive patched `import.meta.dirname` from the resolved filename instead, so later generated lexical `const __dirname` declarations cannot trigger TDZ.
- Add an integration regression covering a patched chunk that declares `const __dirname` after the `import.meta` object.

## Root Cause

The post-pack import.meta patch emitted `typeof __dirname === "string" ? __dirname : ...`.
In cnpmcore's generated root chunk, Turbopack also emits a later `const __dirname = ...` in the same module scope. That lexical declaration shadows CommonJS `__dirname` for the whole scope, so even `typeof __dirname` throws `ReferenceError: Cannot access __dirname before initialization` before the later declaration runs.

This is a general shadowed-lexical-binding issue in Egg's import.meta output patch, not cnpmcore-specific application code.

## Verification

- `pnpm vitest run test/integration.test.ts` from `tools/egg-bundler`
- `pnpm --filter @eggjs/egg-bundler typecheck`
- `pnpm --filter @eggjs/egg-bundler lint`
- `pnpm --filter @eggjs/egg-bundler test`
- cnpmcore `971784993927` local reproduction with `egg@4.1.2-beta.9` dependencies:
  - bundle via local built egg-bundler plus app-level `supports-color` alias completed and produced `dist-bundle-tdz-fix/worker.js`
  - `timeout 20s node dist-bundle-tdz-fix/worker.js` no longer hit the `__dirname` TDZ blocker
  - new first runtime blocker is `Cannot find native binding` for `@cnpmjs/packument-linux-x64-gnu` / `packument.linux-x64-gnu.node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bundled outputs so import metadata derives the directory from the computed filename, ensuring correct behavior when a module-local dirname is present.

* **Tests**
  * Updated and added integration tests to verify bundler behavior when dirname is shadowed and when patching import metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->