### PR TITLE
feat(core): add manifest-backed loader fs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "get-ready": "catalog:",
     "globby": "catalog:",
     "is-type-of": "catalog:",
+    "multimatch": "catalog:",
     "node-homedir": "catalog:",
     "performance-ms": "catalog:",
     "ready-callback": "catalog:",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './loader/egg_loader.ts';
 export * from './loader/file_loader.ts';
 export * from './loader/context_loader.ts';
 export * from '@eggjs/loader-fs';
+export { ManifestLoaderFS } from './loader/loader_fs.ts';
 export * from './loader/manifest.ts';
 export * from './utils/sequencify.ts';
 export * from './utils/timing.ts';

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -652,7 +652,7 @@ export class EggLoader {
     let eggPluginConfig: any;
     const pluginPackage = path.join(plugin.path as string, 'package.json');
     if (this.loaderFS.exists(pluginPackage)) {
-      pkg = this.loaderFS.readJSON(pluginPackage);
+      pkg = await this.loaderFS.loadFile(pluginPackage);
       eggPluginConfig = pkg.eggPlugin;
       if (pkg.version) {
         plugin.version = pkg.version;

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -14,7 +14,7 @@ import { isAsyncFunction, isClass, isGeneratorFunction, isObject, isPromise } fr
 import { homedir } from 'node-homedir';
 import { now, diff } from 'performance-ms';
 import { register as tsconfigPathsRegister } from 'tsconfig-paths';
-import { getParamNames, readJSONSync } from 'utility';
+import { getParamNames } from 'utility';
 
 import type { BaseContextClass } from '../base_context_class.ts';
 import type { Context, EggCore, MiddlewareFunc } from '../egg.ts';
@@ -111,7 +111,7 @@ export class EggLoader {
      * @see {@link AppInfo#pkg}
      * @since 1.0.0
      */
-    this.pkg = readJSONSync(path.join(this.options.baseDir, 'package.json'));
+    this.pkg = this.loaderFS.readJSON<Record<string, unknown>>(path.join(this.options.baseDir, 'package.json'));
     this.outDir = this.#resolveOutDir();
 
     // auto require('tsconfig-paths/register') on typescript app

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -14,7 +14,7 @@ import { isAsyncFunction, isClass, isGeneratorFunction, isObject, isPromise } fr
 import { homedir } from 'node-homedir';
 import { now, diff } from 'performance-ms';
 import { register as tsconfigPathsRegister } from 'tsconfig-paths';
-import { getParamNames, readJSONSync, readJSON, exists } from 'utility';
+import { getParamNames, readJSONSync } from 'utility';
 
 import type { BaseContextClass } from '../base_context_class.ts';
 import type { Context, EggCore, MiddlewareFunc } from '../egg.ts';
@@ -25,6 +25,7 @@ import { sequencify } from '../utils/sequencify.ts';
 import { Timing } from '../utils/timing.ts';
 import { type ContextLoaderOptions, ContextLoader } from './context_loader.ts';
 import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';
+import { ManifestLoaderFS } from './loader_fs.ts';
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
@@ -95,7 +96,10 @@ export class EggLoader {
    */
   constructor(options: EggLoaderOptions) {
     this.options = options;
-    this.loaderFS = this.options.loaderFS ?? new RealLoaderFS();
+    const bundleStore = ManifestStore.getBundleStore();
+    this.loaderFS =
+      this.options.loaderFS ??
+      (bundleStore?.baseDir === this.options.baseDir ? new ManifestLoaderFS(bundleStore) : new RealLoaderFS());
     assert(fs.existsSync(this.options.baseDir), `${this.options.baseDir} not exists`);
     assert(this.options.app, 'options.app is required');
     assert(this.options.logger, 'options.logger is required');
@@ -176,6 +180,9 @@ export class EggLoader {
     this.manifest =
       ManifestStore.load(this.options.baseDir, this.serverEnv, this.serverScope) ??
       ManifestStore.createCollector(this.options.baseDir);
+    if (!this.options.loaderFS && !(this.loaderFS instanceof ManifestLoaderFS)) {
+      this.loaderFS = new ManifestLoaderFS(this.manifest, this.loaderFS);
+    }
   }
 
   get app(): EggCore {
@@ -644,8 +651,8 @@ export class EggLoader {
     let pkg: any;
     let eggPluginConfig: any;
     const pluginPackage = path.join(plugin.path as string, 'package.json');
-    if (await utils.existsPath(pluginPackage)) {
-      pkg = await readJSON(pluginPackage);
+    if (this.loaderFS.exists(pluginPackage)) {
+      pkg = this.loaderFS.readJSON(pluginPackage);
       eggPluginConfig = pkg.eggPlugin;
       if (pkg.version) {
         plugin.version = pkg.version;
@@ -848,7 +855,7 @@ export class EggLoader {
       } else if (exports.require) {
         realPluginPath = path.join(pluginPath, exports.require);
       }
-      if (exports.typescript && isSupportTypeScript() && !(await exists(realPluginPath))) {
+      if (exports.typescript && isSupportTypeScript() && !this.loaderFS.exists(realPluginPath)) {
         // if require/import path not exists, use typescript path for development stage
         realPluginPath = path.join(pluginPath, exports.typescript);
         debug('[formatPluginPathFromPackageJSON] use typescript path %o', realPluginPath);
@@ -1796,6 +1803,7 @@ export class EggLoader {
    */
   #collectConventionalDynamicFiles(manifest: StartupManifest): void {
     for (const unit of this.getLoadUnits()) {
+      this.#collectConventionFile(manifest, path.join(unit.path, 'package.json'));
       for (const load of CONVENTIONAL_MANIFEST_LOADS) {
         const target = path.join(unit.path, ...load.path);
         if (load.type === 'resolve') {
@@ -1836,6 +1844,19 @@ export class EggLoader {
         ? globby.sync(FileLoader.getDefaultMatch(), { cwd: directory }).sort()
         : [];
     return manifest.fileDiscovery[dirKey];
+  }
+
+  #collectConventionFile(manifest: StartupManifest, filepath: string): void {
+    const fileKey = this.#toManifestRel(filepath);
+    if (Object.values(manifest.resolveCache).includes(fileKey)) return;
+    if (!fs.existsSync(filepath) || !fs.statSync(filepath).isFile()) return;
+
+    const dirKey = this.#toManifestRel(path.dirname(filepath));
+    const basename = path.basename(filepath);
+    const files = manifest.fileDiscovery[dirKey] ?? [];
+    if (!files.includes(basename)) {
+      manifest.fileDiscovery[dirKey] = [...files, basename].sort();
+    }
   }
 
   #toManifestRel(filepath: string): string {

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { RealLoaderFS, type LoaderFS, type LoaderFSGlobOptions } from '@eggjs/loader-fs';
 import type {} from '@eggjs/typings/global';
-import multimatch from 'multimatch';
+import multimatch, { type Options as MultimatchOptions } from 'multimatch';
 
 import type { ManifestStore } from './manifest.ts';
 
@@ -277,7 +277,18 @@ function filterManifestGlob(files: string[], patterns: string | string[], option
   const normalizedPatterns = patternList
     .map(normalizeAlternationGroups)
     .concat(ignoreList.map((pattern) => `!${normalizeAlternationGroups(pattern)}`));
-  return multimatch(files, normalizedPatterns);
+  return multimatch(files, normalizedPatterns, toMultimatchOptions(options));
+}
+
+function toMultimatchOptions(options?: LoaderFSGlobOptions): MultimatchOptions {
+  return {
+    ...(options?.dot !== undefined ? { dot: options.dot } : {}),
+    ...(options?.caseSensitiveMatch !== undefined ? { nocase: !options.caseSensitiveMatch } : {}),
+    ...(options?.braceExpansion !== undefined ? { nobrace: !options.braceExpansion } : {}),
+    ...(options?.extglob !== undefined ? { noext: !options.extglob } : {}),
+    ...(options?.globstar !== undefined ? { noglobstar: !options.globstar } : {}),
+    ...(options?.baseNameMatch !== undefined ? { matchBase: options.baseNameMatch } : {}),
+  };
 }
 
 function normalizeAlternationGroups(pattern: string): string {

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -1,2 +1,356 @@
-export { RealLoaderFS } from '@eggjs/loader-fs';
-export type { LoaderFS, LoaderFSGlobOptions } from '@eggjs/loader-fs';
+import fs, { type Stats } from 'node:fs';
+import path from 'node:path';
+
+import { RealLoaderFS, type LoaderFS, type LoaderFSGlobOptions } from '@eggjs/loader-fs';
+import type {} from '@eggjs/typings/global';
+import multimatch from 'multimatch';
+
+import type { ManifestStore } from './manifest.ts';
+
+export { RealLoaderFS };
+export type { LoaderFS, LoaderFSGlobOptions };
+
+export class ManifestLoaderFS implements LoaderFS {
+  readonly #manifest: ManifestStore;
+  readonly #fallback: LoaderFS;
+
+  constructor(manifest: ManifestStore, fallback: LoaderFS = new RealLoaderFS()) {
+    this.#manifest = manifest;
+    this.#fallback = fallback;
+  }
+
+  exists(filepath: string): boolean {
+    const entry = this.#getManifestEntry(filepath);
+    if (entry) {
+      return entry.type !== 'missing';
+    }
+    return this.#fallback.exists(filepath);
+  }
+
+  stat(filepath: string): Stats {
+    const entry = this.#getManifestEntry(filepath);
+    if (entry?.type === 'file' || entry?.type === 'directory') {
+      return createVirtualStats(entry.type);
+    }
+    if (entry?.type === 'missing') {
+      throw createNotFoundError('stat', filepath);
+    }
+    return this.#fallback.stat(filepath);
+  }
+
+  realpath(filepath: string): string {
+    const entry = this.#getManifestEntry(filepath);
+    if (entry?.type === 'file' || entry?.type === 'directory') {
+      return this.#toAbsolute(entry.rel);
+    }
+    if (entry?.type === 'missing') {
+      throw createNotFoundError('realpath', filepath);
+    }
+    return this.#fallback.realpath(filepath);
+  }
+
+  readJSON<T = unknown>(filepath: string): T {
+    const entry = this.#getManifestEntry(filepath);
+    if (entry?.type === 'file') {
+      const bundled = this.#loadBundledModule(entry.rel);
+      if (bundled !== undefined) {
+        return unwrapDefaultExport(bundled) as T;
+      }
+    }
+    if (entry?.type === 'missing') {
+      throw createNotFoundError('open', filepath);
+    }
+    return this.#fallback.readJSON(filepath);
+  }
+
+  glob(patterns: string | string[], options?: LoaderFSGlobOptions): string[] {
+    const cwd = options?.cwd === undefined ? process.cwd() : String(options.cwd);
+    const absoluteCwd = path.resolve(cwd);
+    const cwdRel = this.#toRelative(absoluteCwd);
+    const manifestFiles = this.#listManifestFilesUnder(cwdRel);
+    if (manifestFiles === undefined) {
+      return this.#fallback.glob(patterns, options);
+    }
+
+    const matched = filterManifestGlob(manifestFiles, patterns, options);
+    if (options?.absolute) {
+      return matched.map((file) => path.join(absoluteCwd, file));
+    }
+    return matched;
+  }
+
+  async loadFile(filepath: string): Promise<unknown> {
+    const entry = this.#getManifestEntry(filepath);
+    if (entry?.type === 'file') {
+      const bundled = this.#loadBundledModule(entry.rel);
+      if (bundled !== undefined) {
+        return unwrapDefaultExport(bundled);
+      }
+    }
+    if (entry?.type === 'missing') {
+      throw createNotFoundError('open', filepath);
+    }
+    return this.#fallback.loadFile(filepath);
+  }
+
+  #getManifestEntry(filepath: string): ManifestEntry | undefined {
+    const rel = this.#toRelative(filepath);
+    const resolved = this.#resolveManifestFile(rel);
+    if (resolved?.type === 'file') {
+      return { type: 'file', rel: resolved.rel };
+    }
+    if (resolved?.type === 'missing') {
+      return { type: 'missing', rel };
+    }
+    if (this.#isManifestDirectory(rel)) {
+      return { type: 'directory', rel };
+    }
+  }
+
+  #resolveManifestFile(rel: string): ManifestFileResolution | undefined {
+    const cache = this.#manifest.data.resolveCache;
+    if (Object.hasOwn(cache, rel)) {
+      const cached = cache[rel];
+      return cached === null ? { type: 'missing' } : { type: 'file', rel: cached };
+    }
+
+    if (this.#isManifestFile(rel)) {
+      return { type: 'file', rel };
+    }
+
+    const discovered = this.#resolveFromFileDiscovery(rel);
+    if (discovered) {
+      return { type: 'file', rel: discovered };
+    }
+  }
+
+  #resolveFromFileDiscovery(rel: string): string | undefined {
+    let matchedDir: string | undefined;
+    for (const dir of Object.keys(this.#manifest.data.fileDiscovery)) {
+      if ((rel === dir || rel.startsWith(dir + '/')) && (!matchedDir || dir.length > matchedDir.length)) {
+        matchedDir = dir;
+      }
+    }
+    if (!matchedDir || rel === matchedDir) return;
+
+    const request = rel.slice(matchedDir.length + 1);
+    for (const file of this.#manifest.data.fileDiscovery[matchedDir]) {
+      if (file === request) {
+        return path.posix.join(matchedDir, file);
+      }
+
+      const ext = path.posix.extname(file);
+      if (!ext || ext === '.map') continue;
+
+      const extensionlessFile = file.slice(0, -ext.length);
+      if (extensionlessFile === request || extensionlessFile === `${request}/index`) {
+        return path.posix.join(matchedDir, file);
+      }
+    }
+  }
+
+  #isManifestFile(rel: string): boolean {
+    for (const [dir, files] of Object.entries(this.#manifest.data.fileDiscovery)) {
+      const file = relativeFileUnderDir(dir, rel);
+      if (file !== undefined && files.includes(file)) {
+        return true;
+      }
+    }
+    return Object.values(this.#manifest.data.resolveCache).includes(rel);
+  }
+
+  #isManifestDirectory(rel: string): boolean {
+    if (rel === '') {
+      return this.#hasManifestData();
+    }
+    if (Object.hasOwn(this.#manifest.data.fileDiscovery, rel)) {
+      return true;
+    }
+
+    for (const [dir, files] of Object.entries(this.#manifest.data.fileDiscovery)) {
+      if (dir.startsWith(rel + '/')) {
+        return true;
+      }
+      for (const file of files) {
+        const fullRel = path.posix.join(dir, file);
+        if (path.posix.dirname(fullRel) === rel || fullRel.startsWith(rel + '/')) {
+          return true;
+        }
+      }
+    }
+
+    for (const target of Object.values(this.#manifest.data.resolveCache)) {
+      if (target && (path.posix.dirname(target) === rel || target.startsWith(rel + '/'))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  #listManifestFilesUnder(cwdRel: string): string[] | undefined {
+    if (!this.#isManifestDirectory(cwdRel)) return;
+
+    const files = new Set<string>();
+    for (const [dir, entries] of Object.entries(this.#manifest.data.fileDiscovery)) {
+      const prefix = dir === cwdRel ? '' : relativePrefix(cwdRel, dir);
+      if (prefix === undefined) continue;
+      for (const entry of entries) {
+        files.add(path.posix.join(prefix, entry));
+      }
+    }
+
+    for (const target of Object.values(this.#manifest.data.resolveCache)) {
+      if (!target) continue;
+      const prefix = relativePrefix(cwdRel, path.posix.dirname(target));
+      if (prefix !== undefined) {
+        files.add(path.posix.join(prefix, path.posix.basename(target)));
+      }
+    }
+    return [...files].sort();
+  }
+
+  #loadBundledModule(rel: string): unknown {
+    const loader = globalThis.__EGG_BUNDLE_MODULE_LOADER__;
+    if (!loader) return undefined;
+
+    for (const key of this.#bundleKeys(rel)) {
+      const loaded = loader(key);
+      if (loaded !== undefined) {
+        return loaded;
+      }
+    }
+  }
+
+  #bundleKeys(rel: string): string[] {
+    const abs = this.#toAbsolute(rel);
+    return [...new Set([rel, normalizePath(abs)])];
+  }
+
+  #hasManifestData(): boolean {
+    return (
+      Object.keys(this.#manifest.data.fileDiscovery).length > 0 ||
+      Object.keys(this.#manifest.data.resolveCache).some((key) => this.#manifest.data.resolveCache[key] !== null)
+    );
+  }
+
+  #toRelative(filepath: string): string {
+    const rel = path.relative(this.#manifest.baseDir, path.resolve(filepath));
+    return normalizePath(rel);
+  }
+
+  #toAbsolute(rel: string): string {
+    return path.isAbsolute(rel) ? rel : path.join(this.#manifest.baseDir, rel);
+  }
+}
+
+interface ManifestEntry {
+  type: 'file' | 'directory' | 'missing';
+  rel: string;
+}
+
+type ManifestFileResolution = { type: 'file'; rel: string } | { type: 'missing' };
+
+function normalizePath(filepath: string): string {
+  return filepath.replaceAll(path.sep, '/');
+}
+
+function relativePrefix(cwdRel: string, dirRel: string): string | undefined {
+  if (cwdRel === '') return dirRel;
+  if (dirRel === cwdRel) return '';
+  if (dirRel.startsWith(cwdRel + '/')) return dirRel.slice(cwdRel.length + 1);
+}
+
+function relativeFileUnderDir(dirRel: string, fileRel: string): string | undefined {
+  if (dirRel === '') return fileRel;
+  if (fileRel.startsWith(dirRel + '/')) return fileRel.slice(dirRel.length + 1);
+}
+
+function filterManifestGlob(files: string[], patterns: string | string[], options?: LoaderFSGlobOptions): string[] {
+  const patternList = Array.isArray(patterns) ? patterns : [patterns];
+  if (!patternList.some((pattern) => !pattern.startsWith('!'))) return [];
+
+  const ignoreList = Array.isArray(options?.ignore)
+    ? options.ignore.map(String)
+    : options?.ignore
+      ? [String(options.ignore)]
+      : [];
+  const normalizedPatterns = patternList
+    .map(normalizeAlternationGroups)
+    .concat(ignoreList.map((pattern) => `!${normalizeAlternationGroups(pattern)}`));
+  return multimatch(files, normalizedPatterns);
+}
+
+function normalizeAlternationGroups(pattern: string): string {
+  let normalized = '';
+  for (let index = 0; index < pattern.length; index++) {
+    const char = pattern[index];
+    if (char !== '(' || isExtglobPrefix(pattern[index - 1])) {
+      normalized += char;
+      continue;
+    }
+
+    const end = pattern.indexOf(')', index + 1);
+    if (end === -1) {
+      normalized += char;
+      continue;
+    }
+
+    const group = pattern.slice(index + 1, end);
+    if (group.includes('|')) {
+      normalized += `{${group.replaceAll('|', ',')}}`;
+      index = end;
+    } else {
+      normalized += char;
+    }
+  }
+  return normalized;
+}
+
+function isExtglobPrefix(char: string | undefined): boolean {
+  return char === '@' || char === '!' || char === '?' || char === '+' || char === '*';
+}
+
+function unwrapDefaultExport(value: unknown): unknown {
+  let unwrapped = value;
+  if (isRecord(unwrapped) && isRecord(unwrapped.default) && unwrapped.default.__esModule === true) {
+    unwrapped = unwrapped.default;
+  }
+  if (isRecord(unwrapped) && 'default' in unwrapped) {
+    return unwrapped.default;
+  }
+  return unwrapped;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function createVirtualStats(type: 'file' | 'directory'): Stats {
+  const stat = Object.create(fs.Stats.prototype) as Stats;
+  const isFile = type === 'file';
+  const timestamp = new Date(0);
+  Object.defineProperties(stat, {
+    size: { value: 0 },
+    atimeMs: { value: 0 },
+    mtimeMs: { value: 0 },
+    ctimeMs: { value: 0 },
+    birthtimeMs: { value: 0 },
+    atime: { value: timestamp },
+    mtime: { value: timestamp },
+    ctime: { value: timestamp },
+    birthtime: { value: timestamp },
+    isFile: { value: () => isFile },
+    isDirectory: { value: () => !isFile },
+    isSymbolicLink: { value: () => false },
+  });
+  return stat;
+}
+
+function createNotFoundError(syscall: string, filepath: string): NodeJS.ErrnoException {
+  const err = new Error(`ENOENT: no such file or directory, ${syscall} '${filepath}'`) as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  err.errno = -2;
+  err.syscall = syscall;
+  err.path = filepath;
+  return err;
+}

--- a/packages/core/test/__snapshots__/index.test.ts.snap
+++ b/packages/core/test/__snapshots__/index.test.ts.snap
@@ -18,6 +18,7 @@ exports[`should expose properties 1`] = `
   "KoaRequest",
   "KoaResponse",
   "Lifecycle",
+  "ManifestLoaderFS",
   "ManifestStore",
   "RealLoaderFS",
   "Request",

--- a/packages/core/test/loader/egg_loader.test.ts
+++ b/packages/core/test/loader/egg_loader.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -85,6 +86,32 @@ describe('test/loader/egg_loader.test.ts', () => {
       ret = await loader.loadFile(getFilepath('load_file/function'), 1, 2);
       assert.equal(ret[0], 1);
       assert.equal(ret[1], 2);
+    });
+
+    it('should read app package metadata through loaderFS', async () => {
+      const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-loader-package-fs-'));
+      const packagePath = path.join(baseDir, 'package.json');
+      const loaderFS = new PackageMetadataLoaderFS(packagePath, {
+        name: 'manifest-app',
+        egg: { outDir: 'bundle-dist' },
+      });
+
+      try {
+        const loader = new EggLoader({
+          env: 'unittest',
+          baseDir,
+          app: {} as EggLoaderOptions['app'],
+          logger: app.logger,
+          loaderFS,
+        });
+
+        assert.equal(loader.getAppname(), 'manifest-app');
+        assert.equal(loader.outDir, 'bundle-dist');
+        assert.deepEqual(loaderFS.readJSONCalls, [packagePath]);
+        await assert.rejects(fs.access(packagePath), { code: 'ENOENT' });
+      } finally {
+        await fs.rm(baseDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -229,3 +256,23 @@ describe('test/loader/egg_loader.test.ts', () => {
     });
   });
 });
+
+class PackageMetadataLoaderFS extends RealLoaderFS {
+  readonly readJSONCalls: string[] = [];
+  readonly #packagePath: string;
+  readonly #packageMetadata: Record<string, unknown>;
+
+  constructor(packagePath: string, packageMetadata: Record<string, unknown>) {
+    super();
+    this.#packagePath = packagePath;
+    this.#packageMetadata = packageMetadata;
+  }
+
+  readJSON<T = unknown>(filepath: string): T {
+    this.readJSONCalls.push(filepath);
+    if (filepath === this.#packagePath) {
+      return this.#packageMetadata as T;
+    }
+    return super.readJSON<T>(filepath);
+  }
+}

--- a/packages/core/test/loader/egg_loader.test.ts
+++ b/packages/core/test/loader/egg_loader.test.ts
@@ -113,6 +113,54 @@ describe('test/loader/egg_loader.test.ts', () => {
         await fs.rm(baseDir, { recursive: true, force: true });
       }
     });
+
+    it('should load plugin package metadata through loaderFS loadFile', async () => {
+      const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-loader-plugin-package-fs-'));
+      const appPackagePath = path.join(baseDir, 'package.json');
+      const pluginPath = path.join(baseDir, 'plugins/manifest-plugin');
+      const pluginPackagePath = path.join(pluginPath, 'package.json');
+      const loaderFS = new PackageMetadataLoaderFS(
+        appPackagePath,
+        { name: 'manifest-app' },
+        {
+          [pluginPackagePath]: {
+            name: 'manifest-plugin',
+            version: '1.2.3',
+            eggPlugin: { name: 'manifestPlugin' },
+          },
+        },
+      );
+
+      try {
+        await fs.mkdir(pluginPath, { recursive: true });
+        const loader = new EggLoader({
+          env: 'unittest',
+          baseDir,
+          app: {} as EggLoaderOptions['app'],
+          logger: app.logger,
+          loaderFS,
+          plugins: {
+            manifestPlugin: {
+              name: 'manifestPlugin',
+              enable: true,
+              dependencies: [],
+              optionalDependencies: [],
+              env: [],
+              from: '<egg_loader.test.ts>',
+              path: pluginPath,
+            },
+          },
+        });
+
+        await loader.loadPlugin();
+
+        assert.equal(loader.plugins.manifestPlugin.version, '1.2.3');
+        assert.deepEqual(loaderFS.loadFileCalls, [pluginPackagePath]);
+        await assert.rejects(fs.access(pluginPackagePath), { code: 'ENOENT' });
+      } finally {
+        await fs.rm(baseDir, { recursive: true, force: true });
+      }
+    });
   });
 
   it('should be loaded by loadToApp, support symbol property', async () => {
@@ -259,20 +307,40 @@ describe('test/loader/egg_loader.test.ts', () => {
 
 class PackageMetadataLoaderFS extends RealLoaderFS {
   readonly readJSONCalls: string[] = [];
-  readonly #packagePath: string;
-  readonly #packageMetadata: Record<string, unknown>;
+  readonly loadFileCalls: string[] = [];
+  readonly #packageMetadataByPath: Map<string, Record<string, unknown>>;
 
-  constructor(packagePath: string, packageMetadata: Record<string, unknown>) {
+  constructor(
+    packagePath: string,
+    packageMetadata: Record<string, unknown>,
+    extraPackageMetadata: Record<string, Record<string, unknown>> = {},
+  ) {
     super();
-    this.#packagePath = packagePath;
-    this.#packageMetadata = packageMetadata;
+    this.#packageMetadataByPath = new Map([[packagePath, packageMetadata], ...Object.entries(extraPackageMetadata)]);
+  }
+
+  exists(filepath: string): boolean {
+    if (this.#packageMetadataByPath.has(filepath)) {
+      return true;
+    }
+    return super.exists(filepath);
   }
 
   readJSON<T = unknown>(filepath: string): T {
     this.readJSONCalls.push(filepath);
-    if (filepath === this.#packagePath) {
-      return this.#packageMetadata as T;
+    const metadata = this.#packageMetadataByPath.get(filepath);
+    if (metadata) {
+      return metadata as T;
     }
     return super.readJSON<T>(filepath);
+  }
+
+  async loadFile(filepath: string): Promise<unknown> {
+    this.loadFileCalls.push(filepath);
+    const metadata = this.#packageMetadataByPath.get(filepath);
+    if (metadata) {
+      return metadata;
+    }
+    return super.loadFile(filepath);
   }
 }

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -175,6 +175,10 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
         manifest.fileDiscovery['node_modules/@eggjs/security/app/middleware']?.includes('securities.js'),
         'security middleware should be included in manifest fileDiscovery',
       );
+      assert.ok(
+        manifest.fileDiscovery['node_modules/@eggjs/security']?.includes('package.json'),
+        'plugin package metadata should be included in manifest fileDiscovery',
+      );
     } finally {
       await testApp.close();
     }

--- a/packages/core/test/loader/manifest_coverage.test.ts
+++ b/packages/core/test/loader/manifest_coverage.test.ts
@@ -176,6 +176,10 @@ describe('ManifestStore coverage: FileLoader getter auto-injects manifest', () =
         'security middleware should be included in manifest fileDiscovery',
       );
       assert.ok(
+        manifest.fileDiscovery['']?.includes('package.json'),
+        'app package metadata should be included in manifest fileDiscovery',
+      );
+      assert.ok(
         manifest.fileDiscovery['node_modules/@eggjs/security']?.includes('package.json'),
         'plugin package metadata should be included in manifest fileDiscovery',
       );

--- a/packages/core/test/loader/manifest_loader_fs.test.ts
+++ b/packages/core/test/loader/manifest_loader_fs.test.ts
@@ -170,6 +170,29 @@ describe('test/loader/manifest_loader_fs.test.ts', () => {
     assert.throws(() => loaderFS.readJSON(missingPath), /ENOENT/);
     await assert.rejects(() => loaderFS.loadFile(missingPath), /ENOENT/);
   });
+
+  it('passes common globby matching options to manifest glob matching', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-glob-options-');
+    const serviceDir = path.join(baseDir, 'app/service');
+    const store = ManifestStore.fromBundle(
+      createManifest({
+        fileDiscovery: {
+          'app/service': ['.hidden.ts', 'User.TS', 'user.ts'],
+        },
+      }),
+      baseDir,
+    );
+    const loaderFS = new ManifestLoaderFS(store, new ThrowingGlobLoaderFS());
+
+    assert.deepEqual(loaderFS.glob('**/*.ts', { cwd: serviceDir }), ['user.ts']);
+    assert.deepEqual(loaderFS.glob('**/*.ts', { cwd: serviceDir, dot: true }), ['.hidden.ts', 'user.ts']);
+    assert.deepEqual(loaderFS.glob('**/*.ts', { cwd: serviceDir, caseSensitiveMatch: false }), ['User.TS', 'user.ts']);
+    assert.deepEqual(loaderFS.glob('**/*.ts', { cwd: serviceDir, dot: true, caseSensitiveMatch: false }), [
+      '.hidden.ts',
+      'User.TS',
+      'user.ts',
+    ]);
+  });
 });
 
 class ThrowingGlobLoaderFS extends RealLoaderFS {

--- a/packages/core/test/loader/manifest_loader_fs.test.ts
+++ b/packages/core/test/loader/manifest_loader_fs.test.ts
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { setBundleModuleLoader } from '@eggjs/utils';
+import { afterEach, describe, it } from 'vitest';
+
+import { ManifestLoaderFS, RealLoaderFS, type LoaderFSGlobOptions } from '../../src/loader/loader_fs.ts';
+import { ManifestStore, type StartupManifest } from '../../src/loader/manifest.ts';
+
+describe('test/loader/manifest_loader_fs.test.ts', () => {
+  const createdDirs: string[] = [];
+
+  afterEach(async () => {
+    setBundleModuleLoader(undefined);
+    await Promise.all(createdDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it('serves manifest-backed stat, realpath, glob, readJSON, and loadFile from the bundle map', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-');
+    const manifest = createManifest({
+      fileDiscovery: {
+        'app/service': ['nested/order.ts', 'user.ts', 'user.d.ts'],
+        config: ['config.default.ts', 'plugin.ts'],
+        'node_modules/fake-plugin': ['app.ts', 'package.json'],
+      },
+      resolveCache: {
+        'config/plugin': 'config/plugin.ts',
+        'node_modules/fake-plugin/app': 'node_modules/fake-plugin/app.ts',
+      },
+    });
+    const store = ManifestStore.fromBundle(manifest, baseDir);
+    const modules: Record<string, unknown> = {
+      'config/plugin.ts': { default: { fakePlugin: { enable: true, package: 'fake-plugin' } } },
+      [normalize(path.join(baseDir, 'config/plugin.ts'))]: {
+        default: { fakePlugin: { enable: true, package: 'fake-plugin' } },
+      },
+      'node_modules/fake-plugin/package.json': {
+        default: { name: 'fake-plugin', version: '1.0.0', eggPlugin: { name: 'fakePlugin' } },
+      },
+      [normalize(path.join(baseDir, 'node_modules/fake-plugin/package.json'))]: {
+        default: { name: 'fake-plugin', version: '1.0.0', eggPlugin: { name: 'fakePlugin' } },
+      },
+    };
+    setBundleModuleLoader((filepath) => modules[filepath]);
+
+    const loaderFS = new ManifestLoaderFS(store);
+    const serviceFile = path.join(baseDir, 'app/service/user.ts');
+    const serviceDir = path.join(baseDir, 'app/service');
+    const pluginAlias = path.join(baseDir, 'config/plugin');
+    const pluginPackage = path.join(baseDir, 'node_modules/fake-plugin/package.json');
+
+    assert.equal(loaderFS.exists(serviceFile), true);
+    assert.equal(loaderFS.exists(serviceDir), true);
+    assert.equal(loaderFS.exists(pluginAlias), true);
+    assert.equal(loaderFS.stat(serviceFile).isFile(), true);
+    const serviceDirStat = loaderFS.stat(serviceDir);
+    assert.equal(serviceDirStat.isDirectory(), true);
+    assert.equal(serviceDirStat.mtime.getTime(), 0);
+    assert.equal(loaderFS.realpath(pluginAlias), path.join(baseDir, 'config/plugin.ts'));
+    assert.deepEqual(loaderFS.glob(['**/*.(js|ts)', '!**/*.d.ts'], { cwd: serviceDir }), [
+      'nested/order.ts',
+      'user.ts',
+    ]);
+    assert.deepEqual(loaderFS.glob('user.ts', { cwd: path.relative(process.cwd(), serviceDir), absolute: true }), [
+      serviceFile,
+    ]);
+    assert.deepEqual(loaderFS.glob(['**/[no]*.ts', '!**/*.d.ts'], { cwd: serviceDir }), ['nested/order.ts']);
+    assert.deepEqual(loaderFS.readJSON(pluginPackage), {
+      name: 'fake-plugin',
+      version: '1.0.0',
+      eggPlugin: { name: 'fakePlugin' },
+    });
+    assert.deepEqual(await loaderFS.loadFile(pluginAlias), { fakePlugin: { enable: true, package: 'fake-plugin' } });
+  });
+
+  it('falls back to the real filesystem for paths missing from the manifest', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-fallback-');
+    const realDir = path.join(baseDir, 'real');
+    await fs.mkdir(realDir);
+    await fs.writeFile(path.join(realDir, 'package.json'), JSON.stringify({ name: 'real-package' }));
+    await fs.writeFile(path.join(realDir, 'config.js'), 'export default { real: true };\n');
+    const store = ManifestStore.fromBundle(createManifest(), baseDir);
+    const loaderFS = new ManifestLoaderFS(store);
+
+    assert.equal(loaderFS.exists(path.join(realDir, 'package.json')), true);
+    assert.equal(loaderFS.stat(path.join(realDir, 'package.json')).isFile(), true);
+    assert.deepEqual(loaderFS.glob('**/*.js', { cwd: realDir }), ['config.js']);
+    assert.deepEqual(loaderFS.readJSON(path.join(realDir, 'package.json')), { name: 'real-package' });
+    assert.deepEqual(await loaderFS.loadFile(path.join(realDir, 'config.js')), { real: true });
+  });
+
+  it('prefers manifest and bundle-map results over same-path real files', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-priority-');
+    await fs.mkdir(path.join(baseDir, 'config'));
+    await fs.writeFile(path.join(baseDir, 'config/plugin.js'), 'export default { source: "real" };\n');
+    const manifest = createManifest({
+      fileDiscovery: {
+        config: ['plugin.js'],
+      },
+    });
+    const store = ManifestStore.fromBundle(manifest, baseDir);
+    setBundleModuleLoader((filepath) => {
+      if (filepath === 'config/plugin.js' || filepath === normalize(path.join(baseDir, 'config/plugin.js'))) {
+        return { default: { source: 'manifest' } };
+      }
+    });
+
+    const loaderFS = new ManifestLoaderFS(store);
+
+    assert.deepEqual(await loaderFS.loadFile(path.join(baseDir, 'config/plugin.js')), { source: 'manifest' });
+  });
+
+  it('does not fall back when manifest covers an empty directory', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-empty-');
+    const store = ManifestStore.fromBundle(
+      createManifest({
+        fileDiscovery: {
+          empty: [],
+        },
+      }),
+      baseDir,
+    );
+    const loaderFS = new ManifestLoaderFS(store, new ThrowingGlobLoaderFS());
+
+    assert.deepEqual(loaderFS.glob('**/*.js', { cwd: path.join(baseDir, 'empty') }), []);
+  });
+
+  it('treats direct relative paths as process cwd relative before matching manifest entries', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-relative-');
+    const cwd = await createTempDir(createdDirs, 'egg-manifest-loader-fs-cwd-');
+    const store = ManifestStore.fromBundle(
+      createManifest({
+        fileDiscovery: {
+          config: ['plugin.ts'],
+        },
+      }),
+      baseDir,
+    );
+    const loaderFS = new ManifestLoaderFS(store, new MissingLoaderFS());
+    const manifestFile = path.join(baseDir, 'config/plugin.ts');
+    const cwdRelativeFile = path.relative(cwd, manifestFile);
+
+    withProcessCwd(cwd, () => {
+      assert.equal(loaderFS.exists(cwdRelativeFile), true);
+      assert.equal(loaderFS.realpath(cwdRelativeFile), manifestFile);
+      assert.equal(loaderFS.exists('config/plugin.ts'), false);
+    });
+  });
+
+  it('does not fall back to real fs for explicit resolveCache misses', async () => {
+    const baseDir = await createTempDir(createdDirs, 'egg-manifest-loader-fs-miss-');
+    await fs.mkdir(path.join(baseDir, 'config'));
+    await fs.writeFile(path.join(baseDir, 'config/missing'), '{"source":"real"}\n');
+    const missingPath = path.join(baseDir, 'config/missing');
+    const store = ManifestStore.fromBundle(
+      createManifest({
+        resolveCache: {
+          'config/missing': null,
+        },
+      }),
+      baseDir,
+    );
+    const loaderFS = new ManifestLoaderFS(store, new ThrowingLoaderFS());
+
+    assert.equal(loaderFS.exists(missingPath), false);
+    assert.throws(() => loaderFS.stat(missingPath), /ENOENT/);
+    assert.throws(() => loaderFS.realpath(missingPath), /ENOENT/);
+    assert.throws(() => loaderFS.readJSON(missingPath), /ENOENT/);
+    await assert.rejects(() => loaderFS.loadFile(missingPath), /ENOENT/);
+  });
+});
+
+class ThrowingGlobLoaderFS extends RealLoaderFS {
+  glob(_patterns: string | string[], _options?: LoaderFSGlobOptions): string[] {
+    throw new Error('unexpected real fs fallback');
+  }
+}
+
+class MissingLoaderFS extends RealLoaderFS {
+  exists(_filepath: string): boolean {
+    return false;
+  }
+}
+
+class ThrowingLoaderFS extends RealLoaderFS {
+  exists(_filepath: string): boolean {
+    throw new Error('unexpected real fs fallback');
+  }
+
+  stat(_filepath: string): never {
+    throw new Error('unexpected real fs fallback');
+  }
+
+  realpath(_filepath: string): never {
+    throw new Error('unexpected real fs fallback');
+  }
+
+  readJSON<T = unknown>(_filepath: string): T {
+    throw new Error('unexpected real fs fallback');
+  }
+
+  async loadFile(_filepath: string): Promise<unknown> {
+    throw new Error('unexpected real fs fallback');
+  }
+}
+
+async function createTempDir(createdDirs: string[], prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  createdDirs.push(dir);
+  return dir;
+}
+
+function createManifest(
+  overrides: Partial<Pick<StartupManifest, 'fileDiscovery' | 'resolveCache'>> = {},
+): StartupManifest {
+  return {
+    version: 1,
+    generatedAt: '2026-05-10T00:00:00.000Z',
+    invalidation: {
+      lockfileFingerprint: '',
+      configFingerprint: '',
+      serverEnv: 'unittest',
+      serverScope: '',
+      typescriptEnabled: true,
+    },
+    extensions: {},
+    resolveCache: overrides.resolveCache ?? {},
+    fileDiscovery: overrides.fileDiscovery ?? {},
+  };
+}
+
+function normalize(filepath: string): string {
+  return filepath.replaceAll(path.sep, '/');
+}
+
+function withProcessCwd<T>(cwd: string, fn: () => T): T {
+  const originalCwd = process.cwd.bind(process);
+  process.cwd = () => cwd;
+  try {
+    return fn();
+  } finally {
+    process.cwd = originalCwd;
+  }
+}

--- a/packages/loader-fs/src/index.ts
+++ b/packages/loader-fs/src/index.ts
@@ -55,6 +55,9 @@ export class RealLoaderFS implements LoaderFS {
     debug('[loadFile:start] filepath: %s', filepath);
     try {
       const extname = path.extname(filepath);
+      if (extname === '.json') {
+        return JSON.parse(await fs.promises.readFile(filepath, 'utf8'));
+      }
       if (extname && !extensionNames.includes(extname) && extname !== '.ts') {
         return fs.readFileSync(filepath);
       }

--- a/packages/loader-fs/test/loader_fs.test.ts
+++ b/packages/loader-fs/test/loader_fs.test.ts
@@ -31,6 +31,7 @@ describe('test/loader_fs.test.ts', () => {
 
     assert.deepEqual(loaderFS.readJSON(packagePath), JSON.parse(fs.readFileSync(packagePath, 'utf8')));
     assert.deepEqual(loaderFS.glob(patterns, { cwd: baseDir }).sort(), globby.sync(patterns, { cwd: baseDir }).sort());
+    assert.deepEqual(await loaderFS.loadFile(packagePath), JSON.parse(fs.readFileSync(packagePath, 'utf8')));
     assert.deepEqual(await loaderFS.loadFile(path.join(baseDir, 'object.js')), { a: 1 });
     assert.deepEqual(await loaderFS.loadFile(yamlPath), fs.readFileSync(yamlPath));
   });

--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -388,20 +388,6 @@ export class Bundler {
     );
     debug('copied %d runtime assets', copiedRuntimeAssets.length);
 
-    // Merge project name into output package.json so the framework's
-    // getAppname() finds it (it reads baseDir/package.json).
-    const outputPkgPath = path.join(absOutputDir, 'package.json');
-    await wrapStep('patch output package.json', async () => {
-      const srcPkg = JSON.parse(await fs.readFile(path.join(absBaseDir, 'package.json'), 'utf8')) as {
-        name?: string;
-      };
-      if (srcPkg.name) {
-        const outPkg = JSON.parse(await fs.readFile(outputPkgPath, 'utf8')) as Record<string, unknown>;
-        outPkg.name = srcPkg.name;
-        await fs.writeFile(outputPkgPath, JSON.stringify(outPkg, null, 2));
-      }
-    });
-
     const manifestPathAbs = path.join(absOutputDir, BUNDLE_MANIFEST_FILENAME);
     const bundleManifest: BundleManifest = {
       version: BUNDLE_MANIFEST_VERSION,

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -137,6 +137,17 @@ describe('bundle() integration — minimal-app (Phase 1: mocked @utoo/pack)', ()
     expect(JSON.parse(pkgAtBuildTime!)).toEqual({ type: 'commonjs' });
   });
 
+  it('leaves output package.json as the pack runtime package instead of patching app metadata into it', async () => {
+    await bundle({
+      baseDir: tmpApp,
+      outputDir: tmpOutput,
+      pack: { buildFunc: makeMockBuild() },
+    });
+
+    const outputPkg = JSON.parse(await fs.readFile(path.join(tmpOutput, 'package.json'), 'utf8'));
+    expect(outputPkg).toEqual({ type: 'commonjs' });
+  });
+
   it('writes a bundle-manifest.json whose schema matches docs/output-structure.md', async () => {
     const result = await bundle({
       baseDir: tmpApp,


### PR DESCRIPTION
## Summary

- Add `ManifestLoaderFS`, a manifest-first `LoaderFS` implementation backed by `StartupManifest` discovery/resolve data and the bundled module loader.
- Wire `EggLoader` to use `ManifestLoaderFS` for bundled stores and manifest-backed startup while keeping real filesystem fallback.
- Include package metadata files in generated manifest discovery and add tests for manifest-backed glob/stat/readJSON/loadFile, plugin metadata, and fallback behavior.

## Tests

- `pnpm exec vitest run packages/core/test/loader/loader_fs.test.ts packages/core/test/loader/manifest_loader_fs.test.ts packages/core/test/loader/file_loader.test.ts packages/core/test/loader/manifest_coverage.test.ts packages/core/test/loader/manifest_roundtrip.test.ts --testTimeout 20000`
- `pnpm --filter @eggjs/core typecheck`
- `pnpm exec oxlint packages/core/src/loader/loader_fs.ts packages/core/test/loader/manifest_loader_fs.test.ts --type-aware`

Issue: EGG-98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest-backed filesystem access for loading files and bundled modules; loader now prefers manifest entries when available.

* **Refactor**
  * Plugin package.json reading and path checks now go through the abstracted loader and honor manifest-backed files.
  * Startup manifest generation records discovered package.json basenames and avoids duplicate discovery.

* **Tests**
  * Added/expanded tests covering manifest-backed loading, globbing, JSON parsing, bundled module loading, and regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->