### PR TITLE
docs(wiki): record bundler runtime assets

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-05-08] package | record bundler runtime assets and tegg manifest path normalization
+
+- sources touched: `tools/egg-bundler/src/lib/Bundler.ts`, `tools/egg-bundler/src/lib/ManifestLoader.ts`, `tools/egg-bundler/src/lib/EntryGenerator.ts`, `tegg/core/loader/src/LoaderUtil.ts`, `tools/egg-bundler/README.md`, `tools/egg-bundler/docs/output-structure.md`
+- pages updated: `wiki/log.md`, `wiki/packages/egg-bundler.md`
+- note: Recorded default/configurable runtime asset copying, bundle manifest chunk inclusion for copied assets, tegg module reference/descriptor path normalization, and tegg loader use of the bundle module loader before dynamic import fallback.
+
 ## [2026-05-06] package | sync bundled runtime support changes
 
 - sources touched: `tools/egg-bundler/src/lib/ExternalsResolver.ts`, `packages/utils/src/import.ts`, `plugins/onerror/src/lib/onerror.ts`

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -9,7 +9,7 @@ source_files:
   - tools/egg-bundler/src/lib/ExternalsResolver.ts
   - tools/egg-bin/src/commands/bundle.ts
   - tools/egg-bundler/docs/output-structure.md
-updated_at: 2026-05-06
+updated_at: 2026-05-08
 status: active
 ---
 
@@ -34,7 +34,8 @@ CommonJS artifact from an Egg application.
 3. `EntryGenerator` writes a synthetic worker entry that installs the bundle
    manifest/module loader before starting Egg.
 4. `PackRunner` invokes `@utoo/pack`.
-5. `Bundler` writes `bundle-manifest.json` and returns absolute output paths.
+5. `Bundler` copies configured runtime assets into the output directory.
+6. `Bundler` writes `bundle-manifest.json` and returns absolute output paths.
 
 ## Current Behavior
 
@@ -45,12 +46,24 @@ CommonJS artifact from an Egg application.
   lifecycle, runs `loadMetadata()` hooks, and the manifest generation child
   process exits after writing the manifest, so registered `beforeClose` hooks do
   not run.
+- Applications may configure `bundle.runtimeAssets` in `module.yml` or
+  `BundlerConfig`. By default, the bundler scans `app` for runtime assets and
+  force-copies `app/public`, `app/assets`, and `app/static`, preserving
+  baseDir-relative output paths. Source-like files such as `.js`, `.ts`, `.mjs`,
+  and `.cjs` are skipped outside force-copy directories, and manifest-known
+  module files are not copied as assets.
 - The generated app runs in Egg single-process mode. Its worker entry treats the
   deploy output directory as the runtime Egg `baseDir`, passes the framework
   specifier explicitly to `startEgg`, maps that specifier to the already bundled
   framework module, and precomputes original app absolute aliases so bundled
   module lookup can serve relKeys, output-dir absolute paths, original app
   absolute paths, and manifest `resolveCache` request aliases.
+- `ManifestLoader` normalizes tegg `moduleReferences` and `moduleDescriptors`
+  through the same module map so descriptors and references use matching
+  app-relative or package-normalized paths in the bundle manifest. Decorated
+  files from those descriptors are imported by the worker entry, and tegg loader
+  file loading can use `globalThis.__EGG_BUNDLE_MODULE_LOADER__` before falling
+  back to dynamic import.
 - Explicit `externals.force` entries are external, and `ExternalsResolver`
   auto-detects root `peerDependencies`, root `optionalDependencies`, root
   dependency packages with native addons, root dependency packages whose optional


### PR DESCRIPTION
## Summary
- update the Egg Bundler wiki page for runtime asset copying and tegg manifest path normalization
- add the 2026-05-08 wiki log entry for the latest next branch doc sync

## Verification
- git diff --check
- utoo execute oxfmt --check wiki/log.md wiki/packages/egg-bundler.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated egg-bundler package documentation with details on runtime asset handling and module loader behavior
  * Added new wiki log entry for recent egg-bundler and tegg loader updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->