### PR TITLE
fix(egg-bundler): copy app runtime assets

### DIFF
--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -33,6 +33,13 @@ Applications can also provide stable bundle configuration in
 
 ```yaml
 bundle:
+  runtimeAssets:
+    # Optional. When omitted, defaults to app/public, app/assets, and app/static.
+    # When present, this list replaces the default force-copy directories.
+    forceCopyDirs:
+      - app/public
+      - app/assets
+      - app/static
   pack:
     resolve:
       alias:
@@ -42,7 +49,9 @@ bundle:
 Dot-relative alias targets are resolved from `baseDir`; package-style and
 absolute targets are passed through. Aliases supplied directly through the
 programmatic `pack.resolve.alias` option override aliases with the same key from
-`module.yml`.
+`module.yml`. `runtimeAssets.forceCopyDirs` entries are bundle-output relative
+paths that are copied even when their files use source-like extensions such as
+`.js` or `.ts`.
 
 If the startup manifest is missing, the bundler generates it by starting the app
 with `metadataOnly: true`. In that mode Egg skips the agent and normal boot
@@ -52,19 +61,20 @@ not run.
 
 ## Options
 
-| Option               | Description                                                                     |
-| -------------------- | ------------------------------------------------------------------------------- |
-| `baseDir`            | Application root directory. Required.                                           |
-| `outputDir`          | Output directory for the bundled artifact. Required.                            |
-| `manifestPath`       | Path to `manifest.json`. Defaults to `<baseDir>/.egg/manifest.json`.            |
-| `framework`          | Framework package specifier. Defaults to `egg`; absolute paths are unsupported. |
-| `mode`               | Build mode, `production` or `development`. Defaults to `production`.            |
-| `tegg`               | Accepted by `BundlerConfig`, but not applied by the current implementation yet. |
-| `externals.force`    | Package names to always keep external.                                          |
-| `externals.inline`   | Package names to force inline even if auto-detected as external.                |
-| `pack.buildFunc`     | Test hook for replacing the real `@utoo/pack` build entry.                      |
-| `pack.rootPath`      | Override the monorepo workspace root used by `@utoo/pack`.                      |
-| `pack.resolve.alias` | Application-supplied `@utoo/pack` resolve aliases; overrides `module.yml`.      |
+| Option                        | Description                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------- |
+| `baseDir`                     | Application root directory. Required.                                           |
+| `outputDir`                   | Output directory for the bundled artifact. Required.                            |
+| `manifestPath`                | Path to `manifest.json`. Defaults to `<baseDir>/.egg/manifest.json`.            |
+| `framework`                   | Framework package specifier. Defaults to `egg`; absolute paths are unsupported. |
+| `mode`                        | Build mode, `production` or `development`. Defaults to `production`.            |
+| `tegg`                        | Accepted by `BundlerConfig`, but not applied by the current implementation yet. |
+| `externals.force`             | Package names to always keep external.                                          |
+| `externals.inline`            | Package names to force inline even if auto-detected as external.                |
+| `runtimeAssets.forceCopyDirs` | Relative dirs copied even for source-like files; overrides `module.yml`.        |
+| `pack.buildFunc`              | Test hook for replacing the real `@utoo/pack` build entry.                      |
+| `pack.rootPath`               | Override the monorepo workspace root used by `@utoo/pack`.                      |
+| `pack.resolve.alias`          | Application-supplied `@utoo/pack` resolve aliases; overrides `module.yml`.      |
 
 ## Result
 

--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -34,6 +34,10 @@ Applications can also provide stable bundle configuration in
 ```yaml
 bundle:
   runtimeAssets:
+    # Optional. When omitted, defaults to app.
+    # When present, this list replaces the default runtime asset scan roots.
+    roots:
+      - app
     # Optional. When omitted, defaults to app/public, app/assets, and app/static.
     # When present, this list replaces the default force-copy directories.
     forceCopyDirs:
@@ -51,7 +55,9 @@ absolute targets are passed through. Aliases supplied directly through the
 programmatic `pack.resolve.alias` option override aliases with the same key from
 `module.yml`. `runtimeAssets.forceCopyDirs` entries are bundle-output relative
 paths that are copied even when their files use source-like extensions such as
-`.js` or `.ts`.
+`.js` or `.ts`. `runtimeAssets.roots` entries are baseDir-relative directories
+that are scanned for runtime assets and preserve that same relative path in the
+bundle output.
 
 If the startup manifest is missing, the bundler generates it by starting the app
 with `metadataOnly: true`. In that mode Egg skips the agent and normal boot
@@ -71,6 +77,7 @@ not run.
 | `tegg`                        | Accepted by `BundlerConfig`, but not applied by the current implementation yet. |
 | `externals.force`             | Package names to always keep external.                                          |
 | `externals.inline`            | Package names to force inline even if auto-detected as external.                |
+| `runtimeAssets.roots`         | BaseDir-relative runtime asset scan roots; overrides `module.yml`.              |
 | `runtimeAssets.forceCopyDirs` | Relative dirs copied even for source-like files; overrides `module.yml`.        |
 | `pack.buildFunc`              | Test hook for replacing the real `@utoo/pack` build entry.                      |
 | `pack.rootPath`               | Override the monorepo workspace root used by `@utoo/pack`.                      |

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -54,7 +54,17 @@ directories. For example, `<baseDir>/app/port/binary.html` is emitted as
 the copied file in bundle mode and continue to resolve to the original file in
 non-bundle mode. Static asset directories such as `app/public`, `app/assets`,
 and `app/static` are copied verbatim so frontend `.js` and `.css` files remain
-servable from the bundled app.
+servable from the bundled app. Applications may replace those force-copy
+directories with `bundle.runtimeAssets.forceCopyDirs` in `module.yml`, for
+example:
+
+```yaml
+bundle:
+  runtimeAssets:
+    forceCopyDirs:
+      - app/port
+      - app/public
+```
 
 ## `bundle-manifest.json`
 

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -44,11 +44,11 @@ may still use `fs` for resources such as config, views, or assets.
 
 ## Runtime assets
 
-The bundler copies application runtime assets from `<baseDir>/app` into the
-same relative path under `outputDir`, excluding manifest-known module files and
-source-like files such as `.js`, `.ts`, `.mjs`, and `.cjs` outside static asset
-directories. For example, `<baseDir>/app/port/binary.html` is emitted as
-`<outputDir>/app/port/binary.html`. Since bundled workers start Egg with
+The bundler copies application runtime assets from `<baseDir>/app` by default
+into the same relative path under `outputDir`, excluding manifest-known module
+files and source-like files such as `.js`, `.ts`, `.mjs`, and `.cjs` outside
+static asset directories. For example, `<baseDir>/app/port/binary.html` is
+emitted as `<outputDir>/app/port/binary.html`. Since bundled workers start Egg with
 `baseDir: outputDir`, existing reads such as
 `fs.readFile(path.join(app.config.baseDir, 'app/port/binary.html'))` resolve to
 the copied file in bundle mode and continue to resolve to the original file in
@@ -61,10 +61,16 @@ example:
 ```yaml
 bundle:
   runtimeAssets:
+    roots:
+      - app
     forceCopyDirs:
       - app/port
       - app/public
 ```
+
+Applications may also replace the scanned roots with
+`bundle.runtimeAssets.roots`. Root entries are baseDir-relative directories, and
+the output keeps the same baseDir-relative path.
 
 ## `bundle-manifest.json`
 

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -14,6 +14,8 @@ the chunks.
 ├── _root-of-the-server___<hash>.js.map
 ├── _turbopack__runtime.js             # @utoo/pack runtime shim
 ├── _turbopack__runtime.js.map
+├── app/port/binary.html               # app runtime asset copied from <baseDir>/app/port/binary.html
+├── app/port/login.html                # app runtime asset copied from <baseDir>/app/port/login.html
 ├── tsconfig.json                      # written by PackRunner; SWC reads decorator options from here
 ├── package.json                       # written by PackRunner; `{ "type": "commonjs" }` so node parses *.js as CJS
 └── bundle-manifest.json               # written by Bundler; reference / debug metadata
@@ -39,6 +41,20 @@ the deploy output directory separate from the original app paths: the bundle map
 is keyed by relKey, output-dir absolute paths, precomputed original app absolute
 paths, and manifest `resolveCache` request aliases. Application code and plugins
 may still use `fs` for resources such as config, views, or assets.
+
+## Runtime assets
+
+The bundler copies application runtime assets from `<baseDir>/app` into the
+same relative path under `outputDir`, excluding manifest-known module files and
+source-like files such as `.js`, `.ts`, `.mjs`, and `.cjs` outside static asset
+directories. For example, `<baseDir>/app/port/binary.html` is emitted as
+`<outputDir>/app/port/binary.html`. Since bundled workers start Egg with
+`baseDir: outputDir`, existing reads such as
+`fs.readFile(path.join(app.config.baseDir, 'app/port/binary.html'))` resolve to
+the copied file in bundle mode and continue to resolve to the original file in
+non-bundle mode. Static asset directories such as `app/public`, `app/assets`,
+and `app/static` are copied verbatim so frontend `.js` and `.css` files remain
+servable from the bundled app.
 
 ## `bundle-manifest.json`
 

--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -31,6 +31,8 @@ export interface BundlerPackConfig {
 }
 
 export interface BundlerRuntimeAssetsConfig {
+  /** BaseDir-relative directories scanned for runtime assets. Defaults to `['app']`. */
+  readonly roots?: readonly string[];
   /** Relative directories whose files should be copied even when they use source-like extensions. */
   readonly forceCopyDirs?: readonly string[];
 }

--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -30,6 +30,11 @@ export interface BundlerPackConfig {
   readonly resolve?: PackRunnerResolveConfig;
 }
 
+export interface BundlerRuntimeAssetsConfig {
+  /** Relative directories whose files should be copied even when they use source-like extensions. */
+  readonly forceCopyDirs?: readonly string[];
+}
+
 export interface BundlerConfig {
   /** Application root directory. Required. */
   readonly baseDir: string;
@@ -45,6 +50,8 @@ export interface BundlerConfig {
   readonly externals?: BundlerExternalsConfig;
   /** @utoo/pack tuning. */
   readonly pack?: BundlerPackConfig;
+  /** Runtime asset copy tuning. */
+  readonly runtimeAssets?: BundlerRuntimeAssetsConfig;
   /** Enable tegg decoratedFile collection. Defaults to `true`. */
   readonly tegg?: boolean;
 }

--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -39,6 +39,9 @@ const TURBOPACK_IMPORT_META_OBJECT =
 const LINE_SOURCE_MAP_URL = /(?:\r?\n)?\/\/# sourceMappingURL=([^\r\n]*)\s*$/;
 const BLOCK_SOURCE_MAP_URL = /(?:\r?\n)?\/\*# sourceMappingURL=([\s\S]*?)\*\/\s*$/;
 const UNSAFE_ALIAS_SPECIFIERS = new Set(['__proto__', 'constructor', 'prototype']);
+const RUNTIME_ASSET_ROOTS = ['app'];
+const FORCE_COPY_RUNTIME_ASSET_DIRS = ['app/public', 'app/assets', 'app/static'];
+const BUNDLED_SOURCE_EXTENSIONS = new Set(['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx']);
 
 type JsonRecord = Record<string, unknown>;
 
@@ -259,6 +262,11 @@ export class Bundler {
       patchResult.deletedMapCount,
     );
 
+    const runtimeAssets = await wrapStep('runtime asset copy', () =>
+      this.#copyRuntimeAssets(absBaseDir, absOutputDir, manifestLoader),
+    );
+    debug('copied %d runtime assets', runtimeAssets.length);
+
     // Merge project name into output package.json so the framework's
     // getAppname() finds it (it reads baseDir/package.json).
     const outputPkgPath = path.join(absOutputDir, 'package.json');
@@ -282,14 +290,14 @@ export class Bundler {
       framework,
       entries: [{ name: 'worker', source: entries.workerEntry }],
       externals: Object.keys(externalsMap).sort((a, b) => a.localeCompare(b)),
-      chunks: patchResult.outputFiles,
+      chunks: Array.from(new Set([...patchResult.outputFiles, ...runtimeAssets])).sort((a, b) => a.localeCompare(b)),
     };
     await wrapStep('write bundle-manifest', () =>
       fs.writeFile(manifestPathAbs, JSON.stringify(bundleManifest, null, 2)),
     );
 
     // Re-enumerate files so bundle-manifest.json is included in the result.
-    const finalRelFiles = new Set<string>(patchResult.outputFiles);
+    const finalRelFiles = new Set<string>(bundleManifest.chunks);
     finalRelFiles.add(BUNDLE_MANIFEST_FILENAME);
     const files = Array.from(finalRelFiles)
       .map((rel) => path.join(absOutputDir, rel))
@@ -300,6 +308,80 @@ export class Bundler {
       files,
       manifestPath: manifestPathAbs,
     };
+  }
+
+  async #copyRuntimeAssets(
+    baseDir: string,
+    outputDir: string,
+    manifestLoader: ManifestLoader,
+  ): Promise<readonly string[]> {
+    const copied = new Set<string>();
+    const bundledSourceFiles = new Set<string>();
+    for (const filepath of manifestLoader.getAllDiscoveredFiles()) {
+      bundledSourceFiles.add(filepath);
+    }
+    for (const filepath of manifestLoader.getTeggDecoratedFiles()) {
+      bundledSourceFiles.add(filepath);
+    }
+    for (const value of Object.values(manifestLoader.manifest.resolveCache)) {
+      if (typeof value === 'string') bundledSourceFiles.add(path.resolve(baseDir, value));
+    }
+
+    for (const root of RUNTIME_ASSET_ROOTS) {
+      const absRoot = path.join(baseDir, root);
+      await this.#copyRuntimeAssetsUnderRoot(baseDir, outputDir, absRoot, bundledSourceFiles, copied);
+    }
+
+    return Array.from(copied).sort((a, b) => a.localeCompare(b));
+  }
+
+  async #copyRuntimeAssetsUnderRoot(
+    baseDir: string,
+    outputDir: string,
+    dir: string,
+    bundledSourceFiles: ReadonlySet<string>,
+    copied: Set<string>,
+  ): Promise<void> {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw err;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const filepath = path.join(dir, entry.name);
+      if (this.#isInsideDir(outputDir, filepath)) continue;
+      // Dirent flags from withFileTypes are not followed here; symlinked app
+      // assets are skipped so a link cannot escape baseDir/app during copying.
+      if (entry.isSymbolicLink()) continue;
+      if (this.#shouldSkipRuntimeAssetEntry(entry.name)) continue;
+
+      if (entry.isDirectory()) {
+        await this.#copyRuntimeAssetsUnderRoot(baseDir, outputDir, filepath, bundledSourceFiles, copied);
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+      const rel = this.#sanitizeOutputRelativePath(path.relative(baseDir, filepath));
+      if (bundledSourceFiles.has(filepath) || !this.#shouldCopyRuntimeAsset(rel)) continue;
+
+      const target = path.join(outputDir, rel);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.copyFile(filepath, target);
+      copied.add(rel);
+    }
+  }
+
+  #shouldSkipRuntimeAssetEntry(name: string): boolean {
+    return name === 'node_modules' || name.startsWith('.');
+  }
+
+  #shouldCopyRuntimeAsset(rel: string): boolean {
+    if (FORCE_COPY_RUNTIME_ASSET_DIRS.some((dir) => rel === dir || rel.startsWith(`${dir}/`))) return true;
+    return !BUNDLED_SOURCE_EXTENSIONS.has(path.posix.extname(rel));
   }
 
   async #patchImportMetaOutput(

--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -39,7 +39,7 @@ const TURBOPACK_IMPORT_META_OBJECT =
 const LINE_SOURCE_MAP_URL = /(?:\r?\n)?\/\/# sourceMappingURL=([^\r\n]*)\s*$/;
 const BLOCK_SOURCE_MAP_URL = /(?:\r?\n)?\/\*# sourceMappingURL=([\s\S]*?)\*\/\s*$/;
 const UNSAFE_ALIAS_SPECIFIERS = new Set(['__proto__', 'constructor', 'prototype']);
-const RUNTIME_ASSET_ROOTS = ['app'];
+const DEFAULT_RUNTIME_ASSET_ROOTS = ['app'];
 const DEFAULT_FORCE_COPY_RUNTIME_ASSET_DIRS = ['app/public', 'app/assets', 'app/static'];
 const BUNDLED_SOURCE_EXTENSIONS = new Set(['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx']);
 
@@ -51,6 +51,7 @@ interface ModuleBundleConfig {
 }
 
 interface ResolvedRuntimeAssetsConfig {
+  readonly roots: readonly string[];
   readonly forceCopyDirs: readonly string[];
 }
 
@@ -94,20 +95,32 @@ function validateModulePackAliasSpecifier(filepath: string, specifier: string): 
   }
 }
 
-function normalizeRuntimeAssetForceCopyDir(filepath: string, dir: string): string {
+function normalizeRuntimeAssetDir(filepath: string, configPath: string, dir: string): string {
   let rel: string;
   try {
     rel = sanitizeBundleOutputRelativePath(dir);
   } catch (err) {
     throw new Error(
-      `Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs contains unsafe path ${JSON.stringify(dir)}.`,
+      `Invalid bundle config in ${filepath}: ${configPath} contains unsafe path ${JSON.stringify(dir)}.`,
       { cause: err },
     );
   }
   if (rel.endsWith('/')) {
-    throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs contains ${dir}.`);
+    throw new Error(`Invalid bundle config in ${filepath}: ${configPath} contains ${dir}.`);
   }
   return rel;
+}
+
+function normalizeRuntimeAssetRoot(filepath: string, root: string): string {
+  return normalizeRuntimeAssetDir(filepath, 'bundle.runtimeAssets.roots', root);
+}
+
+function normalizeRuntimeAssetRoots(filepath: string, roots: readonly string[]): readonly string[] {
+  return Array.from(new Set(roots.map((root) => normalizeRuntimeAssetRoot(filepath, root))));
+}
+
+function normalizeRuntimeAssetForceCopyDir(filepath: string, dir: string): string {
+  return normalizeRuntimeAssetDir(filepath, 'bundle.runtimeAssets.forceCopyDirs', dir);
 }
 
 function normalizeRuntimeAssetForceCopyDirs(filepath: string, dirs: readonly string[]): readonly string[] {
@@ -183,22 +196,44 @@ function parseModuleBundleRuntimeAssetsConfig(
     throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets must be an object.`);
   }
 
-  const forceCopyDirsConfig = runtimeAssetsConfig.forceCopyDirs;
-  if (forceCopyDirsConfig == null) return undefined;
-  if (!Array.isArray(forceCopyDirsConfig)) {
-    throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs must be an array.`);
+  const rootsConfig = runtimeAssetsConfig.roots;
+  let roots: readonly string[] | undefined;
+  if (rootsConfig != null) {
+    if (!Array.isArray(rootsConfig)) {
+      throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets.roots must be an array.`);
+    }
+    roots = rootsConfig.map((root, index) => {
+      if (typeof root !== 'string' || root.length === 0) {
+        throw new Error(
+          `Invalid bundle config in ${filepath}: bundle.runtimeAssets.roots[${index}] must be a non-empty string.`,
+        );
+      }
+      return normalizeRuntimeAssetRoot(filepath, root);
+    });
   }
 
-  const forceCopyDirs = forceCopyDirsConfig.map((dir, index) => {
-    if (typeof dir !== 'string' || dir.length === 0) {
-      throw new Error(
-        `Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs[${index}] must be a non-empty string.`,
-      );
+  const forceCopyDirsConfig = runtimeAssetsConfig.forceCopyDirs;
+  let forceCopyDirs: readonly string[] | undefined;
+  if (forceCopyDirsConfig != null) {
+    if (!Array.isArray(forceCopyDirsConfig)) {
+      throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs must be an array.`);
     }
-    return normalizeRuntimeAssetForceCopyDir(filepath, dir);
-  });
+    forceCopyDirs = forceCopyDirsConfig.map((dir, index) => {
+      if (typeof dir !== 'string' || dir.length === 0) {
+        throw new Error(
+          `Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs[${index}] must be a non-empty string.`,
+        );
+      }
+      return normalizeRuntimeAssetForceCopyDir(filepath, dir);
+    });
+  }
 
-  return { forceCopyDirs: normalizeRuntimeAssetForceCopyDirs(filepath, forceCopyDirs) };
+  if (roots == null && forceCopyDirs == null) return undefined;
+
+  return {
+    ...(roots == null ? {} : { roots: normalizeRuntimeAssetRoots(filepath, roots) }),
+    ...(forceCopyDirs == null ? {} : { forceCopyDirs: normalizeRuntimeAssetForceCopyDirs(filepath, forceCopyDirs) }),
+  };
 }
 
 async function loadModuleBundleConfig(baseDir: string): Promise<ModuleBundleConfig | undefined> {
@@ -248,10 +283,12 @@ function mergeRuntimeAssetsConfig(
   moduleRuntimeAssets: BundlerConfig['runtimeAssets'],
   explicitRuntimeAssets: BundlerConfig['runtimeAssets'],
 ): ResolvedRuntimeAssetsConfig {
+  const roots = explicitRuntimeAssets?.roots ?? moduleRuntimeAssets?.roots ?? DEFAULT_RUNTIME_ASSET_ROOTS;
   const forceCopyDirs =
     explicitRuntimeAssets?.forceCopyDirs ?? moduleRuntimeAssets?.forceCopyDirs ?? DEFAULT_FORCE_COPY_RUNTIME_ASSET_DIRS;
 
   return {
+    roots: normalizeRuntimeAssetRoots('BundlerConfig', roots),
     forceCopyDirs: normalizeRuntimeAssetForceCopyDirs('BundlerConfig', forceCopyDirs),
   };
 }
@@ -414,7 +451,7 @@ export class Bundler {
       if (typeof value === 'string') bundledSourceFiles.add(path.resolve(baseDir, value));
     }
 
-    for (const root of RUNTIME_ASSET_ROOTS) {
+    for (const root of runtimeAssetsConfig.roots) {
       const absRoot = path.join(baseDir, root);
       await this.#copyRuntimeAssetsUnderRoot(
         baseDir,

--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -40,10 +40,19 @@ const LINE_SOURCE_MAP_URL = /(?:\r?\n)?\/\/# sourceMappingURL=([^\r\n]*)\s*$/;
 const BLOCK_SOURCE_MAP_URL = /(?:\r?\n)?\/\*# sourceMappingURL=([\s\S]*?)\*\/\s*$/;
 const UNSAFE_ALIAS_SPECIFIERS = new Set(['__proto__', 'constructor', 'prototype']);
 const RUNTIME_ASSET_ROOTS = ['app'];
-const FORCE_COPY_RUNTIME_ASSET_DIRS = ['app/public', 'app/assets', 'app/static'];
+const DEFAULT_FORCE_COPY_RUNTIME_ASSET_DIRS = ['app/public', 'app/assets', 'app/static'];
 const BUNDLED_SOURCE_EXTENSIONS = new Set(['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx']);
 
 type JsonRecord = Record<string, unknown>;
+
+interface ModuleBundleConfig {
+  readonly pack?: BundlerConfig['pack'];
+  readonly runtimeAssets?: BundlerConfig['runtimeAssets'];
+}
+
+interface ResolvedRuntimeAssetsConfig {
+  readonly forceCopyDirs: readonly string[];
+}
 
 interface BundleManifest {
   readonly version: number;
@@ -85,7 +94,31 @@ function validateModulePackAliasSpecifier(filepath: string, specifier: string): 
   }
 }
 
-function parseModuleBundlePackConfig(filepath: string, baseDir: string, rawConfig: unknown): BundlerConfig['pack'] {
+function normalizeRuntimeAssetForceCopyDir(filepath: string, dir: string): string {
+  let rel: string;
+  try {
+    rel = sanitizeBundleOutputRelativePath(dir);
+  } catch (err) {
+    throw new Error(
+      `Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs contains unsafe path ${JSON.stringify(dir)}.`,
+      { cause: err },
+    );
+  }
+  if (rel.endsWith('/')) {
+    throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs contains ${dir}.`);
+  }
+  return rel;
+}
+
+function normalizeRuntimeAssetForceCopyDirs(filepath: string, dirs: readonly string[]): readonly string[] {
+  return Array.from(new Set(dirs.map((dir) => normalizeRuntimeAssetForceCopyDir(filepath, dir))));
+}
+
+function parseModuleBundleConfig(
+  filepath: string,
+  baseDir: string,
+  rawConfig: unknown,
+): ModuleBundleConfig | undefined {
   if (rawConfig == null) return undefined;
   if (!isRecord(rawConfig)) {
     throw new Error(`Invalid bundle config in ${filepath}: module.yml must contain an object.`);
@@ -97,6 +130,17 @@ function parseModuleBundlePackConfig(filepath: string, baseDir: string, rawConfi
     throw new Error(`Invalid bundle config in ${filepath}: bundle must be an object.`);
   }
 
+  return {
+    pack: parseModuleBundlePackConfig(filepath, baseDir, bundleConfig),
+    runtimeAssets: parseModuleBundleRuntimeAssetsConfig(filepath, bundleConfig),
+  };
+}
+
+function parseModuleBundlePackConfig(
+  filepath: string,
+  baseDir: string,
+  bundleConfig: JsonRecord,
+): BundlerConfig['pack'] {
   const packConfig = bundleConfig.pack;
   if (packConfig == null) return undefined;
   if (!isRecord(packConfig)) {
@@ -129,7 +173,35 @@ function parseModuleBundlePackConfig(filepath: string, baseDir: string, rawConfi
   return Object.keys(alias).length > 0 ? { resolve: { alias } } : undefined;
 }
 
-async function loadModuleBundlePackConfig(baseDir: string): Promise<BundlerConfig['pack']> {
+function parseModuleBundleRuntimeAssetsConfig(
+  filepath: string,
+  bundleConfig: JsonRecord,
+): BundlerConfig['runtimeAssets'] {
+  const runtimeAssetsConfig = bundleConfig.runtimeAssets;
+  if (runtimeAssetsConfig == null) return undefined;
+  if (!isRecord(runtimeAssetsConfig)) {
+    throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets must be an object.`);
+  }
+
+  const forceCopyDirsConfig = runtimeAssetsConfig.forceCopyDirs;
+  if (forceCopyDirsConfig == null) return undefined;
+  if (!Array.isArray(forceCopyDirsConfig)) {
+    throw new Error(`Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs must be an array.`);
+  }
+
+  const forceCopyDirs = forceCopyDirsConfig.map((dir, index) => {
+    if (typeof dir !== 'string' || dir.length === 0) {
+      throw new Error(
+        `Invalid bundle config in ${filepath}: bundle.runtimeAssets.forceCopyDirs[${index}] must be a non-empty string.`,
+      );
+    }
+    return normalizeRuntimeAssetForceCopyDir(filepath, dir);
+  });
+
+  return { forceCopyDirs: normalizeRuntimeAssetForceCopyDirs(filepath, forceCopyDirs) };
+}
+
+async function loadModuleBundleConfig(baseDir: string): Promise<ModuleBundleConfig | undefined> {
   const filepath = path.join(baseDir, 'module.yml');
   let content: string;
   try {
@@ -148,7 +220,7 @@ async function loadModuleBundlePackConfig(baseDir: string): Promise<BundlerConfi
     throw new Error(`Unable to parse ${filepath}: ${getErrorMessage(err)}`, { cause: err });
   }
 
-  return parseModuleBundlePackConfig(filepath, baseDir, rawConfig);
+  return parseModuleBundleConfig(filepath, baseDir, rawConfig);
 }
 
 function mergePackConfig(
@@ -169,6 +241,18 @@ function mergePackConfig(
   return {
     ...explicitPack,
     ...(Object.keys(resolve).length > 0 ? { resolve } : {}),
+  };
+}
+
+function mergeRuntimeAssetsConfig(
+  moduleRuntimeAssets: BundlerConfig['runtimeAssets'],
+  explicitRuntimeAssets: BundlerConfig['runtimeAssets'],
+): ResolvedRuntimeAssetsConfig {
+  const forceCopyDirs =
+    explicitRuntimeAssets?.forceCopyDirs ?? moduleRuntimeAssets?.forceCopyDirs ?? DEFAULT_FORCE_COPY_RUNTIME_ASSET_DIRS;
+
+  return {
+    forceCopyDirs: normalizeRuntimeAssetForceCopyDirs('BundlerConfig', forceCopyDirs),
   };
 }
 
@@ -204,16 +288,16 @@ export class Bundler {
       mode = 'production',
       externals,
       pack,
+      runtimeAssets,
     } = this.#config;
 
     const absBaseDir = path.resolve(baseDir);
     const absOutputDir = path.resolve(absBaseDir, rawOutputDir);
     assertFrameworkPackageSpecifier(framework);
     debug('bundle start: baseDir=%s outputDir=%s framework=%s mode=%s', absBaseDir, absOutputDir, framework, mode);
-    const mergedPack = mergePackConfig(
-      await wrapStep('module.yml bundle config load', () => loadModuleBundlePackConfig(absBaseDir)),
-      pack,
-    );
+    const moduleConfig = await wrapStep('module.yml bundle config load', () => loadModuleBundleConfig(absBaseDir));
+    const mergedPack = mergePackConfig(moduleConfig?.pack, pack);
+    const mergedRuntimeAssets = mergeRuntimeAssetsConfig(moduleConfig?.runtimeAssets, runtimeAssets);
 
     const manifestLoader = new ManifestLoader({
       baseDir: absBaseDir,
@@ -262,10 +346,10 @@ export class Bundler {
       patchResult.deletedMapCount,
     );
 
-    const runtimeAssets = await wrapStep('runtime asset copy', () =>
-      this.#copyRuntimeAssets(absBaseDir, absOutputDir, manifestLoader),
+    const copiedRuntimeAssets = await wrapStep('runtime asset copy', () =>
+      this.#copyRuntimeAssets(absBaseDir, absOutputDir, manifestLoader, mergedRuntimeAssets),
     );
-    debug('copied %d runtime assets', runtimeAssets.length);
+    debug('copied %d runtime assets', copiedRuntimeAssets.length);
 
     // Merge project name into output package.json so the framework's
     // getAppname() finds it (it reads baseDir/package.json).
@@ -290,7 +374,9 @@ export class Bundler {
       framework,
       entries: [{ name: 'worker', source: entries.workerEntry }],
       externals: Object.keys(externalsMap).sort((a, b) => a.localeCompare(b)),
-      chunks: Array.from(new Set([...patchResult.outputFiles, ...runtimeAssets])).sort((a, b) => a.localeCompare(b)),
+      chunks: Array.from(new Set([...patchResult.outputFiles, ...copiedRuntimeAssets])).sort((a, b) =>
+        a.localeCompare(b),
+      ),
     };
     await wrapStep('write bundle-manifest', () =>
       fs.writeFile(manifestPathAbs, JSON.stringify(bundleManifest, null, 2)),
@@ -314,6 +400,7 @@ export class Bundler {
     baseDir: string,
     outputDir: string,
     manifestLoader: ManifestLoader,
+    runtimeAssetsConfig: ResolvedRuntimeAssetsConfig,
   ): Promise<readonly string[]> {
     const copied = new Set<string>();
     const bundledSourceFiles = new Set<string>();
@@ -329,7 +416,14 @@ export class Bundler {
 
     for (const root of RUNTIME_ASSET_ROOTS) {
       const absRoot = path.join(baseDir, root);
-      await this.#copyRuntimeAssetsUnderRoot(baseDir, outputDir, absRoot, bundledSourceFiles, copied);
+      await this.#copyRuntimeAssetsUnderRoot(
+        baseDir,
+        outputDir,
+        absRoot,
+        bundledSourceFiles,
+        copied,
+        runtimeAssetsConfig,
+      );
     }
 
     return Array.from(copied).sort((a, b) => a.localeCompare(b));
@@ -341,6 +435,7 @@ export class Bundler {
     dir: string,
     bundledSourceFiles: ReadonlySet<string>,
     copied: Set<string>,
+    runtimeAssetsConfig: ResolvedRuntimeAssetsConfig,
   ): Promise<void> {
     let entries: import('node:fs').Dirent[];
     try {
@@ -360,13 +455,20 @@ export class Bundler {
       if (this.#shouldSkipRuntimeAssetEntry(entry.name)) continue;
 
       if (entry.isDirectory()) {
-        await this.#copyRuntimeAssetsUnderRoot(baseDir, outputDir, filepath, bundledSourceFiles, copied);
+        await this.#copyRuntimeAssetsUnderRoot(
+          baseDir,
+          outputDir,
+          filepath,
+          bundledSourceFiles,
+          copied,
+          runtimeAssetsConfig,
+        );
         continue;
       }
 
       if (!entry.isFile()) continue;
       const rel = this.#sanitizeOutputRelativePath(path.relative(baseDir, filepath));
-      if (bundledSourceFiles.has(filepath) || !this.#shouldCopyRuntimeAsset(rel)) continue;
+      if (bundledSourceFiles.has(filepath) || !this.#shouldCopyRuntimeAsset(rel, runtimeAssetsConfig)) continue;
 
       const target = path.join(outputDir, rel);
       await fs.mkdir(path.dirname(target), { recursive: true });
@@ -379,8 +481,8 @@ export class Bundler {
     return name === 'node_modules' || name.startsWith('.');
   }
 
-  #shouldCopyRuntimeAsset(rel: string): boolean {
-    if (FORCE_COPY_RUNTIME_ASSET_DIRS.some((dir) => rel === dir || rel.startsWith(`${dir}/`))) return true;
+  #shouldCopyRuntimeAsset(rel: string, runtimeAssetsConfig: ResolvedRuntimeAssetsConfig): boolean {
+    if (runtimeAssetsConfig.forceCopyDirs.some((dir) => rel === dir || rel.startsWith(`${dir}/`))) return true;
     return !BUNDLED_SOURCE_EXTENSIONS.has(path.posix.extname(rel));
   }
 

--- a/tools/egg-bundler/test/Bundler.test.ts
+++ b/tools/egg-bundler/test/Bundler.test.ts
@@ -242,6 +242,25 @@ describe('Bundler', () => {
     ).rejects.toThrow(/module\.yml bundle config load failed: .*bundle\.pack\.resolve\.alias\.invalid-target/);
   });
 
+  it('throws a clear error when module.yml runtime asset force-copy dirs config is invalid', async () => {
+    await fs.writeFile(
+      path.join(tmpApp, 'module.yml'),
+      ['bundle:', '  runtimeAssets:', '    forceCopyDirs:', '      - ../secret'].join('\n'),
+    );
+
+    await expect(
+      bundle({
+        baseDir: tmpApp,
+        outputDir: tmpOutput,
+        pack: {
+          buildFunc: async () => {
+            await fs.writeFile(path.join(tmpOutput, 'worker.js'), '// worker\n');
+          },
+        },
+      }),
+    ).rejects.toThrow(/module\.yml bundle config load failed: .*bundle\.runtimeAssets\.forceCopyDirs/);
+  });
+
   it('rejects prototype-polluting module.yml bundle alias specifiers', async () => {
     await fs.writeFile(
       path.join(tmpApp, 'module.yml'),

--- a/tools/egg-bundler/test/Bundler.test.ts
+++ b/tools/egg-bundler/test/Bundler.test.ts
@@ -261,6 +261,25 @@ describe('Bundler', () => {
     ).rejects.toThrow(/module\.yml bundle config load failed: .*bundle\.runtimeAssets\.forceCopyDirs/);
   });
 
+  it('throws a clear error when module.yml runtime asset roots config is invalid', async () => {
+    await fs.writeFile(
+      path.join(tmpApp, 'module.yml'),
+      ['bundle:', '  runtimeAssets:', '    roots:', '      - ../secret'].join('\n'),
+    );
+
+    await expect(
+      bundle({
+        baseDir: tmpApp,
+        outputDir: tmpOutput,
+        pack: {
+          buildFunc: async () => {
+            await fs.writeFile(path.join(tmpOutput, 'worker.js'), '// worker\n');
+          },
+        },
+      }),
+    ).rejects.toThrow(/module\.yml bundle config load failed: .*bundle\.runtimeAssets\.roots/);
+  });
+
   it('rejects prototype-polluting module.yml bundle alias specifiers', async () => {
     await fs.writeFile(
       path.join(tmpApp, 'module.yml'),

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -533,6 +533,48 @@ const __dirname = "/generated/shadow";
       ]),
     );
   });
+
+  it('uses module.yml bundle.runtimeAssets.roots to choose runtime asset scan roots', async () => {
+    await fs.writeFile(
+      path.join(tmpApp, 'module.yml'),
+      [
+        'bundle:',
+        '  runtimeAssets:',
+        '    roots:',
+        '      - resources',
+        '    forceCopyDirs:',
+        '      - resources/port',
+      ].join('\n'),
+    );
+    await fs.mkdir(path.join(tmpApp, 'resources/port'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'resources/port/login.html'), '<html>login</html>\n');
+    await fs.writeFile(path.join(tmpApp, 'resources/port/helper.ts'), 'export const helper = true;\n');
+    await fs.mkdir(path.join(tmpApp, 'app/port'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/port/binary.html'), '<html>binary</html>\n');
+
+    const result = await bundle({
+      baseDir: tmpApp,
+      outputDir: tmpOutput,
+      pack: { buildFunc: makeMockBuild() },
+    });
+
+    await expect(fs.readFile(path.join(tmpOutput, 'resources/port/login.html'), 'utf8')).resolves.toBe(
+      '<html>login</html>\n',
+    );
+    await expect(fs.readFile(path.join(tmpOutput, 'resources/port/helper.ts'), 'utf8')).resolves.toBe(
+      'export const helper = true;\n',
+    );
+    await expect(fs.stat(path.join(tmpOutput, 'app/port/binary.html'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const bm = JSON.parse(await fs.readFile(result.manifestPath, 'utf8')) as { chunks: string[] };
+    expect(bm.chunks).toEqual(expect.arrayContaining(['resources/port/helper.ts', 'resources/port/login.html']));
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        path.join(tmpOutput, 'resources/port/helper.ts'),
+        path.join(tmpOutput, 'resources/port/login.html'),
+      ]),
+    );
+  });
 });
 
 describe('bundle() integration — minimal-app (Phase 2: real @utoo/pack)', () => {

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -498,6 +498,41 @@ const __dirname = "/generated/shadow";
       '<html>binary</html>\n',
     );
   });
+
+  it('uses module.yml bundle.runtimeAssets.forceCopyDirs to force-copy source-like assets', async () => {
+    await fs.writeFile(
+      path.join(tmpApp, 'module.yml'),
+      ['bundle:', '  runtimeAssets:', '    forceCopyDirs:', '      - app/port'].join('\n'),
+    );
+    await fs.mkdir(path.join(tmpApp, 'app/port'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/port/helper.ts'), 'export const helper = true;\n');
+    await fs.writeFile(path.join(tmpApp, 'app/port/binary.html'), '<html>binary</html>\n');
+    await fs.mkdir(path.join(tmpApp, 'app/public'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/public/client.js'), 'globalThis.clientAsset = true;\n');
+
+    const result = await bundle({
+      baseDir: tmpApp,
+      outputDir: tmpOutput,
+      pack: { buildFunc: makeMockBuild() },
+    });
+
+    await expect(fs.readFile(path.join(tmpOutput, 'app/port/helper.ts'), 'utf8')).resolves.toBe(
+      'export const helper = true;\n',
+    );
+    await expect(fs.readFile(path.join(tmpOutput, 'app/port/binary.html'), 'utf8')).resolves.toBe(
+      '<html>binary</html>\n',
+    );
+    await expect(fs.stat(path.join(tmpOutput, 'app/public/client.js'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const bm = JSON.parse(await fs.readFile(result.manifestPath, 'utf8')) as { chunks: string[] };
+    expect(bm.chunks).toEqual(expect.arrayContaining(['app/port/binary.html', 'app/port/helper.ts']));
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        path.join(tmpOutput, 'app/port/binary.html'),
+        path.join(tmpOutput, 'app/port/helper.ts'),
+      ]),
+    );
+  });
 });
 
 describe('bundle() integration — minimal-app (Phase 2: real @utoo/pack)', () => {

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -433,6 +433,71 @@ const __dirname = "/generated/shadow";
     expect(entrySource).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(entrySource).toContain('startEgg');
   });
+
+  it('copies app runtime assets next to the bundle while preserving baseDir-relative readFile paths', async () => {
+    await fs.mkdir(path.join(tmpApp, 'app/port'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/port/binary.html'), '<html>binary</html>\n');
+    await fs.writeFile(path.join(tmpApp, 'app/port/login.html'), '<html>login</html>\n');
+    await fs.writeFile(path.join(tmpApp, 'app/port/helper.ts'), 'export const helper = true;\n');
+    await fs.mkdir(path.join(tmpApp, 'app/public'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/public/client.js'), 'globalThis.clientAsset = true;\n');
+    await fs.writeFile(path.join(tmpApp, 'app/public/app.ts'), 'export const publicAsset = true;\n');
+    await fs.mkdir(path.join(tmpApp, 'app/controller'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/controller/home.ts'), 'export {};\n');
+    await fs.mkdir(path.join(tmpApp, 'app/public/node_modules/ignored'), { recursive: true });
+    await fs.writeFile(path.join(tmpApp, 'app/.env'), 'TOKEN=secret\n');
+    await fs.writeFile(path.join(tmpApp, 'app/public/.hidden'), 'secret\n');
+    await fs.writeFile(path.join(tmpApp, 'app/public/node_modules/ignored/client.js'), 'globalThis.ignored = true;\n');
+
+    const result = await bundle({
+      baseDir: tmpApp,
+      outputDir: tmpOutput,
+      pack: { buildFunc: makeMockBuild() },
+    });
+
+    await expect(fs.readFile(path.join(tmpOutput, 'app/port/binary.html'), 'utf8')).resolves.toBe(
+      '<html>binary</html>\n',
+    );
+    await expect(fs.readFile(path.join(tmpOutput, 'app/port/login.html'), 'utf8')).resolves.toBe(
+      '<html>login</html>\n',
+    );
+    await expect(fs.readFile(path.join(tmpOutput, 'app/public/client.js'), 'utf8')).resolves.toBe(
+      'globalThis.clientAsset = true;\n',
+    );
+    await expect(fs.readFile(path.join(tmpOutput, 'app/public/app.ts'), 'utf8')).resolves.toBe(
+      'export const publicAsset = true;\n',
+    );
+    await expect(fs.stat(path.join(tmpOutput, 'app/controller/home.ts'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(path.join(tmpOutput, 'app/port/helper.ts'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(path.join(tmpOutput, 'app/.env'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(path.join(tmpOutput, 'app/public/.hidden'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(path.join(tmpOutput, 'app/public/node_modules'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const bm = JSON.parse(await fs.readFile(result.manifestPath, 'utf8')) as { chunks: string[] };
+    expect(bm.chunks).toEqual(
+      expect.arrayContaining([
+        'app/port/binary.html',
+        'app/port/login.html',
+        'app/public/app.ts',
+        'app/public/client.js',
+      ]),
+    );
+    expect(result.files).toEqual(
+      expect.arrayContaining([
+        path.join(tmpOutput, 'app/port/binary.html'),
+        path.join(tmpOutput, 'app/port/login.html'),
+        path.join(tmpOutput, 'app/public/app.ts'),
+        path.join(tmpOutput, 'app/public/client.js'),
+      ]),
+    );
+
+    // Non-bundle mode keeps using the original app baseDir; bundle mode uses
+    // outputDir as baseDir, and the copied asset keeps the same relative path.
+    await expect(fs.readFile(path.join(tmpApp, 'app/port/binary.html'), 'utf8')).resolves.toBe('<html>binary</html>\n');
+    await expect(fs.readFile(path.join(tmpOutput, 'app/port/binary.html'), 'utf8')).resolves.toBe(
+      '<html>binary</html>\n',
+    );
+  });
 });
 
 describe('bundle() integration — minimal-app (Phase 2: real @utoo/pack)', () => {


### PR DESCRIPTION
## Summary
- Copy non-source runtime assets under app into the bundle output with the same baseDir-relative paths.
- Preserve source-module exclusion while copying static asset directories such as app/public verbatim.
- Cover app/port/*.html assets and document bundle/non-bundle readFile behavior.

## Tests
- pnpm --filter @eggjs/egg-bundler test -- integration.test.ts
- pnpm --filter @eggjs/egg-bundler typecheck
- pnpm --filter @eggjs/egg-bundler lint
- pnpm exec oxfmt --check tools/egg-bundler/src/lib/Bundler.ts tools/egg-bundler/test/integration.test.ts tools/egg-bundler/docs/output-structure.md
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime assets are copied into the bundle output and listed in the final manifest; a new runtimeAssets config (with roots and forceCopyDirs) controls which app files are preserved.

* **Documentation**
  * README and docs updated with a "Runtime assets" section, examples, and option descriptions for runtimeAssets.roots and runtimeAssets.forceCopyDirs.

* **Tests**
  * Added integration and validation tests for asset copying, manifest inclusion, content preservation, and invalid runtimeAssets config errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->