### PR TITLE
docs(wiki): sync egg bundler runtime notes

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-05-10] package | sync egg bundler runtime asset and tegg notes
+
+- sources touched: `tools/egg-bundler/src/lib/Bundler.ts`, `tools/egg-bundler/src/lib/ManifestLoader.ts`, `tools/egg-bundler/src/lib/EntryGenerator.ts`, `tegg/core/loader/src/LoaderUtil.ts`, `tools/egg-bundler/README.md`, `tools/egg-bundler/docs/output-structure.md`
+- pages updated: `wiki/log.md`, `wiki/packages/egg-bundler.md`
+- note: Recorded `module.yml` bundle config, runtime asset copy roots/force-copy directories, tegg manifest path normalization, and tegg loader use of the global bundle module loader.
+
 ## [2026-05-06] package | sync bundled runtime support changes
 
 - sources touched: `tools/egg-bundler/src/lib/ExternalsResolver.ts`, `packages/utils/src/import.ts`, `plugins/onerror/src/lib/onerror.ts`

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -7,9 +7,12 @@ source_files:
   - tools/egg-bundler/src/lib/Bundler.ts
   - tools/egg-bundler/src/lib/EntryGenerator.ts
   - tools/egg-bundler/src/lib/ExternalsResolver.ts
+  - tools/egg-bundler/src/lib/ManifestLoader.ts
+  - tegg/core/loader/src/LoaderUtil.ts
   - tools/egg-bin/src/commands/bundle.ts
+  - tools/egg-bundler/README.md
   - tools/egg-bundler/docs/output-structure.md
-updated_at: 2026-05-06
+updated_at: 2026-05-10
 status: active
 ---
 
@@ -34,7 +37,8 @@ CommonJS artifact from an Egg application.
 3. `EntryGenerator` writes a synthetic worker entry that installs the bundle
    manifest/module loader before starting Egg.
 4. `PackRunner` invokes `@utoo/pack`.
-5. `Bundler` writes `bundle-manifest.json` and returns absolute output paths.
+5. `Bundler` patches generated `import.meta` output, copies runtime assets,
+   writes `bundle-manifest.json`, and returns absolute output paths.
 
 ## Current Behavior
 
@@ -45,12 +49,28 @@ CommonJS artifact from an Egg application.
   lifecycle, runs `loadMetadata()` hooks, and the manifest generation child
   process exits after writing the manifest, so registered `beforeClose` hooks do
   not run.
+- Applications may define stable bundle config in `<baseDir>/module.yml`.
+  `bundle.pack.resolve.alias` is merged into the pack resolve config, with
+  explicit programmatic aliases taking precedence over aliases from the file.
+  Dot-relative alias targets are resolved from `baseDir`.
+- Runtime assets are copied from `app` by default into the same relative path in
+  the output. Manifest-known source files, tegg decorated files, and
+  `resolveCache` targets are excluded from asset copying; source-like extensions
+  are also skipped unless they are under force-copy directories. The default
+  force-copy directories are `app/public`, `app/assets`, and `app/static`.
+  `bundle.runtimeAssets.roots` and `bundle.runtimeAssets.forceCopyDirs`, from
+  either `module.yml` or programmatic config, replace those defaults.
 - The generated app runs in Egg single-process mode. Its worker entry treats the
   deploy output directory as the runtime Egg `baseDir`, passes the framework
   specifier explicitly to `startEgg`, maps that specifier to the already bundled
   framework module, and precomputes original app absolute aliases so bundled
   module lookup can serve relKeys, output-dir absolute paths, original app
   absolute paths, and manifest `resolveCache` request aliases.
+- `ManifestLoader` normalizes tegg `moduleReferences[].path` and
+  `moduleDescriptors[].unitPath` to the same bundle-relative form so the bundled
+  worker can match tegg decorated files. During runtime, tegg's `LoaderUtil`
+  checks `globalThis.__EGG_BUNDLE_MODULE_LOADER__` before falling back to
+  dynamic `import()`.
 - Explicit `externals.force` entries are external, and `ExternalsResolver`
   auto-detects root `peerDependencies`, root `optionalDependencies`, root
   dependency packages with native addons, root dependency packages whose optional

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -68,7 +68,7 @@ CommonJS artifact from an Egg application.
   absolute paths, and manifest `resolveCache` request aliases.
 - `ManifestLoader` normalizes tegg `moduleReferences[].path` and
   `moduleDescriptors[].unitPath` to the same bundle-relative form so the bundled
-  worker can match tegg decorated files. During runtime, tegg's `LoaderUtil`
+  worker can match tegg-decorated files. During runtime, tegg's `LoaderUtil`
   checks `globalThis.__EGG_BUNDLE_MODULE_LOADER__` before falling back to
   dynamic `import()`.
 - Explicit `externals.force` entries are external, and `ExternalsResolver`


### PR DESCRIPTION
## Summary
- Record module.yml bundle config and runtime asset copy behavior in the Egg Bundler wiki page.
- Record tegg manifest path normalization and runtime LoaderUtil bundle loader behavior.
- Append the wiki maintenance log entry for this sync.

## Verification
- `git diff --check`
- `pnpm exec oxfmt --check wiki/packages/egg-bundler.md wiki/log.md` could not run because this checkout has no node_modules and `oxfmt` is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated bundler package docs with clearer bundle flow, runtime asset handling (copying/exclusions), and module loader behavior.
  * Added a 2026-05-10 wiki log entry documenting the package and configuration updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5941)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->