### PR TITLE
fix(core): include plugin dynamic files in manifest

### DIFF
--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -23,7 +23,7 @@ import utils, { type Fun } from '../utils/index.ts';
 import { sequencify } from '../utils/sequencify.ts';
 import { Timing } from '../utils/timing.ts';
 import { type ContextLoaderOptions, ContextLoader } from './context_loader.ts';
-import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';
+import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader, getDefaultFileLoaderMatch } from './file_loader.ts';
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
@@ -1807,7 +1807,7 @@ export class EggLoader {
     const files = this.#collectConventionFileDiscovery(manifest, directory);
     for (const file of files) {
       const ext = path.extname(file);
-      if (!ext || ext === '.map') continue;
+      if (!ext) continue;
       const request = path.join(directory, file.slice(0, -ext.length));
       this.#collectConventionResolve(manifest, request);
     }
@@ -1817,10 +1817,9 @@ export class EggLoader {
     const dirKey = this.#toManifestRel(directory);
     if (Object.hasOwn(manifest.fileDiscovery, dirKey)) return manifest.fileDiscovery[dirKey];
 
-    const files = isSupportTypeScript() ? ['**/*.{js,ts}', '!**/*.d.ts'] : ['**/*.js'];
     manifest.fileDiscovery[dirKey] =
       fs.existsSync(directory) && fs.statSync(directory).isDirectory()
-        ? globby.sync(files, { cwd: directory }).sort()
+        ? globby.sync(getDefaultFileLoaderMatch(), { cwd: directory }).sort()
         : [];
     return manifest.fileDiscovery[dirKey];
   }

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -8,6 +8,7 @@ import { Request, Response, Application, Context as KoaContext } from '@eggjs/ko
 import { pathMatching, type PathMatchingOptions } from '@eggjs/path-matching';
 import { isESM, isSupportTypeScript } from '@eggjs/utils';
 import type { Logger } from 'egg-logger';
+import globby from 'globby';
 import { isAsyncFunction, isClass, isGeneratorFunction, isObject, isPromise } from 'is-type-of';
 import { homedir } from 'node-homedir';
 import { now, diff } from 'performance-ms';
@@ -26,6 +27,7 @@ import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
+const CONVENTIONAL_EXTEND_NAMES = ['agent', 'application', 'request', 'response', 'context', 'helper'] as const;
 
 const originalPrototypes: Record<string, unknown> = {
   request: Request.prototype,
@@ -1764,11 +1766,56 @@ export class EggLoader {
    * Should be called after all loading phases complete.
    */
   generateManifest(): StartupManifest {
-    return this.manifest.generateManifest({
+    const manifest = this.manifest.generateManifest({
       serverEnv: this.serverEnv,
       serverScope: this.serverScope,
       typescriptEnabled: isSupportTypeScript(),
     });
+    this.#collectConventionalDynamicFiles(manifest);
+    return manifest;
+  }
+
+  /**
+   * metadataOnly startup intentionally skips the agent process, but bundled
+   * single-mode workers still load agent boot hooks and agent extends later.
+   * Record convention-based dynamic entry points so the bundle can satisfy
+   * those runtime lookups without running agent lifecycle hooks at manifest
+   * generation time.
+   */
+  #collectConventionalDynamicFiles(manifest: StartupManifest): void {
+    for (const unit of this.getLoadUnits()) {
+      this.#collectConventionResolve(manifest, unit.path, 'agent');
+      this.#collectConventionResolve(manifest, unit.path, 'app');
+      for (const name of CONVENTIONAL_EXTEND_NAMES) {
+        this.#collectConventionResolve(manifest, unit.path, 'app', 'extend', name);
+      }
+      this.#collectConventionFileDiscovery(manifest, path.join(unit.path, 'app/middleware'));
+    }
+  }
+
+  #collectConventionResolve(manifest: StartupManifest, root: string, ...segments: string[]): void {
+    const request = path.join(root, ...segments);
+    const requestKey = this.#toManifestRel(request);
+    if (Object.hasOwn(manifest.resolveCache, requestKey)) return;
+
+    const resolved = this.#doResolveModule(request);
+    manifest.resolveCache[requestKey] = resolved ? this.#toManifestRel(resolved) : null;
+  }
+
+  #collectConventionFileDiscovery(manifest: StartupManifest, directory: string): void {
+    const dirKey = this.#toManifestRel(directory);
+    if (Object.hasOwn(manifest.fileDiscovery, dirKey)) return;
+
+    const files = isSupportTypeScript() ? ['**/*.{js,ts}', '!**/*.d.ts'] : ['**/*.js'];
+    manifest.fileDiscovery[dirKey] =
+      fs.existsSync(directory) && fs.statSync(directory).isDirectory()
+        ? globby.sync(files, { cwd: directory }).sort()
+        : [];
+  }
+
+  #toManifestRel(filepath: string): string {
+    const rel = path.isAbsolute(filepath) ? path.relative(this.options.baseDir, filepath) : filepath;
+    return rel.replaceAll(path.sep, '/');
   }
 }
 

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -23,7 +23,7 @@ import utils, { type Fun } from '../utils/index.ts';
 import { sequencify } from '../utils/sequencify.ts';
 import { Timing } from '../utils/timing.ts';
 import { type ContextLoaderOptions, ContextLoader } from './context_loader.ts';
-import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader, getDefaultFileLoaderMatch } from './file_loader.ts';
+import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
@@ -1819,7 +1819,7 @@ export class EggLoader {
 
     manifest.fileDiscovery[dirKey] =
       fs.existsSync(directory) && fs.statSync(directory).isDirectory()
-        ? globby.sync(getDefaultFileLoaderMatch(), { cwd: directory }).sort()
+        ? globby.sync(FileLoader.getDefaultMatch(), { cwd: directory }).sort()
         : [];
     return manifest.fileDiscovery[dirKey];
   }

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -1789,6 +1789,7 @@ export class EggLoader {
       for (const name of CONVENTIONAL_EXTEND_NAMES) {
         this.#collectConventionResolve(manifest, unit.path, 'app', 'extend', name);
       }
+      this.#collectConventionExtends(manifest, path.join(unit.path, 'app/extend'));
       this.#collectConventionFileDiscovery(manifest, path.join(unit.path, 'app/middleware'));
     }
   }
@@ -1802,15 +1803,26 @@ export class EggLoader {
     manifest.resolveCache[requestKey] = resolved ? this.#toManifestRel(resolved) : null;
   }
 
-  #collectConventionFileDiscovery(manifest: StartupManifest, directory: string): void {
+  #collectConventionExtends(manifest: StartupManifest, directory: string): void {
+    const files = this.#collectConventionFileDiscovery(manifest, directory);
+    for (const file of files) {
+      const ext = path.extname(file);
+      if (!ext || ext === '.map') continue;
+      const request = path.join(directory, file.slice(0, -ext.length));
+      this.#collectConventionResolve(manifest, request);
+    }
+  }
+
+  #collectConventionFileDiscovery(manifest: StartupManifest, directory: string): string[] {
     const dirKey = this.#toManifestRel(directory);
-    if (Object.hasOwn(manifest.fileDiscovery, dirKey)) return;
+    if (Object.hasOwn(manifest.fileDiscovery, dirKey)) return manifest.fileDiscovery[dirKey];
 
     const files = isSupportTypeScript() ? ['**/*.{js,ts}', '!**/*.d.ts'] : ['**/*.js'];
     manifest.fileDiscovery[dirKey] =
       fs.existsSync(directory) && fs.statSync(directory).isDirectory()
         ? globby.sync(files, { cwd: directory }).sort()
         : [];
+    return manifest.fileDiscovery[dirKey];
   }
 
   #toManifestRel(filepath: string): string {

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -27,7 +27,12 @@ import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
-const CONVENTIONAL_EXTEND_NAMES = ['agent', 'application', 'request', 'response', 'context', 'helper'] as const;
+const CONVENTIONAL_MANIFEST_LOADS = [
+  { type: 'resolve', path: ['agent'] },
+  { type: 'resolve', path: ['app'] },
+  { type: 'discover', path: ['app', 'extend'], extensionlessResolve: true },
+  { type: 'discover', path: ['app', 'middleware'] },
+] as const;
 
 const originalPrototypes: Record<string, unknown> = {
   request: Request.prototype,
@@ -1784,18 +1789,20 @@ export class EggLoader {
    */
   #collectConventionalDynamicFiles(manifest: StartupManifest): void {
     for (const unit of this.getLoadUnits()) {
-      this.#collectConventionResolve(manifest, unit.path, 'agent');
-      this.#collectConventionResolve(manifest, unit.path, 'app');
-      for (const name of CONVENTIONAL_EXTEND_NAMES) {
-        this.#collectConventionResolve(manifest, unit.path, 'app', 'extend', name);
+      for (const load of CONVENTIONAL_MANIFEST_LOADS) {
+        const target = path.join(unit.path, ...load.path);
+        if (load.type === 'resolve') {
+          this.#collectConventionResolve(manifest, target);
+        } else if ('extensionlessResolve' in load && load.extensionlessResolve) {
+          this.#collectConventionFileResolves(manifest, target);
+        } else {
+          this.#collectConventionFileDiscovery(manifest, target);
+        }
       }
-      this.#collectConventionExtends(manifest, path.join(unit.path, 'app/extend'));
-      this.#collectConventionFileDiscovery(manifest, path.join(unit.path, 'app/middleware'));
     }
   }
 
-  #collectConventionResolve(manifest: StartupManifest, root: string, ...segments: string[]): void {
-    const request = path.join(root, ...segments);
+  #collectConventionResolve(manifest: StartupManifest, request: string): void {
     const requestKey = this.#toManifestRel(request);
     if (Object.hasOwn(manifest.resolveCache, requestKey)) return;
 
@@ -1803,7 +1810,7 @@ export class EggLoader {
     manifest.resolveCache[requestKey] = resolved ? this.#toManifestRel(resolved) : null;
   }
 
-  #collectConventionExtends(manifest: StartupManifest, directory: string): void {
+  #collectConventionFileResolves(manifest: StartupManifest, directory: string): void {
     const files = this.#collectConventionFileDiscovery(manifest, directory);
     for (const file of files) {
       const ext = path.extname(file);

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -60,7 +60,7 @@ export interface FileLoaderParseItem {
   exports: object | Fun;
 }
 
-export function getDefaultFileLoaderMatch(): string[] {
+function getDefaultFileLoaderMatch(): string[] {
   return isSupportTypeScript() ? ['**/*.(js|ts)', '!**/*.d.ts'] : ['**/*.js'];
 }
 
@@ -75,6 +75,10 @@ export class FileLoader {
 
   static get EXPORTS(): typeof EXPORTS {
     return EXPORTS;
+  }
+
+  static getDefaultMatch(): string[] {
+    return getDefaultFileLoaderMatch();
   }
 
   readonly options: FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle'>>;
@@ -185,7 +189,7 @@ export class FileLoader {
     if (files) {
       files = Array.isArray(files) ? files : [files];
     } else {
-      files = getDefaultFileLoaderMatch();
+      files = FileLoader.getDefaultMatch();
     }
 
     let ignore = this.options.ignore;

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -60,6 +60,10 @@ export interface FileLoaderParseItem {
   exports: object | Fun;
 }
 
+export function getDefaultFileLoaderMatch(): string[] {
+  return isSupportTypeScript() ? ['**/*.(js|ts)', '!**/*.d.ts'] : ['**/*.js'];
+}
+
 /**
  * Load files from directory to target object.
  * @since 1.0.0
@@ -181,7 +185,7 @@ export class FileLoader {
     if (files) {
       files = Array.isArray(files) ? files : [files];
     } else {
-      files = isSupportTypeScript() ? ['**/*.(js|ts)', '!**/*.d.ts'] : ['**/*.js'];
+      files = getDefaultFileLoaderMatch();
     }
 
     let ignore = this.options.ignore;

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -211,6 +211,12 @@ export class ManifestStore {
       return cached !== null ? this.#toAbsolute(cached) : undefined;
     }
 
+    const discovered = this.#resolveFromFileDiscovery(relKey);
+    if (discovered !== null) {
+      debug('[resolveModule:fileDiscovery] %o => %o', filepath, discovered);
+      return discovered;
+    }
+
     const result = fallback();
     this.#resolveCacheCollector[relKey] = result !== undefined ? this.#toRelative(result) : null;
     return result;
@@ -341,6 +347,30 @@ export class ManifestStore {
       return relPath;
     }
     return path.join(this.baseDir, relPath);
+  }
+
+  #resolveFromFileDiscovery(relKey: string): string | undefined | null {
+    let matchedDir: string | undefined;
+    for (const dir of Object.keys(this.data.fileDiscovery)) {
+      if ((relKey === dir || relKey.startsWith(dir + '/')) && (!matchedDir || dir.length > matchedDir.length)) {
+        matchedDir = dir;
+      }
+    }
+    if (!matchedDir || relKey === matchedDir) return null;
+
+    const request = relKey.slice(matchedDir.length + 1);
+    const files = this.data.fileDiscovery[matchedDir];
+    const matchedFile = files.find((file) => {
+      if (file === request) return true;
+
+      const ext = path.posix.extname(file);
+      if (!ext || ext === '.map') return false;
+
+      const extensionlessFile = file.slice(0, -ext.length);
+      return extensionlessFile === request || extensionlessFile === `${request}/index`;
+    });
+
+    return matchedFile ? this.#toAbsolute(path.posix.join(matchedDir, matchedFile)) : undefined;
   }
 
   // --- Fingerprint Utilities ---

--- a/packages/core/src/loader/manifest.ts
+++ b/packages/core/src/loader/manifest.ts
@@ -212,7 +212,7 @@ export class ManifestStore {
     }
 
     const discovered = this.#resolveFromFileDiscovery(relKey);
-    if (discovered !== null) {
+    if (discovered) {
       debug('[resolveModule:fileDiscovery] %o => %o', filepath, discovered);
       return discovered;
     }
@@ -349,14 +349,14 @@ export class ManifestStore {
     return path.join(this.baseDir, relPath);
   }
 
-  #resolveFromFileDiscovery(relKey: string): string | undefined | null {
+  #resolveFromFileDiscovery(relKey: string): string | undefined {
     let matchedDir: string | undefined;
     for (const dir of Object.keys(this.data.fileDiscovery)) {
       if ((relKey === dir || relKey.startsWith(dir + '/')) && (!matchedDir || dir.length > matchedDir.length)) {
         matchedDir = dir;
       }
     }
-    if (!matchedDir || relKey === matchedDir) return null;
+    if (!matchedDir || relKey === matchedDir) return;
 
     const request = relKey.slice(matchedDir.length + 1);
     const files = this.data.fileDiscovery[matchedDir];

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/config/plugin.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/config/plugin.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  security: {
+    enable: true,
+    package: '@eggjs/security',
+  },
+};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/agent.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/agent.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = class AgentBoot {};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = class AppBoot {};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/extend/agent.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/extend/agent.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  securityAgentExtend: true,
+};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/extend/application.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/extend/application.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  securityApplicationExtend: true,
+};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/extend/filter.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/extend/filter.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  passthrough(value) {
+    return value;
+  },
+};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/middleware/securities.js
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/app/middleware/securities.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = function securities() {
+  return async function securityMiddleware(_ctx, next) {
+    await next();
+  };
+};

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/package.json
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/node_modules/@eggjs/security/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@eggjs/security",
+  "eggPlugin": {
+    "name": "security"
+  }
+}

--- a/packages/core/test/fixtures/manifest-dynamic-plugin/package.json
+++ b/packages/core/test/fixtures/manifest-dynamic-plugin/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "manifest-dynamic-plugin"
+}

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -610,12 +610,12 @@ describe('ManifestStore', () => {
           throw new Error('should not fallback when nested fileDiscovery can resolve');
         });
         const missing = store.resolveModule(path.join(baseDir, 'app/extend/missing'), () => {
-          throw new Error('should not fallback when fileDiscovery has scanned the directory');
+          return path.join(baseDir, 'app/extend/missing.mjs');
         });
 
         assert.equal(filter, path.join(baseDir, 'app/extend/filter.js'));
         assert.equal(nested, path.join(baseDir, 'app/extend/nested/helper.ts'));
-        assert.equal(missing, undefined);
+        assert.equal(missing, path.join(baseDir, 'app/extend/missing.mjs'));
       } finally {
         fs.rmSync(baseDir, { recursive: true, force: true });
       }

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -590,6 +590,37 @@ describe('ManifestStore', () => {
       }
     });
 
+    it('should resolve extensionless modules from cached fileDiscovery', async () => {
+      const baseDir = setupBaseDir();
+      try {
+        const collector = ManifestStore.createCollector(baseDir);
+        collector.globFiles(path.join(baseDir, 'app/extend'), () => ['filter.js', 'nested/helper.ts']);
+        const manifest = collector.generateManifest({
+          serverEnv: 'prod',
+          serverScope: '',
+          typescriptEnabled: true,
+        });
+        await ManifestStore.write(baseDir, manifest);
+
+        const store = ManifestStore.load(baseDir, 'prod', '')!;
+        const filter = store.resolveModule(path.join(baseDir, 'app/extend/filter'), () => {
+          throw new Error('should not fallback when fileDiscovery can resolve');
+        });
+        const nested = store.resolveModule(path.join(baseDir, 'app/extend/nested/helper'), () => {
+          throw new Error('should not fallback when nested fileDiscovery can resolve');
+        });
+        const missing = store.resolveModule(path.join(baseDir, 'app/extend/missing'), () => {
+          throw new Error('should not fallback when fileDiscovery has scanned the directory');
+        });
+
+        assert.equal(filter, path.join(baseDir, 'app/extend/filter.js'));
+        assert.equal(nested, path.join(baseDir, 'app/extend/nested/helper.ts'));
+        assert.equal(missing, undefined);
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
     it('should call fallback on cache miss and collect result', () => {
       const baseDir = setupBaseDir();
       try {

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -163,6 +163,14 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
         manifest.resolveCache['node_modules/@eggjs/security/app/extend/application'],
         'node_modules/@eggjs/security/app/extend/application.js',
       );
+      assert.equal(
+        manifest.resolveCache['node_modules/@eggjs/security/app/extend/filter'],
+        'node_modules/@eggjs/security/app/extend/filter.js',
+      );
+      assert.ok(
+        manifest.fileDiscovery['node_modules/@eggjs/security/app/extend']?.includes('filter.js'),
+        'custom app/extend file should be included in manifest fileDiscovery',
+      );
       assert.ok(
         manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware']?.includes('securities.js'),
         'security middleware should be included in manifest fileDiscovery',

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -103,65 +103,72 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
 
   it('should collect configured customLoader directories in metadataOnly startup', async () => {
     const testApp = createApp('custom-loader', { metadataOnly: true });
-    await testApp.loader.loadPlugin();
-    await testApp.loader.loadConfig();
-    await testApp.loader.loadCustomLoader();
+    try {
+      await testApp.loader.loadPlugin();
+      await testApp.loader.loadConfig();
+      await testApp.loader.loadCustomLoader();
 
-    const manifest = testApp.loader.generateManifest();
+      const manifest = testApp.loader.generateManifest();
 
-    assert.ok(
-      manifest.fileDiscovery['app/adapter']?.includes('docker.js'),
-      'app customLoader directory should be included in manifest fileDiscovery',
-    );
-    assert.ok(
-      manifest.fileDiscovery['app/util']?.includes('sub/fn.js'),
-      'nested app customLoader directory should be included in manifest fileDiscovery',
-    );
-    assert.ok(
-      manifest.fileDiscovery['app/repository']?.includes('user.js'),
-      'ctx customLoader directory should be included in manifest fileDiscovery',
-    );
-    assert.ok(
-      manifest.fileDiscovery['app/plugin']?.includes('a.js'),
-      'app loadunit customLoader directory should be included in manifest fileDiscovery',
-    );
-    assert.ok(
-      manifest.fileDiscovery['config/b/app/plugin']?.includes('b.js'),
-      'plugin loadunit customLoader directory should be included in manifest fileDiscovery',
-    );
-
-    await testApp.close();
+      assert.ok(
+        manifest.fileDiscovery['app/adapter']?.includes('docker.js'),
+        'app customLoader directory should be included in manifest fileDiscovery',
+      );
+      assert.ok(
+        manifest.fileDiscovery['app/util']?.includes('sub/fn.js'),
+        'nested app customLoader directory should be included in manifest fileDiscovery',
+      );
+      assert.ok(
+        manifest.fileDiscovery['app/repository']?.includes('user.js'),
+        'ctx customLoader directory should be included in manifest fileDiscovery',
+      );
+      assert.ok(
+        manifest.fileDiscovery['app/plugin']?.includes('a.js'),
+        'app loadunit customLoader directory should be included in manifest fileDiscovery',
+      );
+      assert.ok(
+        manifest.fileDiscovery['config/b/app/plugin']?.includes('b.js'),
+        'plugin loadunit customLoader directory should be included in manifest fileDiscovery',
+      );
+    } finally {
+      await testApp.close();
+    }
   });
 
   it('should include plugin convention files that metadataOnly app loading does not execute', async () => {
     const testApp = createApp('manifest-dynamic-plugin', { metadataOnly: true });
-    await testApp.loader.loadPlugin();
-    await testApp.loader.loadConfig();
-    await testApp.loader.loadApplicationExtend();
-    await testApp.loader.loadContextExtend();
-    await testApp.loader.loadRequestExtend();
-    await testApp.loader.loadResponseExtend();
-    await testApp.loader.loadHelperExtend();
-    await testApp.loader.loadCustomApp();
-    await testApp.loader.loadMiddleware();
+    try {
+      await testApp.loader.loadPlugin();
+      await testApp.loader.loadConfig();
+      await testApp.loader.loadApplicationExtend();
+      await testApp.loader.loadContextExtend();
+      await testApp.loader.loadRequestExtend();
+      await testApp.loader.loadResponseExtend();
+      await testApp.loader.loadHelperExtend();
+      await testApp.loader.loadCustomApp();
+      await testApp.loader.loadMiddleware();
 
-    const manifest = testApp.loader.generateManifest();
+      const manifest = testApp.loader.generateManifest();
 
-    assert.equal(manifest.resolveCache['node_modules/@eggjs/security/agent'], 'node_modules/@eggjs/security/agent.js');
-    assert.equal(manifest.resolveCache['node_modules/@eggjs/security/app'], 'node_modules/@eggjs/security/app.js');
-    assert.equal(
-      manifest.resolveCache['node_modules/@eggjs/security/app/extend/agent'],
-      'node_modules/@eggjs/security/app/extend/agent.js',
-    );
-    assert.equal(
-      manifest.resolveCache['node_modules/@eggjs/security/app/extend/application'],
-      'node_modules/@eggjs/security/app/extend/application.js',
-    );
-    assert.ok(
-      manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware']?.includes('securities.js'),
-      'security middleware should be included in manifest fileDiscovery',
-    );
-
-    await testApp.close();
+      assert.equal(
+        manifest.resolveCache['node_modules/@eggjs/security/agent'],
+        'node_modules/@eggjs/security/agent.js',
+      );
+      assert.equal(manifest.resolveCache['node_modules/@eggjs/security/app'], 'node_modules/@eggjs/security/app.js');
+      assert.equal(
+        manifest.resolveCache['node_modules/@eggjs/security/app/extend/agent'],
+        'node_modules/@eggjs/security/app/extend/agent.js',
+      );
+      assert.equal(
+        manifest.resolveCache['node_modules/@eggjs/security/app/extend/application'],
+        'node_modules/@eggjs/security/app/extend/application.js',
+      );
+      assert.ok(
+        manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware']?.includes('securities.js'),
+        'security middleware should be included in manifest fileDiscovery',
+      );
+    } finally {
+      await testApp.close();
+    }
   });
 });

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -101,6 +101,38 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
     await testApp.close();
   });
 
+  it('should collect configured customLoader directories in metadataOnly startup', async () => {
+    const testApp = createApp('custom-loader', { metadataOnly: true });
+    await testApp.loader.loadPlugin();
+    await testApp.loader.loadConfig();
+    await testApp.loader.loadCustomLoader();
+
+    const manifest = testApp.loader.generateManifest();
+
+    assert.ok(
+      manifest.fileDiscovery['app/adapter'].includes('docker.js'),
+      'app customLoader directory should be included in manifest fileDiscovery',
+    );
+    assert.ok(
+      manifest.fileDiscovery['app/util'].includes('sub/fn.js'),
+      'nested app customLoader directory should be included in manifest fileDiscovery',
+    );
+    assert.ok(
+      manifest.fileDiscovery['app/repository'].includes('user.js'),
+      'ctx customLoader directory should be included in manifest fileDiscovery',
+    );
+    assert.ok(
+      manifest.fileDiscovery['app/plugin'].includes('a.js'),
+      'app loadunit customLoader directory should be included in manifest fileDiscovery',
+    );
+    assert.ok(
+      manifest.fileDiscovery['config/b/app/plugin'].includes('b.js'),
+      'plugin loadunit customLoader directory should be included in manifest fileDiscovery',
+    );
+
+    await testApp.close();
+  });
+
   it('should include plugin convention files that metadataOnly app loading does not execute', async () => {
     const testApp = createApp('manifest-dynamic-plugin', { metadataOnly: true });
     await testApp.loader.loadPlugin();

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -100,4 +100,36 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
 
     await testApp.close();
   });
+
+  it('should include plugin convention files that metadataOnly app loading does not execute', async () => {
+    const testApp = createApp('manifest-dynamic-plugin', { metadataOnly: true });
+    await testApp.loader.loadPlugin();
+    await testApp.loader.loadConfig();
+    await testApp.loader.loadApplicationExtend();
+    await testApp.loader.loadContextExtend();
+    await testApp.loader.loadRequestExtend();
+    await testApp.loader.loadResponseExtend();
+    await testApp.loader.loadHelperExtend();
+    await testApp.loader.loadCustomApp();
+    await testApp.loader.loadMiddleware();
+
+    const manifest = testApp.loader.generateManifest();
+
+    assert.equal(manifest.resolveCache['node_modules/@eggjs/security/agent'], 'node_modules/@eggjs/security/agent.js');
+    assert.equal(manifest.resolveCache['node_modules/@eggjs/security/app'], 'node_modules/@eggjs/security/app.js');
+    assert.equal(
+      manifest.resolveCache['node_modules/@eggjs/security/app/extend/agent'],
+      'node_modules/@eggjs/security/app/extend/agent.js',
+    );
+    assert.equal(
+      manifest.resolveCache['node_modules/@eggjs/security/app/extend/application'],
+      'node_modules/@eggjs/security/app/extend/application.js',
+    );
+    assert.ok(
+      manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware'].includes('securities.js'),
+      'security middleware should be included in manifest fileDiscovery',
+    );
+
+    await testApp.close();
+  });
 });

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -110,23 +110,23 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
     const manifest = testApp.loader.generateManifest();
 
     assert.ok(
-      manifest.fileDiscovery['app/adapter'].includes('docker.js'),
+      manifest.fileDiscovery['app/adapter']?.includes('docker.js'),
       'app customLoader directory should be included in manifest fileDiscovery',
     );
     assert.ok(
-      manifest.fileDiscovery['app/util'].includes('sub/fn.js'),
+      manifest.fileDiscovery['app/util']?.includes('sub/fn.js'),
       'nested app customLoader directory should be included in manifest fileDiscovery',
     );
     assert.ok(
-      manifest.fileDiscovery['app/repository'].includes('user.js'),
+      manifest.fileDiscovery['app/repository']?.includes('user.js'),
       'ctx customLoader directory should be included in manifest fileDiscovery',
     );
     assert.ok(
-      manifest.fileDiscovery['app/plugin'].includes('a.js'),
+      manifest.fileDiscovery['app/plugin']?.includes('a.js'),
       'app loadunit customLoader directory should be included in manifest fileDiscovery',
     );
     assert.ok(
-      manifest.fileDiscovery['config/b/app/plugin'].includes('b.js'),
+      manifest.fileDiscovery['config/b/app/plugin']?.includes('b.js'),
       'plugin loadunit customLoader directory should be included in manifest fileDiscovery',
     );
 
@@ -158,7 +158,7 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
       'node_modules/@eggjs/security/app/extend/application.js',
     );
     assert.ok(
-      manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware'].includes('securities.js'),
+      manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware']?.includes('securities.js'),
       'security middleware should be included in manifest fileDiscovery',
     );
 

--- a/tools/egg-bundler/src/lib/frameworkSpecifier.ts
+++ b/tools/egg-bundler/src/lib/frameworkSpecifier.ts
@@ -23,7 +23,7 @@ function isPathLikeFrameworkSpecifier(framework: string): boolean {
 export function assertFrameworkPackageSpecifier(framework: string): void {
   if (!framework || isPathLikeFrameworkSpecifier(framework)) {
     throw new Error(
-      `[@eggjs/egg-bundler] framework must be a package specifier for bundled runtime, got path-like value: ${framework}`,
+      `[@eggjs/egg-bundler] framework must be a package specifier for bundled runtime, got path-like value: ${JSON.stringify(framework)}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- Stack on top of PR #5921 / EGG-65 runtime mapping commit because that dependency is not yet in origin/next.
- Complete generated startup manifests with convention-based plugin dynamic files (agent, app, app/extend/*, and app/middleware) so bundled single-mode workers can load files skipped by metadataOnly agent startup.
- Add a security-like @eggjs/security fixture verifying agent, app, app/extend/agent, app/extend/application, and app/middleware/securities are present in the manifest.

## Validation
- pnpm exec vitest run packages/core/test/loader/manifest_coverage.test.ts
- pnpm exec vitest run packages/core/test/loader/manifest.test.ts packages/core/test/loader/manifest_roundtrip.test.ts packages/core/test/loader/manifest_fingerprint.test.ts packages/core/test/loader/manifest_query.test.ts packages/core/test/loader/manifest_coverage.test.ts
- pnpm --filter @eggjs/egg-bundler test -- EntryGenerator.test.ts
- pnpm --filter @eggjs/core typecheck
- pnpm --filter @eggjs/egg-bundler typecheck
- pnpm exec oxfmt --check packages/core/src/loader/egg_loader.ts packages/core/test/loader/manifest_coverage.test.ts tools/egg-bundler/src/lib/EntryGenerator.ts tools/egg-bundler/test/EntryGenerator.test.ts
- git diff --check origin/next...HEAD

Notes: targeted oxlint on changed files exits 0 with existing warnings in pre-existing egg_loader.ts lines outside this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest post-processing now caches convention-based module resolution and records directory-discovered middleware lists for metadata-only runs.
  * Bundler/runtime treats framework as a package specifier, validates specifiers, and precomputes output↔original-app aliasing for deterministic module lookup.

* **Documentation**
  * Updated bundler docs, CLI help, and wiki to explain runtime path mapping, output-dir semantics, and framework-specifier behavior.

* **Tests & Chores**
  * Added fixtures and tests for manifest resolve-cache, file discovery, deterministic worker generation, and framework-specifier validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->