### PR TITLE
docs(core): document loaderFS option

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -224,18 +224,19 @@ await this.loadExtend('application', app);
 
 ### LoaderOptions
 
-| Param       | Type              | Description                                                                                                                                                        |
-| ----------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
-| directory   | `String/Array`    | directories to be loaded                                                                                                                                           |
-| target      | `Object`          | attach the target object from loaded files                                                                                                                         |
-| match       | `String/Array`    | match the files when load, default to `**/*.js`(if process.env.EGG\*TYPESCRIPT was true, default to `[ '\*\*/\_.(js                                                | ts)', '!\*_/_.d.ts' ]`) |
-| ignore      | `String/Array`    | ignore the files when load                                                                                                                                         |
-| initializer | `Function`        | custom file exports, receive two parameters, first is the inject object(if not js file, will be content buffer), second is an `options` object that contain `path` |
-| caseStyle   | `String/Function` | set property's case when converting a filepath to property list.                                                                                                   |
-| override    | `Boolean`         | determine whether override the property when get the same name                                                                                                     |
-| call        | `Boolean`         | determine whether invoke when exports is function                                                                                                                  |
-| inject      | `Object`          | an object that be the argument when invoke the function                                                                                                            |
-| filter      | `Function`        | a function that filter the exports which can be loaded                                                                                                             |
+| Param       | Type              | Description                                                                                                                                                       |
+| ----------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| directory   | `String/Array`    | directories to be loaded                                                                                                                                          |
+| target      | `Object`          | attach the target object from loaded files                                                                                                                        |
+| match       | `String/Array`    | match the files when load, default to `**/*.js` (if `process.env.EGG_TYPESCRIPT` is true, default to `[ '**/*.(js\|ts)', '!**/*.d.ts' ]`)                        |
+| ignore      | `String/Array`    | ignore the files when load                                                                                                                                        |
+| initializer | `Function`        | custom file exports, receive two parameters, first is the inject object (if not js file, will be content buffer), second is an `options` object that contain `path` |
+| caseStyle   | `String/Function` | set property's case when converting a filepath to property list                                                                                                    |
+| override    | `Boolean`         | determine whether override the property when get the same name                                                                                                    |
+| call        | `Boolean`         | determine whether invoke when exports is function                                                                                                                 |
+| inject      | `Object`          | an object that be the argument when invoke the function                                                                                                           |
+| filter      | `Function`        | a function that filter the exports which can be loaded                                                                                                            |
+| loaderFS    | `LoaderFS`        | loader-facing filesystem abstraction used for discovery, file stats, JSON reads, and module loading                                                               |
 
 ## Timing
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -230,12 +230,12 @@ await this.loadExtend('application', app);
 | target      | `Object`          | attach the target object from loaded files                                                                                                                        |
 | match       | `String/Array`    | match the files when load, default to `**/*.js` (if `process.env.EGG_TYPESCRIPT` is true, default to `[ '**/*.(js\|ts)', '!**/*.d.ts' ]`)                        |
 | ignore      | `String/Array`    | ignore the files when load                                                                                                                                        |
-| initializer | `Function`        | custom file exports, receive two parameters, first is the inject object (if not js file, will be content buffer), second is an `options` object that contain `path` |
+| initializer | `Function`        | custom file exports, receive two parameters, first is the inject object (if not js file, will be content buffer), second is an `options` object that contains `path` |
 | caseStyle   | `String/Function` | set property's case when converting a filepath to property list                                                                                                    |
 | override    | `Boolean`         | determine whether override the property when get the same name                                                                                                    |
 | call        | `Boolean`         | determine whether invoke when exports is function                                                                                                                 |
-| inject      | `Object`          | an object that be the argument when invoke the function                                                                                                           |
-| filter      | `Function`        | a function that filter the exports which can be loaded                                                                                                            |
+| inject      | `Object`          | an object that is the argument when invoking the function                                                                                                         |
+| filter      | `Function`        | a function that filters the exports which can be loaded                                                                                                           |
 | loaderFS    | `LoaderFS`        | loader-facing filesystem abstraction used for discovery, file stats, JSON reads, and module loading                                                               |
 
 ## Timing

--- a/site/docs/advanced/loader.md
+++ b/site/docs/advanced/loader.md
@@ -495,6 +495,11 @@ Loading different files uses different configurations:
 | app/middleware | false         |
 | app/service    | true          |
 
+#### `loaderFS [LoaderFS]`
+
+Customize the filesystem boundary used by `loadToApp` and `loadToContext` for file discovery, file stats, and module loading.
+By default, Egg uses `RealLoaderFS`, which delegates to the local filesystem and keeps the existing runtime behavior.
+
 ## CustomLoader
 
 You can use `customLoader` instead of `loadToContext` and `loadToApp`.

--- a/site/docs/advanced/loader.md
+++ b/site/docs/advanced/loader.md
@@ -497,7 +497,7 @@ Loading different files uses different configurations:
 
 #### `loaderFS [LoaderFS]`
 
-Customize the filesystem boundary used by `loadToApp` and `loadToContext` for file discovery, file stats, and module loading.
+Customize the filesystem boundary used by `loadToApp` and `loadToContext` for file discovery, file stats, JSON reads, and module loading.
 By default, Egg uses `RealLoaderFS`, which delegates to the local filesystem and keeps the existing runtime behavior.
 
 ## CustomLoader

--- a/site/docs/zh-CN/advanced/loader.md
+++ b/site/docs/zh-CN/advanced/loader.md
@@ -502,7 +502,7 @@ app.loader.loadToApp(directory, 'model', {
 
 #### loaderFS [LoaderFS]
 
-自定义 `loadToApp` 和 `loadToContext` 使用的文件系统边界，用于文件发现、文件状态读取和模块加载。
+自定义 `loadToApp` 和 `loadToContext` 使用的文件系统边界，用于文件发现、文件状态读取、JSON 读取和模块加载。
 默认使用 `RealLoaderFS`，它会委托给本地文件系统，以保持现有运行时行为。
 
 ## CustomLoader

--- a/site/docs/zh-CN/advanced/loader.md
+++ b/site/docs/zh-CN/advanced/loader.md
@@ -500,6 +500,11 @@ app.loader.loadToApp(directory, 'model', {
 | app/middleware | false       |
 | app/service    | true        |
 
+#### loaderFS [LoaderFS]
+
+自定义 `loadToApp` 和 `loadToContext` 使用的文件系统边界，用于文件发现、文件状态读取和模块加载。
+默认使用 `RealLoaderFS`，它会委托给本地文件系统，以保持现有运行时行为。
+
 ## CustomLoader
 
 `loadToContext` 和 `loadToApp` 方法可以通过 `customLoader` 的配置来替代。

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -4,7 +4,7 @@ Dates use the workspace-local Asia/Shanghai calendar date.
 
 ## [2026-05-13] docs | sync LoaderFS loader option docs
 
-- sources touched: `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/egg_loader.ts`
+- sources referenced: `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/egg_loader.ts`
 - pages updated: `packages/core/README.md`, `site/docs/advanced/loader.md`, `site/docs/zh-CN/advanced/loader.md`, `wiki/packages/core.md`, `wiki/log.md`
 - note: Added the public `loaderFS` LoaderOptions entry to core and site loader docs, and refreshed the core wiki page to point at those docs.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-05-13] docs | sync LoaderFS loader option docs
+
+- sources touched: `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/egg_loader.ts`
+- pages updated: `packages/core/README.md`, `site/docs/advanced/loader.md`, `site/docs/zh-CN/advanced/loader.md`, `wiki/packages/core.md`, `wiki/log.md`
+- note: Added the public `loaderFS` LoaderOptions entry to core and site loader docs, and refreshed the core wiki page to point at those docs.
+
 ## [2026-05-07] package | document core LoaderFS boundary
 
 - sources touched: `packages/core/src/index.ts`, `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/context_loader.ts`, `packages/core/src/loader/egg_loader.ts`

--- a/wiki/packages/core.md
+++ b/wiki/packages/core.md
@@ -3,12 +3,15 @@ title: Core Package
 type: package
 summary: Loader, lifecycle, and application core primitives used by Egg runtime packages.
 source_files:
+  - packages/core/README.md
   - packages/core/src/index.ts
   - packages/core/src/loader/loader_fs.ts
   - packages/core/src/loader/file_loader.ts
   - packages/core/src/loader/context_loader.ts
   - packages/core/src/loader/egg_loader.ts
-updated_at: 2026-05-07
+  - site/docs/advanced/loader.md
+  - site/docs/zh-CN/advanced/loader.md
+updated_at: 2026-05-13
 status: active
 ---
 
@@ -33,3 +36,6 @@ runtime behavior by delegating to `fs.existsSync`, `fs.statSync`,
 custom `loaderFS`. `EggLoader` passes its loader FS into `loadToApp()` and
 `loadToContext()` so later bundled loaders can replace file discovery and module
 loading without changing the public loader call sites.
+
+The public loader docs now list `loaderFS` with the other `LoaderOptions` so
+custom loader filesystem implementations are discoverable for advanced users.


### PR DESCRIPTION
## Summary
- document the new `loaderFS` LoaderOptions entry in `packages/core` README
- add English and Chinese site docs notes for `loadToApp` / `loadToContext`
- refresh the core wiki page and log entry for the docs sync

## Validation
- `git diff --check`
- `pnpm run fmtcheck` attempted, but `oxfmt` is not installed because `node_modules` is missing in this checkout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added and clarified LoaderOptions documentation to introduce the new loaderFS option, explaining how to customize the filesystem used for file discovery, stats, JSON reads, and module loading while preserving the existing default behavior. Updates published in English and Chinese docs and reflected in the project wiki and changelog for discoverability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5950)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->