### PR TITLE
feat(bundler): inject manifest loader fs into worker

### DIFF
--- a/packages/core/src/egg.ts
+++ b/packages/core/src/egg.ts
@@ -16,6 +16,7 @@ import type { ReadyFunctionArg } from 'get-ready';
 import { BaseContextClass } from './base_context_class.ts';
 import { Lifecycle } from './lifecycle.ts';
 import { EggLoader } from './loader/egg_loader.ts';
+import type { LoaderFS } from './loader/loader_fs.ts';
 import { Singleton, type SingletonCreateMethod, type SingletonOptions } from './singleton.ts';
 import type { EggAppConfig } from './types.ts';
 import utils, { type Fun } from './utils/index.ts';
@@ -33,6 +34,8 @@ export interface EggCoreOptions {
   env?: string;
   /** Skip lifecycle hooks, only trigger loadMetadata for manifest generation */
   metadataOnly?: boolean;
+  /** Loader-facing filesystem abstraction */
+  loaderFS?: LoaderFS;
   /**
    * When true, lifecycle stops after the `configWillLoad` phase.
    * `configDidLoad`, `didLoad`, `willReady`, `didReady`, and `serverDidReady`
@@ -230,6 +233,7 @@ export class EggCore extends KoaApplication {
       env: options.env ?? '',
       EggCoreClass: EggCore,
       metadataOnly: options.metadataOnly,
+      loaderFS: options.loaderFS,
     });
   }
 

--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -25,7 +25,6 @@ import { sequencify } from '../utils/sequencify.ts';
 import { Timing } from '../utils/timing.ts';
 import { type ContextLoaderOptions, ContextLoader } from './context_loader.ts';
 import { type FileLoaderOptions, CaseStyle, FULLPATH, FileLoader } from './file_loader.ts';
-import { ManifestLoaderFS } from './loader_fs.ts';
 import { ManifestStore, type StartupManifest } from './manifest.ts';
 
 const debug = debuglog('egg/core/loader/egg_loader');
@@ -96,10 +95,7 @@ export class EggLoader {
    */
   constructor(options: EggLoaderOptions) {
     this.options = options;
-    const bundleStore = ManifestStore.getBundleStore();
-    this.loaderFS =
-      this.options.loaderFS ??
-      (bundleStore?.baseDir === this.options.baseDir ? new ManifestLoaderFS(bundleStore) : new RealLoaderFS());
+    this.loaderFS = this.options.loaderFS ?? new RealLoaderFS();
     assert(fs.existsSync(this.options.baseDir), `${this.options.baseDir} not exists`);
     assert(this.options.app, 'options.app is required');
     assert(this.options.logger, 'options.logger is required');
@@ -180,9 +176,6 @@ export class EggLoader {
     this.manifest =
       ManifestStore.load(this.options.baseDir, this.serverEnv, this.serverScope) ??
       ManifestStore.createCollector(this.options.baseDir);
-    if (!this.options.loaderFS && !(this.loaderFS instanceof ManifestLoaderFS)) {
-      this.loaderFS = new ManifestLoaderFS(this.manifest, this.loaderFS);
-    }
   }
 
   get app(): EggCore {
@@ -1802,14 +1795,17 @@ export class EggLoader {
    * generation time.
    */
   #collectConventionalDynamicFiles(manifest: StartupManifest): void {
+    const resolveCacheTargets = new Set(
+      Object.values(manifest.resolveCache).filter((target): target is string => typeof target === 'string'),
+    );
     for (const unit of this.getLoadUnits()) {
-      this.#collectConventionFile(manifest, path.join(unit.path, 'package.json'));
+      this.#collectConventionFile(manifest, path.join(unit.path, 'package.json'), resolveCacheTargets);
       for (const load of CONVENTIONAL_MANIFEST_LOADS) {
         const target = path.join(unit.path, ...load.path);
         if (load.type === 'resolve') {
-          this.#collectConventionResolve(manifest, target);
+          this.#collectConventionResolve(manifest, target, resolveCacheTargets);
         } else if ('extensionlessResolve' in load && load.extensionlessResolve) {
-          this.#collectConventionFileResolves(manifest, target);
+          this.#collectConventionFileResolves(manifest, target, resolveCacheTargets);
         } else {
           this.#collectConventionFileDiscovery(manifest, target);
         }
@@ -1817,21 +1813,25 @@ export class EggLoader {
     }
   }
 
-  #collectConventionResolve(manifest: StartupManifest, request: string): void {
+  #collectConventionResolve(manifest: StartupManifest, request: string, resolveCacheTargets: Set<string>): void {
     const requestKey = this.#toManifestRel(request);
     if (Object.hasOwn(manifest.resolveCache, requestKey)) return;
 
     const resolved = this.#doResolveModule(request);
-    manifest.resolveCache[requestKey] = resolved ? this.#toManifestRel(resolved) : null;
+    const resolvedKey = resolved ? this.#toManifestRel(resolved) : null;
+    manifest.resolveCache[requestKey] = resolvedKey;
+    if (resolvedKey !== null) {
+      resolveCacheTargets.add(resolvedKey);
+    }
   }
 
-  #collectConventionFileResolves(manifest: StartupManifest, directory: string): void {
+  #collectConventionFileResolves(manifest: StartupManifest, directory: string, resolveCacheTargets: Set<string>): void {
     const files = this.#collectConventionFileDiscovery(manifest, directory);
     for (const file of files) {
       const ext = path.extname(file);
       if (!ext) continue;
       const request = path.join(directory, file.slice(0, -ext.length));
-      this.#collectConventionResolve(manifest, request);
+      this.#collectConventionResolve(manifest, request, resolveCacheTargets);
     }
   }
 
@@ -1846,9 +1846,9 @@ export class EggLoader {
     return manifest.fileDiscovery[dirKey];
   }
 
-  #collectConventionFile(manifest: StartupManifest, filepath: string): void {
+  #collectConventionFile(manifest: StartupManifest, filepath: string, resolveCacheTargets: Set<string>): void {
     const fileKey = this.#toManifestRel(filepath);
-    if (Object.values(manifest.resolveCache).includes(fileKey)) return;
+    if (resolveCacheTargets.has(fileKey)) return;
     if (!fs.existsSync(filepath) || !fs.statSync(filepath).isFile()) return;
 
     const dirKey = this.#toManifestRel(path.dirname(filepath));

--- a/packages/core/src/loader/loader_fs.ts
+++ b/packages/core/src/loader/loader_fs.ts
@@ -13,10 +13,33 @@ export type { LoaderFS, LoaderFSGlobOptions };
 export class ManifestLoaderFS implements LoaderFS {
   readonly #manifest: ManifestStore;
   readonly #fallback: LoaderFS;
+  readonly #manifestFiles: Set<string>;
+  readonly #manifestDirectories: Set<string>;
+  readonly #resolveCacheTargets: Set<string>;
 
   constructor(manifest: ManifestStore, fallback: LoaderFS = new RealLoaderFS()) {
     this.#manifest = manifest;
     this.#fallback = fallback;
+    this.#resolveCacheTargets = new Set(
+      Object.values(manifest.data.resolveCache).filter((target): target is string => typeof target === 'string'),
+    );
+
+    const manifestFiles = new Set<string>();
+    const manifestDirectories = new Set<string>();
+    for (const [dir, files] of Object.entries(manifest.data.fileDiscovery)) {
+      addManifestDirectory(manifestDirectories, dir);
+      for (const file of files) {
+        const fullRel = path.posix.join(dir, file);
+        manifestFiles.add(fullRel);
+        addManifestDirectory(manifestDirectories, path.posix.dirname(fullRel));
+      }
+    }
+    for (const target of this.#resolveCacheTargets) {
+      manifestFiles.add(target);
+      addManifestDirectory(manifestDirectories, path.posix.dirname(target));
+    }
+    this.#manifestFiles = manifestFiles;
+    this.#manifestDirectories = manifestDirectories;
   }
 
   exists(filepath: string): boolean {
@@ -125,15 +148,10 @@ export class ManifestLoaderFS implements LoaderFS {
   }
 
   #resolveFromFileDiscovery(rel: string): string | undefined {
-    let matchedDir: string | undefined;
-    for (const dir of Object.keys(this.#manifest.data.fileDiscovery)) {
-      if ((rel === dir || rel.startsWith(dir + '/')) && (!matchedDir || dir.length > matchedDir.length)) {
-        matchedDir = dir;
-      }
-    }
-    if (!matchedDir || rel === matchedDir) return;
+    const matchedDir = this.#nearestManifestDiscoveryDir(rel);
+    if (matchedDir === undefined || rel === matchedDir) return;
 
-    const request = rel.slice(matchedDir.length + 1);
+    const request = matchedDir === '' ? rel : rel.slice(matchedDir.length + 1);
     for (const file of this.#manifest.data.fileDiscovery[matchedDir]) {
       if (file === request) {
         return path.posix.join(matchedDir, file);
@@ -149,42 +167,24 @@ export class ManifestLoaderFS implements LoaderFS {
     }
   }
 
-  #isManifestFile(rel: string): boolean {
-    for (const [dir, files] of Object.entries(this.#manifest.data.fileDiscovery)) {
-      const file = relativeFileUnderDir(dir, rel);
-      if (file !== undefined && files.includes(file)) {
-        return true;
+  #nearestManifestDiscoveryDir(rel: string): string | undefined {
+    let current = path.posix.dirname(rel);
+    while (true) {
+      const dir = current === '.' ? '' : current;
+      if (Object.hasOwn(this.#manifest.data.fileDiscovery, dir)) {
+        return dir;
       }
+      if (dir === '') return;
+      current = path.posix.dirname(dir);
     }
-    return Object.values(this.#manifest.data.resolveCache).includes(rel);
+  }
+
+  #isManifestFile(rel: string): boolean {
+    return this.#manifestFiles.has(rel);
   }
 
   #isManifestDirectory(rel: string): boolean {
-    if (rel === '') {
-      return this.#hasManifestData();
-    }
-    if (Object.hasOwn(this.#manifest.data.fileDiscovery, rel)) {
-      return true;
-    }
-
-    for (const [dir, files] of Object.entries(this.#manifest.data.fileDiscovery)) {
-      if (dir.startsWith(rel + '/')) {
-        return true;
-      }
-      for (const file of files) {
-        const fullRel = path.posix.join(dir, file);
-        if (path.posix.dirname(fullRel) === rel || fullRel.startsWith(rel + '/')) {
-          return true;
-        }
-      }
-    }
-
-    for (const target of Object.values(this.#manifest.data.resolveCache)) {
-      if (target && (path.posix.dirname(target) === rel || target.startsWith(rel + '/'))) {
-        return true;
-      }
-    }
-    return false;
+    return this.#manifestDirectories.has(rel);
   }
 
   #listManifestFilesUnder(cwdRel: string): string[] | undefined {
@@ -226,13 +226,6 @@ export class ManifestLoaderFS implements LoaderFS {
     return [...new Set([rel, normalizePath(abs)])];
   }
 
-  #hasManifestData(): boolean {
-    return (
-      Object.keys(this.#manifest.data.fileDiscovery).length > 0 ||
-      Object.keys(this.#manifest.data.resolveCache).some((key) => this.#manifest.data.resolveCache[key] !== null)
-    );
-  }
-
   #toRelative(filepath: string): string {
     const rel = path.relative(this.#manifest.baseDir, path.resolve(filepath));
     return normalizePath(rel);
@@ -254,15 +247,20 @@ function normalizePath(filepath: string): string {
   return filepath.replaceAll(path.sep, '/');
 }
 
+function addManifestDirectory(directories: Set<string>, dir: string): void {
+  let current = dir === '.' ? '' : dir;
+  while (true) {
+    directories.add(current);
+    if (current === '') return;
+    const parent = path.posix.dirname(current);
+    current = parent === '.' ? '' : parent;
+  }
+}
+
 function relativePrefix(cwdRel: string, dirRel: string): string | undefined {
   if (cwdRel === '') return dirRel;
   if (dirRel === cwdRel) return '';
   if (dirRel.startsWith(cwdRel + '/')) return dirRel.slice(cwdRel.length + 1);
-}
-
-function relativeFileUnderDir(dirRel: string, fileRel: string): string | undefined {
-  if (dirRel === '') return fileRel;
-  if (fileRel.startsWith(dirRel + '/')) return fileRel.slice(dirRel.length + 1);
 }
 
 function filterManifestGlob(files: string[], patterns: string | string[], options?: LoaderFSGlobOptions): string[] {

--- a/packages/core/test/egg.test.ts
+++ b/packages/core/test/egg.test.ts
@@ -9,7 +9,7 @@ import coffee from 'coffee';
 import { mm } from 'mm';
 import { describe, it, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 
-import { EggCore } from '../src/index.js';
+import { EggCore, ManifestLoaderFS, RealLoaderFS } from '../src/index.js';
 import { createApp, getFilepath, type Application } from './helper.js';
 
 describe('test/egg.test.ts', () => {
@@ -52,6 +52,18 @@ describe('test/egg.test.ts', () => {
     it('should use options.serverScope', () => {
       app = new EggCore({ serverScope: 'scope' });
       assert.equal(app.loader.serverScope, 'scope');
+    });
+
+    it('should pass options.loaderFS to EggLoader', () => {
+      const loaderFS = new RealLoaderFS();
+      app = new EggCore({ loaderFS });
+      assert.equal(app.loader.loaderFS, loaderFS);
+    });
+
+    it('should use RealLoaderFS by default for non-bundled runtime', () => {
+      app = new EggCore();
+      assert.equal(app.loader.loaderFS instanceof RealLoaderFS, true);
+      assert.equal(app.loader.loaderFS instanceof ManifestLoaderFS, false);
     });
 
     it('should not set value expect for application and agent', () => {

--- a/packages/egg/src/lib/start.ts
+++ b/packages/egg/src/lib/start.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { ManifestStore } from '@eggjs/core';
+import { ManifestStore, type LoaderFS } from '@eggjs/core';
 import { importModule } from '@eggjs/utils';
 import { readJSON } from 'utility';
 
@@ -20,6 +20,8 @@ export interface StartEggOptions {
   plugins?: EggPlugin;
   /** Skip lifecycle hooks, only trigger loadMetadata for manifest generation */
   metadataOnly?: boolean;
+  /** Loader-facing filesystem abstraction */
+  loaderFS?: LoaderFS;
   /**
    * When true, load application metadata for V8 startup snapshot construction.
    * The lifecycle stops after configWillLoad (no servers, timers, or connections)

--- a/tools/egg-bundler/src/lib/EntryGenerator.ts
+++ b/tools/egg-bundler/src/lib/EntryGenerator.ts
@@ -258,7 +258,7 @@ for (const [key, spec] of __EXTERNAL_SPECS) {
 /* eslint-disable */
 import path from 'node:path';
 
-import { ManifestStore } from '@eggjs/core';
+import { ManifestLoaderFS, ManifestStore } from '@eggjs/core';
 import type {} from '@eggjs/typings/global';
 import { startEgg } from ${frameworkSpec};
 import * as __frameworkModule from ${frameworkSpec};
@@ -315,12 +315,14 @@ for (const [appAbsRequest, targetRel] of __APP_RESOLVE_CACHE_ALIASES) {
   }
 }
 
-ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA as any, __outputDir));
+const __bundleManifestStore = ManifestStore.fromBundle(MANIFEST_DATA as any, __outputDir);
+const __loaderFS = new ManifestLoaderFS(__bundleManifestStore);
+ManifestStore.setBundleStore(__bundleManifestStore);
 globalThis.__EGG_BUNDLE_MODULE_LOADER__ = (filepath) => {
   return __getBundleMap(filepath);
 };
 
-startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single' }).then((app) => {
+startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single', loaderFS: __loaderFS }).then((app) => {
   const port = process.env.PORT || app.config.cluster?.listen?.port || 7001;
   app.listen(port, () => {
     // eslint-disable-next-line no-console

--- a/tools/egg-bundler/test/EntryGenerator.test.ts
+++ b/tools/egg-bundler/test/EntryGenerator.test.ts
@@ -224,13 +224,17 @@ describe('EntryGenerator', () => {
     const result = await gen.generate();
     const worker = await fs.readFile(result.workerEntry, 'utf8');
 
-    expect(worker).toContain("import { ManifestStore } from '@eggjs/core'");
+    expect(worker).toContain("import { ManifestLoaderFS, ManifestStore } from '@eggjs/core'");
     expect(worker).toContain('import { startEgg } from "egg"');
-    expect(worker).toContain('ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA');
+    expect(worker).toContain('const __bundleManifestStore = ManifestStore.fromBundle(MANIFEST_DATA');
+    expect(worker).toContain('const __loaderFS = new ManifestLoaderFS(__bundleManifestStore)');
+    expect(worker).toContain('ManifestStore.setBundleStore(__bundleManifestStore)');
     expect(worker).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(worker).toContain('__setBundleMap(__framework, __frameworkModule)');
     expect(worker).not.toContain('__frameworkImport');
-    expect(worker).toContain("startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single' })");
+    expect(worker).toContain(
+      "startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single', loaderFS: __loaderFS })",
+    );
   });
 
   it('builds a BUNDLE_MAP keyed by relKey, output absolute, original app absolute, and resolveCache aliases', async () => {
@@ -296,6 +300,11 @@ export const ManifestStore = {
     globalThis.__manifestStore = store;
   },
 };
+export class ManifestLoaderFS {
+  constructor(store) {
+    this.store = store;
+  }
+}
 `,
     );
     await writePackage(
@@ -315,6 +324,8 @@ export async function startEgg(options) {
     frameworkResolved: resolvedFramework?.frameworkMarker,
     frameworkStartEggMatches: resolvedFramework?.startEgg === startEgg,
     controllerResolved: resolvedController?.controllerMarker,
+    loaderFSBaseDir: options.loaderFS?.store?.baseDir,
+    loaderFSUsesManifestStore: options.loaderFS?.store === globalThis.__manifestStore,
   }, null, 2));
   return {
     config: { cluster: { listen: { port: 0 } } },
@@ -349,21 +360,31 @@ export async function startEgg(options) {
     });
 
     const runtimeResult = JSON.parse(await fs.readFile(resultFile, 'utf8')) as {
-      options: { baseDir: string; framework: string; mode: string };
+      options: { baseDir: string; framework: string; mode: string; loaderFS: unknown };
       manifestBaseDir: string;
       frameworkResolved: string;
       frameworkStartEggMatches: boolean;
       controllerResolved: string;
+      loaderFSBaseDir: string;
+      loaderFSUsesManifestStore: boolean;
     };
     expect(runtimeResult.options).toEqual({
       baseDir: outputDir,
       framework: '@runtime/framework',
       mode: 'single',
+      loaderFS: {
+        store: {
+          manifest,
+          baseDir: outputDir,
+        },
+      },
     });
     expect(runtimeResult.manifestBaseDir).toBe(outputDir);
     expect(runtimeResult.frameworkResolved).toBe('bundled-framework');
     expect(runtimeResult.frameworkStartEggMatches).toBe(true);
     expect(runtimeResult.controllerResolved).toBe('bundled-controller');
+    expect(runtimeResult.loaderFSBaseDir).toBe(outputDir);
+    expect(runtimeResult.loaderFSUsesManifestStore).toBe(true);
   });
 
   it('loads externalized package files via createRequire instead of static imports', async () => {
@@ -416,7 +437,9 @@ export async function startEgg(options) {
     const worker = await fs.readFile(result.workerEntry, 'utf8');
 
     expect(extractImports(worker).length).toBe(0);
-    expect(worker).toContain("startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single' })");
+    expect(worker).toContain(
+      "startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single', loaderFS: __loaderFS })",
+    );
     expect(worker).toContain('__EGG_BUNDLE_MODULE_LOADER__');
     expect(worker).toContain('ManifestStore.setBundleStore');
   });

--- a/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
+++ b/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
@@ -2,7 +2,7 @@
 /* eslint-disable */
 import path from 'node:path';
 
-import { ManifestStore } from '@eggjs/core';
+import { ManifestLoaderFS, ManifestStore } from '@eggjs/core';
 import type {} from '@eggjs/typings/global';
 import { startEgg } from "egg";
 import * as __frameworkModule from "egg";
@@ -99,12 +99,14 @@ for (const [appAbsRequest, targetRel] of __APP_RESOLVE_CACHE_ALIASES) {
   }
 }
 
-ManifestStore.setBundleStore(ManifestStore.fromBundle(MANIFEST_DATA as any, __outputDir));
+const __bundleManifestStore = ManifestStore.fromBundle(MANIFEST_DATA as any, __outputDir);
+const __loaderFS = new ManifestLoaderFS(__bundleManifestStore);
+ManifestStore.setBundleStore(__bundleManifestStore);
 globalThis.__EGG_BUNDLE_MODULE_LOADER__ = (filepath) => {
   return __getBundleMap(filepath);
 };
 
-startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single' }).then((app) => {
+startEgg({ baseDir: __outputDir, framework: __framework, mode: 'single', loaderFS: __loaderFS }).then((app) => {
   const port = process.env.PORT || app.config.cluster?.listen?.port || 7001;
   app.listen(port, () => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- add `ManifestLoaderFS` on top of the shared `@eggjs/loader-fs` contracts and export it through `@eggjs/core`
- thread `loaderFS` through `startEgg` and `EggCore` into `EggLoader`, including manifest-backed package metadata reads
- generate bundled worker entries that create a manifest-backed `LoaderFS` from the inline manifest store and pass it via loader options
- update entry generator/runtime tests, loader tests, manifest coverage, and snapshots

## Tests
- `pnpm install`
- `pnpm exec vitest run packages/core/test/index.test.ts packages/core/test/egg.test.ts packages/core/test/loader/egg_loader.test.ts packages/core/test/loader/manifest_loader_fs.test.ts packages/core/test/loader/manifest_coverage.test.ts`
- `pnpm exec vitest run test/EntryGenerator.test.ts` from `tools/egg-bundler`
- `pnpm --filter @eggjs/core typecheck`
- `pnpm --filter egg typecheck`
- `pnpm --filter @eggjs/egg-bundler typecheck`
- `pnpm exec oxlint --type-aware packages/core/src/index.ts packages/core/src/egg.ts packages/core/src/loader/egg_loader.ts packages/core/src/loader/loader_fs.ts packages/core/test/egg.test.ts packages/core/test/loader/egg_loader.test.ts packages/core/test/loader/manifest_loader_fs.test.ts packages/core/test/loader/manifest_coverage.test.ts packages/egg/src/lib/start.ts tools/egg-bundler/src/lib/EntryGenerator.ts tools/egg-bundler/test/EntryGenerator.test.ts` (0 errors; existing warnings in untouched sections)
- `git diff --check origin/next..HEAD`

Issue: EGG-97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable loaderFS option and a manifest-backed filesystem to support bundled-app file resolution; bundler now wires this into startup.
* **Tests**
  * Expanded test coverage for manifest-backed FS behavior, file discovery and resolve caching, loader precedence, and generated bundler runtime hooks.
* **Chores**
  * Declared multimatch dependency to improve pattern matching for manifest-backed globs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->