### PR TITLE
docs(bundler): document manifest dynamic entries

### DIFF
--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -40,8 +40,9 @@ is keyed by relKey, output-dir absolute paths, precomputed original app absolute
 paths, and manifest `resolveCache` request aliases. Application code and plugins
 may still use `fs` for resources such as config, views, or assets.
 
-When the bundler generates a missing startup manifest with `metadataOnly: true`,
-Egg also records convention-based dynamic entries from each load unit, including
+When the bundler generates a missing `.egg/manifest.json` with
+`metadataOnly: true`, Egg also records convention-based dynamic lookups from each
+load unit into the manifest `resolveCache` and `fileDiscovery`, including
 `agent`, `app`, `app/extend/*`, and `app/middleware/*`. This lets bundled
 single-mode workers resolve plugin agent hooks, extensions, and middleware that
 are normally discovered later during runtime loading.

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -40,6 +40,12 @@ is keyed by relKey, output-dir absolute paths, precomputed original app absolute
 paths, and manifest `resolveCache` request aliases. Application code and plugins
 may still use `fs` for resources such as config, views, or assets.
 
+When the bundler generates a missing startup manifest with `metadataOnly: true`,
+Egg also records convention-based dynamic entries from each load unit, including
+`agent`, `app`, `app/extend/*`, and `app/middleware/*`. This lets bundled
+single-mode workers resolve plugin agent hooks, extensions, and middleware that
+are normally discovered later during runtime loading.
+
 ## `bundle-manifest.json`
 
 A reference file produced by `Bundler` (not consumed at runtime). Shape:


### PR DESCRIPTION
## Summary
- Document that metadata-only manifest generation records convention-based dynamic lookups for load units.
- Clarify that the generated `.egg/manifest.json` records these lookups into `resolveCache` and `fileDiscovery` so bundled single-mode workers can resolve plugin agent hooks, extensions, and middleware discovered during runtime loading.

## Validation
- git diff --check origin/next..HEAD
- pnpm exec oxfmt --check tools/egg-bundler/docs/output-structure.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation explaining how the Bundler records convention-based dynamic entries in startup manifests. This clarifies how bundled single-mode workers locate plugin agent hooks, extensions, and middleware at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
