### PR TITLE
feat(agent-runtime): pass metadata through createThread/ensureThread/createRun

### DIFF
--- a/tegg/core/agent-runtime/src/AgentRuntime.ts
+++ b/tegg/core/agent-runtime/src/AgentRuntime.ts
@@ -1,5 +1,7 @@
 import type {
   CreateRunInput,
+  CreateThreadOptions,
+  EnsureThreadOptions,
   ThreadObject,
   ThreadObjectWithMessages,
   RunObject,
@@ -58,8 +60,8 @@ export class AgentRuntime {
     this.runningTasks = new Map();
   }
 
-  async createThread(): Promise<ThreadObject> {
-    const thread = await this.store.createThread();
+  async createThread(options?: CreateThreadOptions): Promise<ThreadObject> {
+    const thread = await this.store.createThread(options?.metadata);
     return {
       id: thread.id,
       object: AgentObjectType.Thread,
@@ -79,16 +81,26 @@ export class AgentRuntime {
     };
   }
 
-  private async ensureThread(input: CreateRunInput): Promise<{ threadId: string; input: CreateRunInput }> {
+  /**
+   * Resolve the thread for a run. If the caller provided a `threadId` we reuse
+   * it as-is — explicitly ignoring `options.metadata` so resume calls cannot
+   * overwrite the metadata captured when the thread was first created. When no
+   * `threadId` is present we auto-create a thread and forward `metadata` to the
+   * store so business identifiers (e.g. agentName) survive across resumes.
+   */
+  private async ensureThread(
+    input: CreateRunInput,
+    options?: EnsureThreadOptions,
+  ): Promise<{ threadId: string; input: CreateRunInput }> {
     if (input.threadId) {
       return { threadId: input.threadId, input };
     }
-    const thread = await this.store.createThread();
+    const thread = await this.store.createThread(options?.metadata);
     return { threadId: thread.id, input: { ...input, threadId: thread.id } };
   }
 
   async syncRun(input: CreateRunInput, signal?: AbortSignal): Promise<RunObject> {
-    const { threadId, input: resolvedInput } = await this.ensureThread(input);
+    const { threadId, input: resolvedInput } = await this.ensureThread(input, { metadata: input.metadata });
     input = resolvedInput;
 
     const run = await this.store.createRun(input.input.messages, threadId, input.config, input.metadata);
@@ -159,7 +171,7 @@ export class AgentRuntime {
   }
 
   async asyncRun(input: CreateRunInput): Promise<RunObject> {
-    const { threadId, input: resolvedInput } = await this.ensureThread(input);
+    const { threadId, input: resolvedInput } = await this.ensureThread(input, { metadata: input.metadata });
     input = resolvedInput;
 
     const run = await this.store.createRun(input.input.messages, threadId, input.config, input.metadata);
@@ -234,7 +246,7 @@ export class AgentRuntime {
     const abortController = new AbortController();
     writer.onClose(() => abortController.abort());
 
-    const { threadId, input: resolvedInput } = await this.ensureThread(input);
+    const { threadId, input: resolvedInput } = await this.ensureThread(input, { metadata: input.metadata });
     input = resolvedInput;
 
     const run = await this.store.createRun(input.input.messages, threadId, input.config, input.metadata);

--- a/tegg/core/agent-runtime/src/AgentRuntime.ts
+++ b/tegg/core/agent-runtime/src/AgentRuntime.ts
@@ -1,7 +1,6 @@
 import type {
   CreateRunInput,
   CreateThreadOptions,
-  EnsureThreadOptions,
   ThreadObject,
   ThreadObjectWithMessages,
   RunObject,
@@ -83,24 +82,19 @@ export class AgentRuntime {
 
   /**
    * Resolve the thread for a run. If the caller provided a `threadId` we reuse
-   * it as-is — explicitly ignoring `options.metadata` so resume calls cannot
-   * overwrite the metadata captured when the thread was first created. When no
-   * `threadId` is present we auto-create a thread and forward `metadata` to the
-   * store so business identifiers (e.g. agentName) survive across resumes.
+   * it as-is. When no `threadId` is present we auto-create an empty thread.
+   * Run metadata belongs to the run record and must not be copied to the thread.
    */
-  private async ensureThread(
-    input: CreateRunInput,
-    options?: EnsureThreadOptions,
-  ): Promise<{ threadId: string; input: CreateRunInput }> {
+  private async ensureThread(input: CreateRunInput): Promise<{ threadId: string; input: CreateRunInput }> {
     if (input.threadId) {
       return { threadId: input.threadId, input };
     }
-    const thread = await this.store.createThread(options?.metadata);
+    const thread = await this.store.createThread();
     return { threadId: thread.id, input: { ...input, threadId: thread.id } };
   }
 
   async syncRun(input: CreateRunInput, signal?: AbortSignal): Promise<RunObject> {
-    const { threadId, input: resolvedInput } = await this.ensureThread(input, { metadata: input.metadata });
+    const { threadId, input: resolvedInput } = await this.ensureThread(input);
     input = resolvedInput;
 
     const run = await this.store.createRun(input.input.messages, threadId, input.config, input.metadata);
@@ -171,7 +165,7 @@ export class AgentRuntime {
   }
 
   async asyncRun(input: CreateRunInput): Promise<RunObject> {
-    const { threadId, input: resolvedInput } = await this.ensureThread(input, { metadata: input.metadata });
+    const { threadId, input: resolvedInput } = await this.ensureThread(input);
     input = resolvedInput;
 
     const run = await this.store.createRun(input.input.messages, threadId, input.config, input.metadata);
@@ -246,7 +240,7 @@ export class AgentRuntime {
     const abortController = new AbortController();
     writer.onClose(() => abortController.abort());
 
-    const { threadId, input: resolvedInput } = await this.ensureThread(input, { metadata: input.metadata });
+    const { threadId, input: resolvedInput } = await this.ensureThread(input);
     input = resolvedInput;
 
     const run = await this.store.createRun(input.input.messages, threadId, input.config, input.metadata);

--- a/tegg/core/agent-runtime/test/AgentRuntime.metadata.test.ts
+++ b/tegg/core/agent-runtime/test/AgentRuntime.metadata.test.ts
@@ -1,19 +1,32 @@
 import assert from 'node:assert/strict';
 
-import { AgentObjectType, MessageRole, RunStatus } from '@eggjs/tegg-types/agent-runtime';
-import type { AgentStreamMessage, CreateRunInput } from '@eggjs/tegg-types/agent-runtime';
+import { AgentObjectType, AgentSSEEvent, MessageRole, RunStatus } from '@eggjs/tegg-types/agent-runtime';
+import type { AgentStreamMessage, CreateRunInput, RunObject } from '@eggjs/tegg-types/agent-runtime';
 import { describe, it, beforeEach, afterEach } from 'vitest';
 
 import { AgentRuntime } from '../src/AgentRuntime.ts';
 import type { AgentExecutor, AgentRuntimeOptions } from '../src/AgentRuntime.ts';
 import { OSSAgentStore } from '../src/OSSAgentStore.ts';
+import type { SSEWriter } from '../src/SSEWriter.ts';
 import { MapStorageClient } from './helpers.ts';
 
-/**
- * Cover the full metadata pass-through from createRun input → ensureThread →
- * AgentStore.createThread, so business callers (e.g. chair-sandbox-ai-use)
- * can persist agentName on the auto-created thread for later resume lookups.
- */
+class MockSSEWriter implements SSEWriter {
+  events: Array<{ event: string; data: unknown }> = [];
+  closed = false;
+
+  writeEvent(event: string, data: unknown): void {
+    this.events.push({ event, data });
+  }
+
+  end(): void {
+    this.closed = true;
+  }
+
+  onClose(): void {
+    /* noop */
+  }
+}
+
 describe('test/AgentRuntime.metadata.test.ts', () => {
   let runtime: AgentRuntime;
   let store: OSSAgentStore;
@@ -64,8 +77,8 @@ describe('test/AgentRuntime.metadata.test.ts', () => {
     });
   });
 
-  describe('syncRun → ensureThread metadata pass-through', () => {
-    it('should forward input.metadata to the auto-created thread when threadId is omitted', async () => {
+  describe('syncRun metadata handling', () => {
+    it('should keep input.metadata on the run and not copy it to an auto-created thread', async () => {
       const meta = { agentName: 'bar', sandboxId: 's-42' };
       const result = await runtime.syncRun({
         input: { messages: [{ role: 'user', content: 'Hi' }] },
@@ -76,9 +89,8 @@ describe('test/AgentRuntime.metadata.test.ts', () => {
       assert.deepEqual(result.metadata, meta);
       assert.equal(result.status, RunStatus.Completed);
 
-      // The auto-created thread should also receive the metadata
       const thread = await store.getThread(result.threadId);
-      assert.deepEqual(thread.metadata, meta);
+      assert.deepEqual(thread.metadata, {});
     });
 
     it('should NOT overwrite metadata of an existing thread (resume path)', async () => {
@@ -101,8 +113,8 @@ describe('test/AgentRuntime.metadata.test.ts', () => {
     });
   });
 
-  describe('asyncRun → ensureThread metadata pass-through', () => {
-    it('should forward input.metadata to the auto-created thread', async () => {
+  describe('asyncRun metadata handling', () => {
+    it('should keep input.metadata on the run and not copy it to an auto-created thread', async () => {
       const meta = { agentName: 'baz' };
       const result = await runtime.asyncRun({
         input: { messages: [{ role: 'user', content: 'Hi' }] },
@@ -110,8 +122,31 @@ describe('test/AgentRuntime.metadata.test.ts', () => {
       });
       await runtime.waitForPendingTasks();
 
+      assert.deepEqual(result.metadata, meta);
       const thread = await store.getThread(result.threadId);
-      assert.deepEqual(thread.metadata, meta);
+      assert.deepEqual(thread.metadata, {});
+    });
+  });
+
+  describe('streamRun metadata handling', () => {
+    it('should keep input.metadata on the run and not copy it to an auto-created thread', async () => {
+      const meta = { agentName: 'stream', source: 'sse' };
+      const writer = new MockSSEWriter();
+
+      await runtime.streamRun(
+        {
+          input: { messages: [{ role: 'user', content: 'Hi' }] },
+          metadata: meta,
+        },
+        writer,
+      );
+
+      const runCreatedEvent = writer.events.find((e) => e.event === AgentSSEEvent.ThreadRunCreated);
+      const run = runCreatedEvent!.data as RunObject;
+
+      assert.deepEqual(run.metadata, meta);
+      const thread = await store.getThread(run.threadId);
+      assert.deepEqual(thread.metadata, {});
     });
   });
 });

--- a/tegg/core/agent-runtime/test/AgentRuntime.metadata.test.ts
+++ b/tegg/core/agent-runtime/test/AgentRuntime.metadata.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+
+import { AgentObjectType, MessageRole, RunStatus } from '@eggjs/tegg-types/agent-runtime';
+import type { AgentStreamMessage, CreateRunInput } from '@eggjs/tegg-types/agent-runtime';
+import { describe, it, beforeEach, afterEach } from 'vitest';
+
+import { AgentRuntime } from '../src/AgentRuntime.ts';
+import type { AgentExecutor, AgentRuntimeOptions } from '../src/AgentRuntime.ts';
+import { OSSAgentStore } from '../src/OSSAgentStore.ts';
+import { MapStorageClient } from './helpers.ts';
+
+/**
+ * Cover the full metadata pass-through from createRun input → ensureThread →
+ * AgentStore.createThread, so business callers (e.g. chair-sandbox-ai-use)
+ * can persist agentName on the auto-created thread for later resume lookups.
+ */
+describe('test/AgentRuntime.metadata.test.ts', () => {
+  let runtime: AgentRuntime;
+  let store: OSSAgentStore;
+  let executor: AgentExecutor;
+
+  beforeEach(() => {
+    store = new OSSAgentStore({ client: new MapStorageClient() });
+    executor = {
+      async *execRun(input: CreateRunInput): AsyncGenerator<AgentStreamMessage> {
+        const messages = input.input.messages;
+        yield {
+          message: {
+            role: MessageRole.Assistant,
+            content: [{ type: 'text', text: `Hello ${messages.length} messages` }],
+          },
+        };
+      },
+    };
+    runtime = new AgentRuntime({
+      executor,
+      store,
+      logger: {
+        error() {
+          /* noop */
+        },
+      } as unknown as AgentRuntimeOptions['logger'],
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.destroy();
+  });
+
+  describe('createThread', () => {
+    it('should accept metadata and persist it on the thread record', async () => {
+      const meta = { agentName: 'foo', traceId: 't-1' };
+      const result = await runtime.createThread({ metadata: meta });
+      assert.equal(result.object, AgentObjectType.Thread);
+      assert.deepEqual(result.metadata, meta);
+
+      const stored = await store.getThread(result.id);
+      assert.deepEqual(stored.metadata, meta);
+    });
+
+    it('should default to empty metadata when not provided', async () => {
+      const result = await runtime.createThread();
+      assert.deepEqual(result.metadata, {});
+    });
+  });
+
+  describe('syncRun → ensureThread metadata pass-through', () => {
+    it('should forward input.metadata to the auto-created thread when threadId is omitted', async () => {
+      const meta = { agentName: 'bar', sandboxId: 's-42' };
+      const result = await runtime.syncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+        metadata: meta,
+      });
+
+      // Run metadata is preserved (existing behaviour)
+      assert.deepEqual(result.metadata, meta);
+      assert.equal(result.status, RunStatus.Completed);
+
+      // The auto-created thread should also receive the metadata
+      const thread = await store.getThread(result.threadId);
+      assert.deepEqual(thread.metadata, meta);
+    });
+
+    it('should NOT overwrite metadata of an existing thread (resume path)', async () => {
+      // Pre-create a thread with original metadata
+      const original = { agentName: 'orig', createdBy: 'user-1' };
+      const thread = await runtime.createThread({ metadata: original });
+
+      // Run with conflicting metadata while reusing the existing threadId
+      const result = await runtime.syncRun({
+        threadId: thread.id,
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+        metadata: { agentName: 'OVERRIDE' },
+      });
+
+      assert.equal(result.threadId, thread.id);
+
+      // Thread metadata must remain the original — resume must not mutate it.
+      const stored = await store.getThread(thread.id);
+      assert.deepEqual(stored.metadata, original);
+    });
+  });
+
+  describe('asyncRun → ensureThread metadata pass-through', () => {
+    it('should forward input.metadata to the auto-created thread', async () => {
+      const meta = { agentName: 'baz' };
+      const result = await runtime.asyncRun({
+        input: { messages: [{ role: 'user', content: 'Hi' }] },
+        metadata: meta,
+      });
+      await runtime.waitForPendingTasks();
+
+      const thread = await store.getThread(result.threadId);
+      assert.deepEqual(thread.metadata, meta);
+    });
+  });
+});

--- a/tegg/core/types/src/agent-runtime/AgentRuntime.ts
+++ b/tegg/core/types/src/agent-runtime/AgentRuntime.ts
@@ -87,6 +87,30 @@ export interface CreateRunInput {
   metadata?: Record<string, unknown>;
 }
 
+// ===== Thread input =====
+
+/**
+ * Options for {@link AgentRuntime.createThread}.
+ *
+ * `metadata` is forwarded verbatim to {@link AgentStore.createThread} so callers
+ * can persist additional business semantics on the thread record (e.g. the
+ * resolved agent name, owning sandbox id, trace id). It is stored once at
+ * creation time and never overwritten by subsequent runs on the same thread.
+ */
+export interface CreateThreadOptions {
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options consumed by `AgentRuntime.ensureThread` when it has to auto-create
+ * a thread because no `threadId` was supplied. When a `threadId` is already
+ * present the options are ignored — resume must never mutate existing thread
+ * metadata, even if the caller passes a different value.
+ */
+export interface EnsureThreadOptions {
+  metadata?: Record<string, unknown>;
+}
+
 // ===== Message delta =====
 
 export interface MessageDeltaObject {

--- a/tegg/core/types/src/agent-runtime/AgentRuntime.ts
+++ b/tegg/core/types/src/agent-runtime/AgentRuntime.ts
@@ -101,16 +101,6 @@ export interface CreateThreadOptions {
   metadata?: Record<string, unknown>;
 }
 
-/**
- * Options consumed by `AgentRuntime.ensureThread` when it has to auto-create
- * a thread because no `threadId` was supplied. When a `threadId` is already
- * present the options are ignored — resume must never mutate existing thread
- * metadata, even if the caller passes a different value.
- */
-export interface EnsureThreadOptions {
-  metadata?: Record<string, unknown>;
-}
-
 // ===== Message delta =====
 
 export interface MessageDeltaObject {


### PR DESCRIPTION
createThread support params to set metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread creation now accepts optional metadata that persists on the thread object.
  * Metadata is properly isolated between threads and runs—run metadata no longer overwrites thread metadata.

* **Tests**
  * Added comprehensive test suite validating metadata persistence and isolation across all runtime APIs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5949)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->