### PR TITLE
feat(core): add loader fs abstraction

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from './singleton.ts';
 export * from './loader/egg_loader.ts';
 export * from './loader/file_loader.ts';
 export * from './loader/context_loader.ts';
+export * from './loader/loader_fs.ts';
 export * from './loader/manifest.ts';
 export * from './utils/sequencify.ts';
 export * from './utils/timing.ts';

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -13,7 +13,7 @@ import { isAsyncFunction, isClass, isGeneratorFunction, isObject, isPromise } fr
 import { homedir } from 'node-homedir';
 import { now, diff } from 'performance-ms';
 import { register as tsconfigPathsRegister } from 'tsconfig-paths';
-import { getParamNames, exists } from 'utility';
+import { getParamNames, readJSONSync, readJSON, exists } from 'utility';
 
 import type { BaseContextClass } from '../base_context_class.ts';
 import type { Context, EggCore, MiddlewareFunc } from '../egg.ts';
@@ -96,7 +96,7 @@ export class EggLoader {
   constructor(options: EggLoaderOptions) {
     this.options = options;
     this.loaderFS = this.options.loaderFS ?? new RealLoaderFS();
-    assert(this.loaderFS.exists(this.options.baseDir), `${this.options.baseDir} not exists`);
+    assert(fs.existsSync(this.options.baseDir), `${this.options.baseDir} not exists`);
     assert(this.options.app, 'options.app is required');
     assert(this.options.logger, 'options.logger is required');
 
@@ -107,7 +107,7 @@ export class EggLoader {
      * @see {@link AppInfo#pkg}
      * @since 1.0.0
      */
-    this.pkg = this.loaderFS.readJSON(path.join(this.options.baseDir, 'package.json'));
+    this.pkg = readJSONSync(path.join(this.options.baseDir, 'package.json'));
     this.outDir = this.#resolveOutDir();
 
     // auto require('tsconfig-paths/register') on typescript app
@@ -115,7 +115,7 @@ export class EggLoader {
     if (process.env.EGG_TYPESCRIPT === 'true' || (this.pkg.egg && this.pkg.egg.typescript)) {
       // skip require tsconfig-paths if tsconfig.json not exists
       const tsConfigFile = path.join(this.options.baseDir, 'tsconfig.json');
-      if (this.loaderFS.exists(tsConfigFile)) {
+      if (fs.existsSync(tsConfigFile)) {
         // @ts-expect-error only cwd is required
         tsconfigPathsRegister({ cwd: this.options.baseDir });
       } else {
@@ -378,8 +378,8 @@ export class EggLoader {
         );
       }
       assert(typeof eggPath === 'string', "Symbol.for('egg#eggPath') should be string");
-      assert(this.loaderFS.exists(eggPath), `${eggPath} not exists`);
-      const realpath = this.loaderFS.realpath(eggPath);
+      assert(fs.existsSync(eggPath), `${eggPath} not exists`);
+      const realpath = fs.realpathSync(eggPath);
       if (!eggPaths.includes(realpath)) {
         eggPaths.unshift(realpath);
       }
@@ -594,7 +594,7 @@ export class EggLoader {
         continue;
       }
 
-      const config: Record<string, EggPluginInfo> = await this.loaderFS.loadFile(filepath);
+      const config: Record<string, EggPluginInfo> = await utils.loadFile(filepath);
       for (const name in config) {
         this.#normalizePluginConfig(config, name, filepath);
       }
@@ -644,8 +644,8 @@ export class EggLoader {
     let pkg: any;
     let eggPluginConfig: any;
     const pluginPackage = path.join(plugin.path as string, 'package.json');
-    if (this.loaderFS.exists(pluginPackage)) {
-      pkg = this.loaderFS.readJSON(pluginPackage);
+    if (await utils.existsPath(pluginPackage)) {
+      pkg = await readJSON(pluginPackage);
       eggPluginConfig = pkg.eggPlugin;
       if (pkg.version) {
         plugin.version = pkg.version;
@@ -1585,7 +1585,7 @@ export class EggLoader {
   async requireFile(filepath: string): Promise<any> {
     const timingKey = `Require(${this.#requiredCount++}) ${utils.getResolvedFilename(filepath, this.options.baseDir)}`;
     this.timing.start(timingKey);
-    const mod = await this.loaderFS.loadFile(filepath);
+    const mod = await utils.loadFile(filepath);
     this.timing.end(timingKey);
     return mod;
   }

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -13,7 +13,7 @@ import { isAsyncFunction, isClass, isGeneratorFunction, isObject, isPromise } fr
 import { homedir } from 'node-homedir';
 import { now, diff } from 'performance-ms';
 import { register as tsconfigPathsRegister } from 'tsconfig-paths';
-import { getParamNames, readJSONSync, readJSON, exists } from 'utility';
+import { getParamNames, readJSONSync, exists } from 'utility';
 
 import type { BaseContextClass } from '../base_context_class.ts';
 import type { Context, EggCore, MiddlewareFunc } from '../egg.ts';
@@ -24,6 +24,7 @@ import { sequencify } from '../utils/sequencify.ts';
 import { Timing } from '../utils/timing.ts';
 import { type ContextLoaderOptions, ContextLoader } from './context_loader.ts';
 import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';
+import { RealLoaderFS, type LoaderFS } from './loader_fs.ts';
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
@@ -57,6 +58,8 @@ export interface EggLoaderOptions {
   plugins?: Record<string, EggPluginInfo>;
   /** Skip lifecycle hooks, only trigger loadMetadata for manifest generation */
   metadataOnly?: boolean;
+  /** Loader-facing filesystem abstraction */
+  loaderFS?: LoaderFS;
 }
 
 export type EggDirInfoType = 'app' | 'plugin' | 'framework';
@@ -79,6 +82,7 @@ export class EggLoader {
   dirs?: EggDirInfo[];
   /** Startup manifest — loaded from cache or collecting for generation */
   readonly manifest: ManifestStore;
+  readonly loaderFS: LoaderFS;
 
   /**
    * @class
@@ -91,7 +95,8 @@ export class EggLoader {
    */
   constructor(options: EggLoaderOptions) {
     this.options = options;
-    assert(fs.existsSync(this.options.baseDir), `${this.options.baseDir} not exists`);
+    this.loaderFS = this.options.loaderFS ?? new RealLoaderFS();
+    assert(this.loaderFS.exists(this.options.baseDir), `${this.options.baseDir} not exists`);
     assert(this.options.app, 'options.app is required');
     assert(this.options.logger, 'options.logger is required');
 
@@ -110,7 +115,7 @@ export class EggLoader {
     if (process.env.EGG_TYPESCRIPT === 'true' || (this.pkg.egg && this.pkg.egg.typescript)) {
       // skip require tsconfig-paths if tsconfig.json not exists
       const tsConfigFile = path.join(this.options.baseDir, 'tsconfig.json');
-      if (fs.existsSync(tsConfigFile)) {
+      if (this.loaderFS.exists(tsConfigFile)) {
         // @ts-expect-error only cwd is required
         tsconfigPathsRegister({ cwd: this.options.baseDir });
       } else {
@@ -373,8 +378,8 @@ export class EggLoader {
         );
       }
       assert(typeof eggPath === 'string', "Symbol.for('egg#eggPath') should be string");
-      assert(fs.existsSync(eggPath), `${eggPath} not exists`);
-      const realpath = fs.realpathSync(eggPath);
+      assert(this.loaderFS.exists(eggPath), `${eggPath} not exists`);
+      const realpath = this.loaderFS.realpath(eggPath);
       if (!eggPaths.includes(realpath)) {
         eggPaths.unshift(realpath);
       }
@@ -589,7 +594,7 @@ export class EggLoader {
         continue;
       }
 
-      const config: Record<string, EggPluginInfo> = await utils.loadFile(filepath);
+      const config: Record<string, EggPluginInfo> = await this.loaderFS.loadFile(filepath);
       for (const name in config) {
         this.#normalizePluginConfig(config, name, filepath);
       }
@@ -639,8 +644,8 @@ export class EggLoader {
     let pkg: any;
     let eggPluginConfig: any;
     const pluginPackage = path.join(plugin.path as string, 'package.json');
-    if (await utils.existsPath(pluginPackage)) {
-      pkg = await readJSON(pluginPackage);
+    if (this.loaderFS.exists(pluginPackage)) {
+      pkg = await this.loaderFS.readJSON(pluginPackage);
       eggPluginConfig = pkg.eggPlugin;
       if (pkg.version) {
         plugin.version = pkg.version;
@@ -1580,7 +1585,7 @@ export class EggLoader {
   async requireFile(filepath: string): Promise<any> {
     const timingKey = `Require(${this.#requiredCount++}) ${utils.getResolvedFilename(filepath, this.options.baseDir)}`;
     this.timing.start(timingKey);
-    const mod = await utils.loadFile(filepath);
+    const mod = await this.loaderFS.loadFile(filepath);
     this.timing.end(timingKey);
     return mod;
   }
@@ -1653,6 +1658,7 @@ export class EggLoader {
       target,
       inject: this.app,
       manifest: this.manifest,
+      loaderFS: options?.loaderFS ?? this.loaderFS,
     };
 
     const timingKey = `Load "${String(property)}" to Application`;
@@ -1679,6 +1685,7 @@ export class EggLoader {
       property,
       inject: this.app,
       manifest: this.manifest,
+      loaderFS: options?.loaderFS ?? this.loaderFS,
     };
 
     const timingKey = `Load "${String(property)}" to Context`;

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -13,7 +13,7 @@ import { isAsyncFunction, isClass, isGeneratorFunction, isObject, isPromise } fr
 import { homedir } from 'node-homedir';
 import { now, diff } from 'performance-ms';
 import { register as tsconfigPathsRegister } from 'tsconfig-paths';
-import { getParamNames, readJSONSync, exists } from 'utility';
+import { getParamNames, exists } from 'utility';
 
 import type { BaseContextClass } from '../base_context_class.ts';
 import type { Context, EggCore, MiddlewareFunc } from '../egg.ts';
@@ -107,7 +107,7 @@ export class EggLoader {
      * @see {@link AppInfo#pkg}
      * @since 1.0.0
      */
-    this.pkg = readJSONSync(path.join(this.options.baseDir, 'package.json'));
+    this.pkg = this.loaderFS.readJSON(path.join(this.options.baseDir, 'package.json'));
     this.outDir = this.#resolveOutDir();
 
     // auto require('tsconfig-paths/register') on typescript app
@@ -645,7 +645,7 @@ export class EggLoader {
     let eggPluginConfig: any;
     const pluginPackage = path.join(plugin.path as string, 'package.json');
     if (this.loaderFS.exists(pluginPackage)) {
-      pkg = await this.loaderFS.readJSON(pluginPackage);
+      pkg = this.loaderFS.readJSON(pluginPackage);
       eggPluginConfig = pkg.eggPlugin;
       if (pkg.version) {
         plugin.version = pkg.version;

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -1,13 +1,12 @@
 import assert from 'node:assert';
-import fs from 'node:fs';
 import path from 'node:path';
 import { debuglog } from 'node:util';
 
 import { isSupportTypeScript } from '@eggjs/utils';
-import globby from 'globby';
 import { isClass, isGeneratorFunction, isAsyncFunction, isPrimitive } from 'is-type-of';
 
 import utils, { type Fun } from '../utils/index.ts';
+import { RealLoaderFS, type LoaderFS } from './loader_fs.ts';
 import type { ManifestStore } from './manifest.ts';
 
 const debug = debuglog('egg/core/file_loader');
@@ -52,6 +51,8 @@ export interface FileLoaderOptions {
   lowercaseFirst?: boolean;
   /** Startup manifest for caching globby scans and collecting results */
   manifest?: ManifestStore;
+  /** Loader-facing filesystem abstraction */
+  loaderFS?: LoaderFS;
 }
 
 export interface FileLoaderParseItem {
@@ -81,7 +82,7 @@ export class FileLoader {
     return getDefaultFileLoaderMatch();
   }
 
-  readonly options: FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle'>>;
+  readonly options: FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle' | 'loaderFS'>>;
 
   /**
    * @class
@@ -108,6 +109,7 @@ export class FileLoader {
       caseStyle: CaseStyle.camel,
       call: true,
       override: false,
+      loaderFS: new RealLoaderFS(),
       ...options,
     };
 
@@ -210,12 +212,12 @@ export class FileLoader {
     for (const directory of directories) {
       const manifest = this.options.manifest;
       const filepaths = manifest
-        ? manifest.globFiles(directory, () => globby.sync(files, { cwd: directory }))
-        : globby.sync(files, { cwd: directory });
+        ? manifest.globFiles(directory, () => this.options.loaderFS.glob(files, { cwd: directory }))
+        : this.options.loaderFS.glob(files, { cwd: directory });
       debug('[parse] files: %o, cwd: %o => %o', files, directory, filepaths);
       for (const filepath of filepaths) {
         const fullpath = path.join(directory, filepath);
-        if (!fs.statSync(fullpath).isFile()) continue;
+        if (!this.options.loaderFS.stat(fullpath).isFile()) continue;
         if (filepath.endsWith('.js')) {
           const filepathTs = filepath.replace(/\.js$/, '.ts');
           if (filepaths.includes(filepathTs)) {
@@ -267,7 +269,7 @@ function getProperties(filepath: string, caseStyle: CaseStyle | CaseStyleFunctio
 // Get exports from filepath
 // If exports is null/undefined, it will be ignored
 async function getExports(fullpath: string, options: FileLoaderOptions, pathName: string): Promise<any> {
-  let exports = await utils.loadFile(fullpath);
+  let exports = await (options.loaderFS ?? new RealLoaderFS()).loadFile(fullpath);
   // process exports as you like
   if (options.initializer) {
     exports = options.initializer(exports, { path: fullpath, pathName });

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -61,6 +61,8 @@ export interface FileLoaderParseItem {
   exports: object | Fun;
 }
 
+type NormalizedFileLoaderOptions = FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle' | 'loaderFS'>>;
+
 function getDefaultFileLoaderMatch(): string[] {
   return isSupportTypeScript() ? ['**/*.(js|ts)', '!**/*.d.ts'] : ['**/*.js'];
 }
@@ -82,7 +84,7 @@ export class FileLoader {
     return getDefaultFileLoaderMatch();
   }
 
-  readonly options: FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle' | 'loaderFS'>>;
+  readonly options: NormalizedFileLoaderOptions;
 
   /**
    * @class
@@ -268,8 +270,8 @@ function getProperties(filepath: string, caseStyle: CaseStyle | CaseStyleFunctio
 
 // Get exports from filepath
 // If exports is null/undefined, it will be ignored
-async function getExports(fullpath: string, options: FileLoaderOptions, pathName: string): Promise<any> {
-  let exports = await (options.loaderFS ?? new RealLoaderFS()).loadFile(fullpath);
+async function getExports(fullpath: string, options: NormalizedFileLoaderOptions, pathName: string): Promise<any> {
+  let exports = await options.loaderFS.loadFile(fullpath);
   // process exports as you like
   if (options.initializer) {
     exports = options.initializer(exports, { path: fullpath, pathName });

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -1,10 +1,8 @@
 import assert from 'node:assert';
-import fs from 'node:fs';
 import path from 'node:path';
 import { debuglog } from 'node:util';
 
 import { isSupportTypeScript } from '@eggjs/utils';
-import globby from 'globby';
 import { isClass, isGeneratorFunction, isAsyncFunction, isPrimitive } from 'is-type-of';
 
 import utils, { type Fun } from '../utils/index.ts';
@@ -216,12 +214,12 @@ export class FileLoader {
     for (const directory of directories) {
       const manifest = this.options.manifest;
       const filepaths = manifest
-        ? manifest.globFiles(directory, () => globby.sync(files, { cwd: directory }))
-        : globby.sync(files, { cwd: directory });
+        ? manifest.globFiles(directory, () => this.options.loaderFS.glob(files, { cwd: directory }))
+        : this.options.loaderFS.glob(files, { cwd: directory });
       debug('[parse] files: %o, cwd: %o => %o', files, directory, filepaths);
       for (const filepath of filepaths) {
         const fullpath = path.join(directory, filepath);
-        if (!fs.statSync(fullpath).isFile()) continue;
+        if (!this.options.loaderFS.stat(fullpath).isFile()) continue;
         if (filepath.endsWith('.js')) {
           const filepathTs = filepath.replace(/\.js$/, '.ts');
           if (filepaths.includes(filepathTs)) {
@@ -272,8 +270,8 @@ function getProperties(filepath: string, caseStyle: CaseStyle | CaseStyleFunctio
 
 // Get exports from filepath
 // If exports is null/undefined, it will be ignored
-async function getExports(fullpath: string, options: FileLoaderOptions, pathName: string): Promise<any> {
-  let exports = await utils.loadFile(fullpath);
+async function getExports(fullpath: string, options: NormalizedFileLoaderOptions, pathName: string): Promise<any> {
+  let exports = await options.loaderFS.loadFile(fullpath);
   // process exports as you like
   if (options.initializer) {
     exports = options.initializer(exports, { path: fullpath, pathName });

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert';
+import fs from 'node:fs';
 import path from 'node:path';
 import { debuglog } from 'node:util';
 
 import { isSupportTypeScript } from '@eggjs/utils';
+import globby from 'globby';
 import { isClass, isGeneratorFunction, isAsyncFunction, isPrimitive } from 'is-type-of';
 
 import utils, { type Fun } from '../utils/index.ts';
@@ -214,12 +216,12 @@ export class FileLoader {
     for (const directory of directories) {
       const manifest = this.options.manifest;
       const filepaths = manifest
-        ? manifest.globFiles(directory, () => this.options.loaderFS.glob(files, { cwd: directory }))
-        : this.options.loaderFS.glob(files, { cwd: directory });
+        ? manifest.globFiles(directory, () => globby.sync(files, { cwd: directory }))
+        : globby.sync(files, { cwd: directory });
       debug('[parse] files: %o, cwd: %o => %o', files, directory, filepaths);
       for (const filepath of filepaths) {
         const fullpath = path.join(directory, filepath);
-        if (!this.options.loaderFS.stat(fullpath).isFile()) continue;
+        if (!fs.statSync(fullpath).isFile()) continue;
         if (filepath.endsWith('.js')) {
           const filepathTs = filepath.replace(/\.js$/, '.ts');
           if (filepaths.includes(filepathTs)) {
@@ -270,8 +272,8 @@ function getProperties(filepath: string, caseStyle: CaseStyle | CaseStyleFunctio
 
 // Get exports from filepath
 // If exports is null/undefined, it will be ignored
-async function getExports(fullpath: string, options: NormalizedFileLoaderOptions, pathName: string): Promise<any> {
-  let exports = await options.loaderFS.loadFile(fullpath);
+async function getExports(fullpath: string, options: FileLoaderOptions, pathName: string): Promise<any> {
+  let exports = await utils.loadFile(fullpath);
   // process exports as you like
   if (options.initializer) {
     exports = options.initializer(exports, { path: fullpath, pathName });

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -5,7 +5,7 @@ import { debuglog } from 'node:util';
 import { isSupportTypeScript } from '@eggjs/utils';
 import { isClass, isGeneratorFunction, isAsyncFunction, isPrimitive } from 'is-type-of';
 
-import utils, { type Fun } from '../utils/index.ts';
+import utils from '../utils/index.ts';
 import { RealLoaderFS, type LoaderFS } from './loader_fs.ts';
 import type { ManifestStore } from './manifest.ts';
 
@@ -58,7 +58,7 @@ export interface FileLoaderOptions {
 export interface FileLoaderParseItem {
   fullpath: string;
   properties: string[];
-  exports: object | Fun;
+  exports: unknown;
 }
 
 type NormalizedFileLoaderOptions = FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle' | 'loaderFS'>>;
@@ -270,7 +270,7 @@ function getProperties(filepath: string, caseStyle: CaseStyle | CaseStyleFunctio
 
 // Get exports from filepath
 // If exports is null/undefined, it will be ignored
-async function getExports(fullpath: string, options: NormalizedFileLoaderOptions, pathName: string): Promise<any> {
+async function getExports(fullpath: string, options: NormalizedFileLoaderOptions, pathName: string): Promise<unknown> {
   let exports = await options.loaderFS.loadFile(fullpath);
   // process exports as you like
   if (options.initializer) {
@@ -297,7 +297,8 @@ async function getExports(fullpath: string, options: NormalizedFileLoaderOptions
   //   return {};
   // }
   if (options.call && typeof exports === 'function') {
-    exports = exports(options.inject);
+    const callableExports = exports as (inject?: FileLoaderOptions['inject']) => unknown;
+    exports = callableExports(options.inject);
     if (exports !== null && exports !== undefined) {
       return exports;
     }

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -5,10 +5,7 @@ import { readJSONSync } from 'utility';
 
 import utils from '../utils/index.ts';
 
-export interface LoaderFSGlobOptions {
-  cwd?: string;
-  [key: string]: unknown;
-}
+export type LoaderFSGlobOptions = globby.GlobbyOptions;
 
 export interface LoaderFS {
   exists(filepath: string): boolean;
@@ -37,7 +34,7 @@ export class RealLoaderFS implements LoaderFS {
   }
 
   glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[] {
-    return globby.sync(patterns, options as any) as unknown as string[];
+    return globby.sync(patterns, options);
   }
 
   async loadFile(filepath: string): Promise<any> {

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -1,0 +1,46 @@
+import fs, { type Stats } from 'node:fs';
+
+import globby from 'globby';
+import { readJSON } from 'utility';
+
+import utils from '../utils/index.ts';
+
+export interface LoaderFSGlobOptions {
+  cwd?: string;
+  [key: string]: unknown;
+}
+
+export interface LoaderFS {
+  exists(filepath: string): boolean;
+  stat(filepath: string): Stats;
+  realpath(filepath: string): string;
+  readJSON<T = unknown>(filepath: string): Promise<T>;
+  glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[];
+  loadFile(filepath: string): Promise<any>;
+}
+
+export class RealLoaderFS implements LoaderFS {
+  exists(filepath: string): boolean {
+    return fs.existsSync(filepath);
+  }
+
+  stat(filepath: string): Stats {
+    return fs.statSync(filepath);
+  }
+
+  realpath(filepath: string): string {
+    return fs.realpathSync(filepath);
+  }
+
+  async readJSON<T = unknown>(filepath: string): Promise<T> {
+    return readJSON(filepath) as Promise<T>;
+  }
+
+  glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[] {
+    return globby.sync(patterns, options as any) as unknown as string[];
+  }
+
+  async loadFile(filepath: string): Promise<any> {
+    return utils.loadFile(filepath);
+  }
+}

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -1,7 +1,7 @@
 import fs, { type Stats } from 'node:fs';
 
 import globby from 'globby';
-import { readJSON } from 'utility';
+import { readJSONSync } from 'utility';
 
 import utils from '../utils/index.ts';
 
@@ -14,7 +14,7 @@ export interface LoaderFS {
   exists(filepath: string): boolean;
   stat(filepath: string): Stats;
   realpath(filepath: string): string;
-  readJSON<T = unknown>(filepath: string): Promise<T>;
+  readJSON<T = unknown>(filepath: string): T;
   glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[];
   loadFile(filepath: string): Promise<any>;
 }
@@ -32,8 +32,8 @@ export class RealLoaderFS implements LoaderFS {
     return fs.realpathSync(filepath);
   }
 
-  async readJSON<T = unknown>(filepath: string): Promise<T> {
-    return readJSON(filepath) as Promise<T>;
+  readJSON<T = unknown>(filepath: string): T {
+    return readJSONSync(filepath) as T;
   }
 
   glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[] {

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -13,7 +13,7 @@ export interface LoaderFS {
   realpath(filepath: string): string;
   readJSON<T = unknown>(filepath: string): T;
   glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[];
-  loadFile(filepath: string): Promise<any>;
+  loadFile(filepath: string): Promise<unknown>;
 }
 
 export class RealLoaderFS implements LoaderFS {
@@ -37,7 +37,7 @@ export class RealLoaderFS implements LoaderFS {
     return globby.sync(patterns, options);
   }
 
-  async loadFile(filepath: string): Promise<any> {
+  async loadFile(filepath: string): Promise<unknown> {
     return utils.loadFile(filepath);
   }
 }

--- a/packages/core/test/__snapshots__/index.test.ts.snap
+++ b/packages/core/test/__snapshots__/index.test.ts.snap
@@ -19,6 +19,7 @@ exports[`should expose properties 1`] = `
   "KoaResponse",
   "Lifecycle",
   "ManifestStore",
+  "RealLoaderFS",
   "Request",
   "Response",
   "Router",

--- a/packages/core/test/loader/egg_loader.test.ts
+++ b/packages/core/test/loader/egg_loader.test.ts
@@ -6,7 +6,7 @@ import { getPlugins } from '@eggjs/utils';
 import { mm } from 'mm';
 import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
 
-import { EggLoader } from '../../src/index.js';
+import { EggLoader, RealLoaderFS } from '../../src/index.js';
 import { createApp, getFilepath, type Application } from '../helper.js';
 
 describe('test/loader/egg_loader.test.ts', () => {
@@ -107,6 +107,42 @@ describe('test/loader/egg_loader.test.ts', () => {
     } as any);
     await loader.loadToContext(directory, prop);
     assert(Reflect.get(app.context, prop).user);
+  });
+
+  it('should pass loaderFS to loadToApp and loadToContext', async () => {
+    class MockLoaderFS extends RealLoaderFS {
+      glob(): string[] {
+        return ['user.js'];
+      }
+
+      stat(): any {
+        return {
+          isFile: () => true,
+        };
+      }
+
+      async loadFile(filepath: string): Promise<any> {
+        return {
+          filepath,
+        };
+      }
+    }
+
+    const baseDir = getFilepath('load_to_app');
+    const loaderFS = new MockLoaderFS();
+    const app: any = { context: {} };
+    const loader = new EggLoader({
+      baseDir,
+      app,
+      logger: console,
+      loaderFS,
+    } as any);
+
+    await loader.loadToApp('/virtual/app/model', 'model');
+    await loader.loadToContext('/virtual/app/service', 'service');
+
+    assert.equal(app.model.user.filepath, path.join('/virtual/app/model', 'user.js'));
+    assert.equal(app.context.service.user.filepath, path.join('/virtual/app/service', 'user.js'));
   });
 
   describe('resolveModule with outDir', () => {

--- a/packages/core/test/loader/egg_loader.test.ts
+++ b/packages/core/test/loader/egg_loader.test.ts
@@ -6,7 +6,14 @@ import { getPlugins } from '@eggjs/utils';
 import { mm } from 'mm';
 import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
 
-import { ContextLoader, EggLoader, FileLoader, RealLoaderFS } from '../../src/index.js';
+import {
+  ContextLoader,
+  EggLoader,
+  FileLoader,
+  RealLoaderFS,
+  type EggLoaderOptions,
+  type LoaderFS,
+} from '../../src/index.js';
 import { createApp, getFilepath, type Application } from '../helper.js';
 
 describe('test/loader/egg_loader.test.ts', () => {
@@ -112,14 +119,15 @@ describe('test/loader/egg_loader.test.ts', () => {
   it('should pass loaderFS to loadToApp and loadToContext', async () => {
     const baseDir = getFilepath('load_to_app');
     const loaderFS = new RealLoaderFS();
-    const app: any = { context: {} };
+    const loaderApp = { context: {} } as EggLoaderOptions['app'];
     const loader = new EggLoader({
+      env: 'unittest',
       baseDir,
-      app,
-      logger: console,
+      app: loaderApp,
+      logger: app.logger,
       loaderFS,
-    } as any);
-    const passedLoaderFS: any[] = [];
+    });
+    const passedLoaderFS: LoaderFS[] = [];
 
     mm(FileLoader.prototype, 'load', async function (this: FileLoader) {
       passedLoaderFS.push(this.options.loaderFS);

--- a/packages/core/test/loader/egg_loader.test.ts
+++ b/packages/core/test/loader/egg_loader.test.ts
@@ -6,7 +6,7 @@ import { getPlugins } from '@eggjs/utils';
 import { mm } from 'mm';
 import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
 
-import { EggLoader, RealLoaderFS } from '../../src/index.js';
+import { ContextLoader, EggLoader, FileLoader, RealLoaderFS } from '../../src/index.js';
 import { createApp, getFilepath, type Application } from '../helper.js';
 
 describe('test/loader/egg_loader.test.ts', () => {
@@ -110,26 +110,8 @@ describe('test/loader/egg_loader.test.ts', () => {
   });
 
   it('should pass loaderFS to loadToApp and loadToContext', async () => {
-    class MockLoaderFS extends RealLoaderFS {
-      glob(): string[] {
-        return ['user.js'];
-      }
-
-      stat(): any {
-        return {
-          isFile: () => true,
-        };
-      }
-
-      async loadFile(filepath: string): Promise<any> {
-        return {
-          filepath,
-        };
-      }
-    }
-
     const baseDir = getFilepath('load_to_app');
-    const loaderFS = new MockLoaderFS();
+    const loaderFS = new RealLoaderFS();
     const app: any = { context: {} };
     const loader = new EggLoader({
       baseDir,
@@ -137,12 +119,25 @@ describe('test/loader/egg_loader.test.ts', () => {
       logger: console,
       loaderFS,
     } as any);
+    const passedLoaderFS: any[] = [];
 
-    await loader.loadToApp('/virtual/app/model', 'model');
-    await loader.loadToContext('/virtual/app/service', 'service');
+    mm(FileLoader.prototype, 'load', async function (this: FileLoader) {
+      passedLoaderFS.push(this.options.loaderFS);
+      return {};
+    });
+    mm(ContextLoader.prototype, 'load', async function (this: ContextLoader) {
+      passedLoaderFS.push(this.options.loaderFS);
+      return {};
+    });
 
-    assert.equal(app.model.user.filepath, path.join('/virtual/app/model', 'user.js'));
-    assert.equal(app.context.service.user.filepath, path.join('/virtual/app/service', 'user.js'));
+    try {
+      await loader.loadToApp(path.join(baseDir, 'app/model'), 'model');
+      await loader.loadToContext(path.join(baseDir, 'app/service'), 'service');
+
+      assert.deepEqual(passedLoaderFS, [loaderFS, loaderFS]);
+    } finally {
+      mm.restore();
+    }
   });
 
   describe('resolveModule with outDir', () => {

--- a/packages/core/test/loader/file_loader.test.ts
+++ b/packages/core/test/loader/file_loader.test.ts
@@ -27,7 +27,7 @@ class RecordingLoaderFS extends RealLoaderFS {
     return super.stat(filepath);
   }
 
-  async loadFile(filepath: string): Promise<any> {
+  async loadFile(filepath: string): Promise<unknown> {
     this.loadFileCalls.push(filepath);
     return super.loadFile(filepath);
   }
@@ -422,7 +422,7 @@ describe('test/loader/file_loader.test.ts', () => {
   });
 
   it('should use loaderFS for discovery, stat and loadFile', async () => {
-    const target: Record<string, any> = {};
+    const target: Record<string, unknown> = {};
     const loaderFS = new RecordingLoaderFS();
     await new FileLoader({
       directory: path.join(dirBase, 'services'),

--- a/packages/core/test/loader/file_loader.test.ts
+++ b/packages/core/test/loader/file_loader.test.ts
@@ -6,9 +6,32 @@ import yaml from 'js-yaml';
 import { describe, it, expect } from 'vitest';
 
 import { FileLoader, CaseStyle } from '../../src/loader/file_loader.ts';
+import { RealLoaderFS, type LoaderFSGlobOptions } from '../../src/loader/loader_fs.ts';
+import { ManifestStore } from '../../src/loader/manifest.ts';
 import { getFilepath } from '../helper.ts';
 
 const dirBase = getFilepath('load_dirs');
+
+class RecordingLoaderFS extends RealLoaderFS {
+  readonly globCalls: Array<{ patterns: string | string[]; cwd: string | undefined }> = [];
+  readonly statCalls: string[] = [];
+  readonly loadFileCalls: string[] = [];
+
+  glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[] {
+    this.globCalls.push({ patterns, cwd: options?.cwd ? String(options.cwd) : undefined });
+    return super.glob(patterns, options);
+  }
+
+  stat(filepath: string) {
+    this.statCalls.push(filepath);
+    return super.stat(filepath);
+  }
+
+  async loadFile(filepath: string): Promise<any> {
+    this.loadFileCalls.push(filepath);
+    return super.loadFile(filepath);
+  }
+}
 
 describe('test/loader/file_loader.test.ts', () => {
   it('should load files with package.json#exports', async () => {
@@ -396,5 +419,21 @@ describe('test/loader/file_loader.test.ts', () => {
       },
     }).load();
     assert.deepEqual(Object.keys(target), ['arr', 'class']);
+  });
+
+  it('should use loaderFS for discovery, stat and loadFile', async () => {
+    const target: Record<string, any> = {};
+    const loaderFS = new RecordingLoaderFS();
+    await new FileLoader({
+      directory: path.join(dirBase, 'services'),
+      target,
+      loaderFS,
+      manifest: ManifestStore.createCollector(dirBase),
+    }).load();
+
+    assert(target.fooService);
+    assert(loaderFS.globCalls.some((call) => call.cwd === path.join(dirBase, 'services')));
+    assert(loaderFS.statCalls.some((filepath) => filepath.endsWith(path.join('services', 'foo_service.js'))));
+    assert(loaderFS.loadFileCalls.some((filepath) => filepath.endsWith(path.join('services', 'foo_service.js'))));
   });
 });

--- a/packages/core/test/loader/loader_fs.test.ts
+++ b/packages/core/test/loader/loader_fs.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import globby from 'globby';
+import { describe, it } from 'vitest';
+
+import { RealLoaderFS } from '../../src/loader/loader_fs.ts';
+import utils from '../../src/utils/index.ts';
+import { getFilepath } from '../helper.ts';
+
+describe('test/loader/loader_fs.test.ts', () => {
+  const loaderFS = new RealLoaderFS();
+  const baseDir = getFilepath('loadfile');
+
+  it('should wrap exists/stat/realpath with node fs behavior', () => {
+    const filepath = path.join(baseDir, 'object.js');
+
+    assert.equal(loaderFS.exists(filepath), fs.existsSync(filepath));
+    assert.equal(loaderFS.exists(path.join(baseDir, 'not-exists.js')), false);
+    assert.equal(loaderFS.stat(filepath).isFile(), fs.statSync(filepath).isFile());
+    assert.equal(loaderFS.realpath(baseDir), fs.realpathSync(baseDir));
+  });
+
+  it('should wrap readJSON/glob/loadFile with current loader behavior', async () => {
+    const packagePath = path.join(baseDir, 'package.json');
+    const patterns = ['*.js', '!null.js'];
+
+    assert.deepEqual(await loaderFS.readJSON(packagePath), JSON.parse(fs.readFileSync(packagePath, 'utf8')));
+    assert.deepEqual(loaderFS.glob(patterns, { cwd: baseDir }).sort(), globby.sync(patterns, { cwd: baseDir }).sort());
+    assert.deepEqual(
+      await loaderFS.loadFile(path.join(baseDir, 'object.js')),
+      await utils.loadFile(path.join(baseDir, 'object.js')),
+    );
+  });
+});

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,6 +18,7 @@ Read this file before exploring raw sources.
 
 ## Packages
 
+- [Core Package](./packages/core.md) - Loader, lifecycle, and application core primitives used by Egg runtime packages.
 - [Egg Bundler](./packages/egg-bundler.md) - Tooling package that bundles Egg applications and backs `egg-bin bundle`.
 - [Onerror Plugin](./packages/onerror.md) - Default Egg error-handling plugin and configurable response negotiation layer.
 - [Typings Package](./packages/typings.md) - Shared TypeScript type surface for cross-package Egg typings.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-05-07] package | document core LoaderFS boundary
+
+- sources touched: `packages/core/src/index.ts`, `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/context_loader.ts`, `packages/core/src/loader/egg_loader.ts`
+- pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/packages/core.md`
+- note: Recorded `LoaderFS` as the minimal loader filesystem boundary and `RealLoaderFS` as the default implementation for existing non-bundled behavior.
+
 ## [2026-05-06] package | sync bundled runtime support changes
 
 - sources touched: `tools/egg-bundler/src/lib/ExternalsResolver.ts`, `packages/utils/src/import.ts`, `plugins/onerror/src/lib/onerror.ts`

--- a/wiki/packages/core.md
+++ b/wiki/packages/core.md
@@ -26,7 +26,7 @@ trying to polyfill the full Node.js `fs` module.
 
 `RealLoaderFS` is the default implementation. It preserves normal non-bundled
 runtime behavior by delegating to `fs.existsSync`, `fs.statSync`,
-`fs.realpathSync`, `utility.readJSON`, `globby.sync`, and the existing
+`fs.realpathSync`, `utility.readJSONSync`, `globby.sync`, and the existing
 `utils.loadFile()` helper.
 
 `EggLoaderOptions`, `FileLoaderOptions`, and `ContextLoaderOptions` can carry a

--- a/wiki/packages/core.md
+++ b/wiki/packages/core.md
@@ -1,0 +1,35 @@
+---
+title: Core Package
+type: package
+summary: Loader, lifecycle, and application core primitives used by Egg runtime packages.
+source_files:
+  - packages/core/src/index.ts
+  - packages/core/src/loader/loader_fs.ts
+  - packages/core/src/loader/file_loader.ts
+  - packages/core/src/loader/context_loader.ts
+  - packages/core/src/loader/egg_loader.ts
+updated_at: 2026-05-07
+status: active
+---
+
+# Core Package
+
+`@eggjs/core` exports the runtime loader primitives used to assemble an Egg
+application, including `EggLoader`, `FileLoader`, `ContextLoader`, manifest
+support, lifecycle, and base context classes.
+
+## LoaderFS
+
+`LoaderFS` is the minimal filesystem boundary for loader-facing file access. It
+covers `exists`, `stat`, `realpath`, `readJSON`, `glob`, and `loadFile` without
+trying to polyfill the full Node.js `fs` module.
+
+`RealLoaderFS` is the default implementation. It preserves normal non-bundled
+runtime behavior by delegating to `fs.existsSync`, `fs.statSync`,
+`fs.realpathSync`, `utility.readJSON`, `globby.sync`, and the existing
+`utils.loadFile()` helper.
+
+`EggLoaderOptions`, `FileLoaderOptions`, and `ContextLoaderOptions` can carry a
+custom `loaderFS`. `EggLoader` passes its loader FS into `loadToApp()` and
+`loadToContext()` so later bundled loaders can replace file discovery and module
+loading without changing the public loader call sites.


### PR DESCRIPTION
## Summary
- add LoaderFS and RealLoaderFS as the loader-facing filesystem boundary
- thread loaderFS through EggLoader/FileLoader/ContextLoader paths without changing default runtime behavior
- add targeted loader tests and wiki notes for the exported API

## Tests
- pnpm exec vitest run packages/core/test/loader/file_loader.test.ts packages/core/test/loader/context_loader.test.ts packages/core/test/loader/loader_fs.test.ts packages/core/test/loader/egg_loader.test.ts --testTimeout 20000 --hookTimeout 20000
- pnpm --filter @eggjs/core run typecheck
- pnpm exec oxfmt --check packages/core/src/loader/loader_fs.ts packages/core/src/loader/file_loader.ts packages/core/src/loader/egg_loader.ts packages/core/src/index.ts packages/core/test/loader/loader_fs.test.ts packages/core/test/loader/egg_loader.test.ts wiki/packages/core.md wiki/index.md wiki/log.md
- pnpm exec oxlint --type-aware --type-check --quiet packages/core/src/loader/loader_fs.ts packages/core/src/loader/file_loader.ts packages/core/src/loader/egg_loader.ts packages/core/test/loader/loader_fs.test.ts packages/core/test/loader/egg_loader.test.ts (0 errors; 7 existing warnings in egg_loader.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loader filesystem abstraction to allow custom filesystem implementations.
  * Loaders can accept an injected filesystem via options and forward it during loading.
  * Core package now re-exports and exposes the LoaderFS boundary.

* **Documentation**
  * Added Core Package docs describing the LoaderFS boundary and default implementation.
  * Added changelog entry documenting the filesystem boundary.

* **Tests**
  * Added tests for the default filesystem implementation and loader integration with a custom filesystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->