### PR TITLE
docs(wiki): record test infrastructure workflows

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -11,6 +11,7 @@ Read this file before exploring raw sources.
 ## Workflows
 
 - [Docs and API Updates](./workflows/docs-and-api-updates.md) - How to handle changes that affect user-facing docs or durable project understanding.
+- [Test Infrastructure](./workflows/test-infrastructure.md) - Local external services and optional CI benchmark report tooling.
 
 ## Decisions
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,7 +2,7 @@
 
 ## [2026-05-04] workflow | record local test infrastructure
 
-- sources touched: `README.md`, `benchmark/ci-test/README.md`, `scripts/dev-services.js`, `scripts/ci-test-benchmark.js`
+- sources consulted: `README.md`, `benchmark/ci-test/README.md`, `dev-services.compose.yml`, `package.json`, `scripts/dev-services.js`, `scripts/ci-test-benchmark.js`
 - pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/workflows/test-infrastructure.md`
 - note: Added a durable workflow page for local MySQL/Redis service helpers and optional CI benchmark report generation.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,5 +1,11 @@
 # Wiki Log
 
+## [2026-05-04] workflow | record local test infrastructure
+
+- sources touched: `README.md`, `benchmark/ci-test/README.md`, `scripts/dev-services.js`, `scripts/ci-test-benchmark.js`
+- pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/workflows/test-infrastructure.md`
+- note: Added a durable workflow page for local MySQL/Redis service helpers and optional CI benchmark report generation.
+
 ## [2026-05-03] package | record egg bundler runtime path mapping
 
 - sources touched: `tools/egg-bundler/src/lib/EntryGenerator.ts`, `tools/egg-bundler/docs/output-structure.md`

--- a/wiki/workflows/test-infrastructure.md
+++ b/wiki/workflows/test-infrastructure.md
@@ -5,6 +5,7 @@ summary: Local services and CI benchmark tooling used to reproduce and measure t
 source_files:
   - README.md
   - benchmark/ci-test/README.md
+  - dev-services.compose.yml
   - package.json
   - scripts/dev-services.js
   - scripts/ci-test-benchmark.js
@@ -19,16 +20,17 @@ and optional CI benchmark reports.
 
 ## Local External Services
 
-`utoo run dev:services:start` starts the Docker Compose stack declared in
+`ut run dev:services:start` starts the Docker Compose stack declared in
 `dev-services.compose.yml`. It provides MySQL 8 and Redis 7 on the CI-aligned
 default host ports:
 
 - MySQL: `127.0.0.1:3306`
 - Redis: `127.0.0.1:6379`
 
-The helper creates the MySQL databases used by DAL, ORM, Redis, session, and
-cnpmcore-related fixtures. `dev:services:status`, `dev:services:stop`, and
-`dev:services:reset` wrap the corresponding lifecycle actions. Port and image
+The helper creates MySQL databases used by DAL, ORM, session, and
+cnpmcore-related fixtures, and provides Redis for fixture requirements.
+`ut run dev:services:status`, `ut run dev:services:stop`, and
+`ut run dev:services:reset` wrap the corresponding lifecycle actions. Port and image
 overrides exist for compatibility checks, but the full local test path still
 expects the default host ports because several fixtures hard-code them.
 

--- a/wiki/workflows/test-infrastructure.md
+++ b/wiki/workflows/test-infrastructure.md
@@ -1,0 +1,46 @@
+---
+title: Test Infrastructure
+type: workflow
+summary: Local services and CI benchmark tooling used to reproduce and measure test behavior.
+source_files:
+  - README.md
+  - benchmark/ci-test/README.md
+  - package.json
+  - scripts/dev-services.js
+  - scripts/ci-test-benchmark.js
+updated_at: 2026-05-04
+status: active
+---
+
+# Test Infrastructure
+
+Egg's repository-level test tooling includes helpers for local external services
+and optional CI benchmark reports.
+
+## Local External Services
+
+`utoo run dev:services:start` starts the Docker Compose stack declared in
+`dev-services.compose.yml`. It provides MySQL 8 and Redis 7 on the CI-aligned
+default host ports:
+
+- MySQL: `127.0.0.1:3306`
+- Redis: `127.0.0.1:6379`
+
+The helper creates the MySQL databases used by DAL, ORM, Redis, session, and
+cnpmcore-related fixtures. `dev:services:status`, `dev:services:stop`, and
+`dev:services:reset` wrap the corresponding lifecycle actions. Port and image
+overrides exist for compatibility checks, but the full local test path still
+expects the default host ports because several fixtures hard-code them.
+
+## CI Test Benchmark
+
+`ut run benchmark:ci-test` runs `scripts/ci-test-benchmark.js`, which executes a
+Vitest command and writes:
+
+- `report.md`
+- `report.json`
+- `vitest-results.json`
+
+The default output directory is `benchmark/ci-test/<timestamp>`. The harness is
+for explicit measurement runs only; it does not change required checks or CI
+gate semantics. Use `--output-dir` when a deterministic artifact path is needed.


### PR DESCRIPTION
## Summary
- add a wiki workflow page for local MySQL/Redis dev services and the CI test benchmark harness
- link the new page from the wiki index and append the daily wiki log entry

## Validation
- git diff --check passed
- pnpm exec oxfmt --check wiki/index.md wiki/log.md wiki/workflows/test-infrastructure.md could not run because oxfmt is not installed in this checkout (Command "oxfmt" not found)

Docs/wiki only; no runtime code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Test Infrastructure" workflow documentation describing local Docker Compose setup for MySQL 8 and Redis 7 and how to start/inspect/stop/reset the stack.
  * Documented CI benchmark tooling execution and output artifact handling.
  * Added a Workflows index entry linking to the new page and a wiki log entry (2026-05-04) summarizing the updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->