### PR TITLE
fix(bundler): preserve framework loader paths

### DIFF
--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -27,6 +27,7 @@ import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
+const LOADER_MANIFEST_EXTENSION = 'eggLoader';
 const CONVENTIONAL_MANIFEST_LOADS = [
   { type: 'resolve', path: ['agent'] },
   { type: 'resolve', path: ['app'] },
@@ -64,6 +65,20 @@ export type EggDirInfoType = 'app' | 'plugin' | 'framework';
 export interface EggDirInfo {
   path: string;
   type: EggDirInfoType;
+}
+
+interface LoaderManifestPluginInfo {
+  path?: string;
+  package?: string;
+  dependencies?: string[];
+  optionalDependencies?: string[];
+  env?: string[];
+  version?: string;
+}
+
+interface LoaderManifestExtension {
+  eggPaths?: string[];
+  plugins?: Record<string, LoaderManifestPluginInfo>;
 }
 
 export class EggLoader {
@@ -379,6 +394,20 @@ export class EggLoader {
         eggPaths.unshift(realpath);
       }
     }
+
+    const bundleStore = ManifestStore.getBundleStore();
+    const extension =
+      bundleStore?.baseDir === this.options.baseDir
+        ? (bundleStore.getExtension(LOADER_MANIFEST_EXTENSION) as LoaderManifestExtension | undefined)
+        : undefined;
+    if (extension?.eggPaths?.length) {
+      return Array.from(
+        new Set([
+          ...extension.eggPaths.map((eggPath) => this.#toManifestAbsolute(eggPath)),
+          ...eggPaths.filter((eggPath) => !this.#isBundleOutputRootPath(eggPath)),
+        ]),
+      );
+    }
     return eggPaths;
   }
 
@@ -450,6 +479,7 @@ export class EggLoader {
     this.#extendPlugins(this.allPlugins, this.eggPlugins);
     this.#extendPlugins(this.allPlugins, this.appPlugins);
     this.#extendPlugins(this.allPlugins, this.customPlugins);
+    this.#applyManifestPluginInfo(this.allPlugins);
 
     const enabledPluginNames: string[] = []; // enabled plugins that configured explicitly
     const plugins: Record<string, EggPluginInfo> = {};
@@ -498,6 +528,7 @@ export class EggLoader {
      * @since 1.0.0
      */
     this.plugins = enablePlugins;
+    this.#collectLoaderManifestExtension();
     this.timing.end('Load Plugin');
   }
 
@@ -923,6 +954,68 @@ export class EggLoader {
         Reflect.set(targetPlugin, prop, value);
       }
     }
+  }
+
+  #applyManifestPluginInfo(allPlugins: Record<string, EggPluginInfo>): void {
+    // getEggPaths reads ManifestStore.getBundleStore in the constructor before this.manifest is assigned.
+    const extension = this.manifest.getExtension(LOADER_MANIFEST_EXTENSION) as LoaderManifestExtension | undefined;
+    const plugins = extension?.plugins;
+    if (!plugins) return;
+
+    for (const [name, manifestPlugin] of Object.entries(plugins)) {
+      const plugin = allPlugins[name];
+      if (!plugin) continue;
+
+      if (manifestPlugin.path && (!plugin.path || this.#isBundleOutputRootPath(plugin.path))) {
+        plugin.path = this.#toManifestAbsolute(manifestPlugin.path);
+      }
+      if (manifestPlugin.package && !plugin.package) {
+        plugin.package = manifestPlugin.package;
+      }
+      for (const key of ['dependencies', 'optionalDependencies', 'env'] as const) {
+        const values = manifestPlugin[key];
+        if (Array.isArray(values) && !plugin[key]?.length) {
+          plugin[key] = [...values];
+        }
+      }
+      if (manifestPlugin.version && !plugin.version) {
+        plugin.version = manifestPlugin.version;
+      }
+    }
+  }
+
+  #collectLoaderManifestExtension(): void {
+    if (this.manifest === ManifestStore.getBundleStore()) return;
+
+    const plugins: Record<string, LoaderManifestPluginInfo> = {};
+    for (const [name, plugin] of Object.entries(this.allPlugins)) {
+      plugins[name] = {
+        path: plugin.path ? this.#toManifestRelative(plugin.path) : undefined,
+        package: plugin.package,
+        dependencies: plugin.dependencies ? [...plugin.dependencies] : undefined,
+        optionalDependencies: plugin.optionalDependencies ? [...plugin.optionalDependencies] : undefined,
+        env: plugin.env ? [...plugin.env] : undefined,
+        version: plugin.version,
+      };
+    }
+    this.manifest.setExtension(LOADER_MANIFEST_EXTENSION, {
+      eggPaths: this.eggPaths.map((eggPath) => this.#toManifestRelative(eggPath)),
+      plugins,
+    } satisfies LoaderManifestExtension);
+  }
+
+  #toManifestAbsolute(filepath: string): string {
+    return path.isAbsolute(filepath) ? filepath : path.join(this.options.baseDir, filepath);
+  }
+
+  #toManifestRelative(filepath: string): string {
+    return path.isAbsolute(filepath)
+      ? path.relative(this.options.baseDir, filepath).replaceAll(path.sep, '/')
+      : filepath;
+  }
+
+  #isBundleOutputRootPath(filepath: string): boolean {
+    return path.resolve(this.options.baseDir, filepath) === path.resolve(this.options.baseDir);
   }
   /** end Plugin loader */
 

--- a/packages/core/test/loader/mixin/load_plugin.test.ts
+++ b/packages/core/test/loader/mixin/load_plugin.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { mm } from 'mm';
 import { describe, it, afterEach } from 'vitest';
 
-import { EggCore, EggLoader } from '../../../src/index.js';
+import { EggCore, EggLoader, ManifestStore, type StartupManifest } from '../../../src/index.js';
 import { createApp, getFilepath, type Application } from '../../helper.js';
 
 // windows path is case-insensitive, the equal assert will fail
@@ -14,6 +14,7 @@ describe.skipIf(process.platform === 'win32')('test/loader/mixin/load_plugin.tes
 
   afterEach(async () => {
     mm.restore();
+    ManifestStore.setBundleStore(undefined);
     if (app) {
       await app.close();
     }
@@ -39,6 +40,57 @@ describe.skipIf(process.platform === 'win32')('test/loader/mixin/load_plugin.tes
     assert('customPlugins' in loader);
     assert('eggPlugins' in loader);
     assert(loader.plugins.a.enable);
+  });
+
+  it('should apply bundled loader manifest eggPaths and plugin paths', async () => {
+    const baseDir = getFilepath('plugin');
+    const manifest: StartupManifest = {
+      version: 1,
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      invalidation: {
+        lockfileFingerprint: 'bundle-test',
+        configFingerprint: 'bundle-test',
+        serverEnv: 'unittest',
+        serverScope: '',
+        typescriptEnabled: true,
+      },
+      extensions: {
+        eggLoader: {
+          eggPaths: ['node_modules/egg'],
+          plugins: {
+            virtual: {
+              path: 'node_modules/virtual-plugin',
+            },
+          },
+        },
+      },
+      resolveCache: {},
+      fileDiscovery: {},
+    };
+    const bundleStore = ManifestStore.fromBundle(manifest, baseDir);
+    ManifestStore.setBundleStore(bundleStore);
+
+    app = createApp('plugin');
+    const loader = app.loader;
+    assert.deepEqual(loader.eggPaths, [path.join(baseDir, 'node_modules/egg'), getFilepath('egg-esm')]);
+    mm(loader, 'loadEggPlugins', async () => ({
+      virtual: {
+        enable: true,
+        name: 'virtual',
+        path: baseDir,
+        dependencies: [],
+        optionalDependencies: [],
+        env: [],
+        from: path.join(baseDir, 'config/plugin.js'),
+      },
+    }));
+    mm(loader, 'loadAppPlugins', async () => ({}));
+    mm(loader, 'loadCustomPlugins', () => ({}));
+
+    await loader.loadPlugin();
+
+    assert.equal(loader.allPlugins.virtual.path, path.join(baseDir, 'node_modules/virtual-plugin'));
+    assert.deepEqual(bundleStore.getExtension('eggLoader'), manifest.extensions.eggLoader);
   });
 
   it('should loadConfig all plugins', async () => {

--- a/tegg/plugin/aop/test/aop.test.ts
+++ b/tegg/plugin/aop/test/aop.test.ts
@@ -19,7 +19,7 @@ describe('plugin/aop/test/aop.test.ts', () => {
       baseDir: path.join(import.meta.dirname, 'fixtures/apps/aop-app'),
     });
     await app.ready();
-  });
+  }, 30000);
 
   it('module aop should work', async () => {
     app.mockCsrf();

--- a/tegg/plugin/orm/test/index.test.ts
+++ b/tegg/plugin/orm/test/index.test.ts
@@ -31,7 +31,7 @@ describe('plugin/orm/test/orm.test.ts', () => {
     });
     await app.ready();
     appService = await app.getEggObject(AppService);
-  });
+  }, 30000);
 
   afterAll(() => {
     return app.close();

--- a/tegg/plugin/tegg/test/ModuleConfig.test.ts
+++ b/tegg/plugin/tegg/test/ModuleConfig.test.ts
@@ -21,7 +21,7 @@ describe('plugin/tegg/test/ModuleConfig.test.ts', () => {
       baseDir: getAppBaseDir('inject-module-config'),
     });
     await app.ready();
-  });
+  }, 30000);
 
   it('should work', async () => {
     await app

--- a/tools/egg-bundler/src/lib/EntryGenerator.ts
+++ b/tools/egg-bundler/src/lib/EntryGenerator.ts
@@ -290,7 +290,48 @@ const __setBundleAliases = (rel: string, mod: unknown) => {
     __setBundleMap(path.resolve(__outputDir, rel), mod);
   }
 };
+const __packageName = (specifier: string) => {
+  const parts = specifier.split('/');
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+};
+const __packageRoot = (specifier: string) => path.join(__outputDir, 'node_modules', ...__packageName(specifier).split('/'));
+const __toOutputPath = (filepath: string) => (path.isAbsolute(filepath) ? filepath : path.resolve(__outputDir, filepath));
+const __loaderEggPaths = (
+  ((MANIFEST_DATA.extensions as { eggLoader?: { eggPaths?: unknown[] } }).eggLoader?.eggPaths ?? []).filter(
+    (filepath): filepath is string => typeof filepath === 'string',
+  )
+).map(__toOutputPath);
+const __fallbackFrameworkPaths = [
+  __packageRoot(__framework),
+  __framework === 'egg' ? undefined : __packageRoot('egg'),
+].filter((filepath): filepath is string => typeof filepath === 'string');
+const __frameworkPaths = Array.from(
+  new Set(__loaderEggPaths.length > 0 ? __loaderEggPaths : __fallbackFrameworkPaths),
+);
+const __isOutputRootPath = (filepath: unknown) =>
+  typeof filepath === 'string' && path.resolve(__outputDir, filepath) === path.resolve(__outputDir);
+const __patchFrameworkPaths = (Clazz: unknown) => {
+  const proto = (Clazz as { prototype?: Record<string, unknown> } | undefined)?.prototype;
+  if (!proto) return;
+  const original = proto.customEggPaths;
+  const descriptor = Object.getOwnPropertyDescriptor(proto, 'customEggPaths');
+  if (descriptor && !descriptor.configurable && !descriptor.writable) return;
+  Object.defineProperty(proto, 'customEggPaths', {
+    configurable: descriptor?.configurable ?? true,
+    enumerable: descriptor?.enumerable ?? false,
+    writable: descriptor?.writable ?? true,
+    value: function (this: unknown) {
+      const originalPaths = typeof original === 'function' ? original.call(this) : [];
+      const preservedPaths = Array.isArray(originalPaths)
+        ? originalPaths.filter((p: unknown) => !__isOutputRootPath(p))
+        : [];
+      return Array.from(new Set([...__frameworkPaths, ...preservedPaths]));
+    },
+  });
+};
 __setBundleMap(__framework, __frameworkModule);
+__patchFrameworkPaths(__frameworkModule.Application);
+__patchFrameworkPaths(__frameworkModule.Agent);
 for (const [rel, mod] of Object.entries(__BUNDLE_MAP_REL)) {
   __setBundleAliases(rel, mod);
 }

--- a/tools/egg-bundler/src/lib/ManifestLoader.ts
+++ b/tools/egg-bundler/src/lib/ManifestLoader.ts
@@ -12,6 +12,7 @@ const debug = debuglog('egg/bundler/manifest-loader');
 const SUPPORTED_MANIFEST_VERSION = 1;
 const FRAMEWORK_DEFAULT = 'egg';
 const PACKAGE_ENTRY_ACTIVE_CONDITIONS = new Set(['import', 'node', 'default']);
+const LOADER_MANIFEST_EXTENSION = 'eggLoader';
 
 export interface ManifestLoaderOptions {
   baseDir: string;
@@ -35,6 +36,17 @@ interface TeggManifestExtension {
 interface ModuleMapEntry {
   realDir: string;
   normalizedDir: string;
+}
+
+interface LoaderManifestPluginInfo {
+  path?: string;
+  [key: string]: unknown;
+}
+
+interface LoaderManifestExtension {
+  eggPaths?: string[];
+  plugins?: Record<string, LoaderManifestPluginInfo>;
+  [key: string]: unknown;
 }
 
 export class ManifestLoader {
@@ -425,6 +437,28 @@ export class ManifestLoader {
             return { ...desc, unitPath };
           }),
         ),
+      };
+    }
+    const eggLoader = extensions?.[LOADER_MANIFEST_EXTENSION] as LoaderManifestExtension | undefined;
+    if (eggLoader) {
+      result[LOADER_MANIFEST_EXTENSION] = {
+        ...eggLoader,
+        eggPaths: eggLoader.eggPaths
+          ? await Promise.all(eggLoader.eggPaths.map((eggPath) => this.#normalizeRelKey(eggPath, moduleMap)))
+          : undefined,
+        plugins: eggLoader.plugins
+          ? Object.fromEntries(
+              await Promise.all(
+                Object.entries(eggLoader.plugins).map(async ([name, plugin]) => [
+                  name,
+                  {
+                    ...plugin,
+                    path: plugin.path ? await this.#normalizeRelKey(plugin.path, moduleMap) : undefined,
+                  },
+                ]),
+              ),
+            )
+          : undefined,
       };
     }
     return result;

--- a/tools/egg-bundler/test/EntryGenerator.test.ts
+++ b/tools/egg-bundler/test/EntryGenerator.test.ts
@@ -197,6 +197,7 @@ describe('EntryGenerator', () => {
     expect(worker).toContain('ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA');
     expect(worker).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(worker).toContain('__setBundleMap(__framework, __frameworkModule)');
+    expect(worker).toContain('__patchFrameworkPaths(__frameworkModule.Application)');
     expect(worker).not.toContain('__frameworkImport');
     expect(worker).toContain("startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single' })");
   });
@@ -332,6 +333,104 @@ export async function startEgg(options) {
     expect(runtimeResult.frameworkResolved).toBe('bundled-framework');
     expect(runtimeResult.frameworkStartEggMatches).toBe(true);
     expect(runtimeResult.controllerResolved).toBe('bundled-controller');
+  });
+
+  it('virtualizes framework eggPaths under node_modules before startEgg runs', async () => {
+    const resultFile = path.join(tmpDir, 'framework-paths.json');
+    await fs.writeFile(path.join(tmpDir, 'package.json'), JSON.stringify({ type: 'module' }));
+    await writePackage(
+      path.join(tmpDir, 'node_modules/@eggjs/core'),
+      `
+export const ManifestStore = {
+  fromBundle(manifest, baseDir) {
+    return { manifest, baseDir };
+  },
+  setBundleStore() {},
+};
+`,
+    );
+    const frameworkDir = path.join(tmpDir, 'node_modules/@runtime/framework');
+    await fs.mkdir(frameworkDir, { recursive: true });
+    await fs.writeFile(
+      path.join(frameworkDir, 'package.json'),
+      JSON.stringify({ type: 'module', exports: { './subpath': './subpath.js' } }),
+    );
+    await fs.writeFile(
+      path.join(frameworkDir, 'subpath.js'),
+      `
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const outputDir = () => path.dirname(path.resolve(process.argv[1]));
+
+export class Application {
+  customEggPaths() {
+    return [outputDir(), path.join(outputDir(), 'preserved-framework')];
+  }
+}
+
+export class Agent extends Application {}
+
+export async function startEgg(options) {
+  await fs.writeFile(process.env.EGG_RUNTIME_RESULT, JSON.stringify({
+    appPaths: new Application().customEggPaths(),
+    agentPaths: new Agent().customEggPaths(),
+    appDescriptor: Object.getOwnPropertyDescriptor(Application.prototype, 'customEggPaths'),
+    agentDescriptor: Object.getOwnPropertyDescriptor(Agent.prototype, 'customEggPaths'),
+  }, null, 2));
+  return {
+    config: { cluster: { listen: { port: 0 } } },
+    listen(_port, callback) {
+      callback();
+    },
+  };
+}
+`,
+    );
+
+    const outputDir = path.join(tmpDir, 'dist');
+    const gen = new EntryGenerator({
+      baseDir: tmpDir,
+      outputDir,
+      framework: '@runtime/framework/subpath',
+      manifestLoader: createFakeLoader(
+        makeManifest({
+          extensions: {
+            eggLoader: {
+              eggPaths: ['node_modules/@runtime/root-framework', 'node_modules/@runtime/framework', 'node_modules/egg'],
+            },
+          },
+        }),
+      ),
+    });
+    const result = await gen.generate();
+
+    await execaNode(result.workerEntry, [], {
+      cwd: tmpDir,
+      env: {
+        ...process.env,
+        EGG_RUNTIME_RESULT: resultFile,
+      },
+      nodeOptions: ['--experimental-strip-types'],
+      timeout: 5_000,
+    });
+
+    const runtimeResult = JSON.parse(await fs.readFile(resultFile, 'utf8')) as {
+      appPaths: string[];
+      agentPaths: string[];
+      appDescriptor: PropertyDescriptor;
+      agentDescriptor: PropertyDescriptor;
+    };
+    const expected = [
+      path.join(outputDir, 'node_modules/@runtime/root-framework'),
+      path.join(outputDir, 'node_modules/@runtime/framework'),
+      path.join(outputDir, 'node_modules/egg'),
+      path.join(outputDir, 'preserved-framework'),
+    ];
+    expect(runtimeResult.appPaths).toEqual(expected);
+    expect(runtimeResult.agentPaths).toEqual(expected);
+    expect(runtimeResult.appDescriptor).toMatchObject({ configurable: true, enumerable: false, writable: true });
+    expect(runtimeResult.agentDescriptor).toMatchObject({ configurable: true, enumerable: false, writable: true });
   });
 
   it('loads externalized package files via createRequire instead of static imports', async () => {

--- a/tools/egg-bundler/test/ManifestLoader.test.ts
+++ b/tools/egg-bundler/test/ManifestLoader.test.ts
@@ -250,6 +250,18 @@ describe('ManifestLoader', () => {
               },
             ],
           },
+          eggLoader: {
+            eggPaths: [directRoot],
+            plugins: {
+              direct: {
+                path: directRoot,
+                dependencies: [],
+              },
+              transitive: {
+                path: transitiveRoot,
+              },
+            },
+          },
         },
       }),
     );
@@ -265,13 +277,27 @@ describe('ManifestLoader', () => {
       'node_modules/direct/node_modules/transitive/entry': 'node_modules/direct/node_modules/transitive/lib/svc.ts',
       'node_modules/optional-native/entry': 'node_modules/optional-native/index.ts',
     });
-    expect(loaded.extensions.tegg).toEqual({
-      moduleDescriptors: [
-        {
-          unitPath: 'node_modules/direct/node_modules/transitive',
-          decoratedFiles: ['lib/svc.ts'],
+    expect(loaded.extensions).toEqual({
+      tegg: {
+        moduleDescriptors: [
+          {
+            unitPath: 'node_modules/direct/node_modules/transitive',
+            decoratedFiles: ['lib/svc.ts'],
+          },
+        ],
+      },
+      eggLoader: {
+        eggPaths: ['node_modules/direct'],
+        plugins: {
+          direct: {
+            path: 'node_modules/direct',
+            dependencies: [],
+          },
+          transitive: {
+            path: 'node_modules/direct/node_modules/transitive',
+          },
         },
-      ],
+      },
     });
     expect(loader.getAllDiscoveredFiles()).toEqual([transitiveFile]);
     expect(loader.getTeggDecoratedFiles()).toEqual([transitiveFile]);

--- a/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
+++ b/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
@@ -74,7 +74,48 @@ const __setBundleAliases = (rel: string, mod: unknown) => {
     __setBundleMap(path.resolve(__outputDir, rel), mod);
   }
 };
+const __packageName = (specifier: string) => {
+  const parts = specifier.split('/');
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+};
+const __packageRoot = (specifier: string) => path.join(__outputDir, 'node_modules', ...__packageName(specifier).split('/'));
+const __toOutputPath = (filepath: string) => (path.isAbsolute(filepath) ? filepath : path.resolve(__outputDir, filepath));
+const __loaderEggPaths = (
+  ((MANIFEST_DATA.extensions as { eggLoader?: { eggPaths?: unknown[] } }).eggLoader?.eggPaths ?? []).filter(
+    (filepath): filepath is string => typeof filepath === 'string',
+  )
+).map(__toOutputPath);
+const __fallbackFrameworkPaths = [
+  __packageRoot(__framework),
+  __framework === 'egg' ? undefined : __packageRoot('egg'),
+].filter((filepath): filepath is string => typeof filepath === 'string');
+const __frameworkPaths = Array.from(
+  new Set(__loaderEggPaths.length > 0 ? __loaderEggPaths : __fallbackFrameworkPaths),
+);
+const __isOutputRootPath = (filepath: unknown) =>
+  typeof filepath === 'string' && path.resolve(__outputDir, filepath) === path.resolve(__outputDir);
+const __patchFrameworkPaths = (Clazz: unknown) => {
+  const proto = (Clazz as { prototype?: Record<string, unknown> } | undefined)?.prototype;
+  if (!proto) return;
+  const original = proto.customEggPaths;
+  const descriptor = Object.getOwnPropertyDescriptor(proto, 'customEggPaths');
+  if (descriptor && !descriptor.configurable && !descriptor.writable) return;
+  Object.defineProperty(proto, 'customEggPaths', {
+    configurable: descriptor?.configurable ?? true,
+    enumerable: descriptor?.enumerable ?? false,
+    writable: descriptor?.writable ?? true,
+    value: function (this: unknown) {
+      const originalPaths = typeof original === 'function' ? original.call(this) : [];
+      const preservedPaths = Array.isArray(originalPaths)
+        ? originalPaths.filter((p: unknown) => !__isOutputRootPath(p))
+        : [];
+      return Array.from(new Set([...__frameworkPaths, ...preservedPaths]));
+    },
+  });
+};
 __setBundleMap(__framework, __frameworkModule);
+__patchFrameworkPaths(__frameworkModule.Application);
+__patchFrameworkPaths(__frameworkModule.Agent);
 for (const [rel, mod] of Object.entries(__BUNDLE_MAP_REL)) {
   __setBundleAliases(rel, mod);
 }


### PR DESCRIPTION
## Summary
- record framework eggPaths and resolved plugin path metadata into the startup manifest
- replay bundled loader metadata before runtime plugin resolution so framework config/plugin files do not collapse onto the app output dir
- normalize the new loader manifest extension and patch generated worker framework paths for bundled runtime startup

## Tests
- pnpm exec vitest run packages/core/test/loader/mixin/load_plugin.test.ts --testTimeout 20000
- cd tools/egg-bundler && pnpm exec vitest run test/EntryGenerator.test.ts test/ManifestLoader.test.ts --testTimeout 20000
- pnpm --filter @eggjs/core typecheck
- pnpm --filter @eggjs/egg-bundler typecheck
- pnpm --filter @eggjs/egg-bundler lint
- pnpm exec oxfmt --check packages/core/src/loader/egg_loader.ts packages/core/test/loader/mixin/load_plugin.test.ts tools/egg-bundler/src/lib/EntryGenerator.ts tools/egg-bundler/src/lib/ManifestLoader.ts tools/egg-bundler/test/EntryGenerator.test.ts tools/egg-bundler/test/ManifestLoader.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle manifest support for the egg loader so startup manifest data can influence loader egg paths, plugin metadata, and resolution.
  * Public exports for manifest handling (ManifestStore, StartupManifest) to enable manifest-based bundle configuration.
  * Improved framework path patching and virtualization for bundled applications.

* **Tests**
  * Added/updated tests for manifest-driven loader behavior, egg loader entries, framework path patching, and plugin/path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->