### PR TITLE
fix(koa): sanitize protocol-relative redirects

### DIFF
--- a/packages/koa/src/response.ts
+++ b/packages/koa/src/response.ts
@@ -21,12 +21,18 @@ import type { Request } from './request.ts';
 function formatRedirectUrl(url: string): string {
   if (url.startsWith('https://') || url.startsWith('http://')) {
     // formatting url again avoid security escapes
-    return new URL(url).toString();
+    try {
+      return new URL(url).toString();
+    } catch {
+      return url;
+    }
   }
   if (url.startsWith('/\\')) {
     return `/%5C${url.slice(2)}`;
   }
-  if (/^[\\/]{2,}/.test(url)) {
+  const firstChar = url[0];
+  const secondChar = url[1];
+  if ((firstChar === '/' || firstChar === '\\') && (secondChar === '/' || secondChar === '\\')) {
     return `/%2F${url.slice(2)}`;
   }
   if (url.startsWith('\\')) {

--- a/packages/koa/src/response.ts
+++ b/packages/koa/src/response.ts
@@ -18,6 +18,23 @@ import type { Application } from './application.ts';
 import type { Context } from './context.ts';
 import type { Request } from './request.ts';
 
+function formatRedirectUrl(url: string): string {
+  if (url.startsWith('https://') || url.startsWith('http://')) {
+    // formatting url again avoid security escapes
+    return new URL(url).toString();
+  }
+  if (url.startsWith('/\\')) {
+    return `/%5C${url.slice(2)}`;
+  }
+  if (/^[\\/]{2,}/.test(url)) {
+    return `/%2F${url.slice(2)}`;
+  }
+  if (url.startsWith('\\')) {
+    return `/%5C${url.slice(1)}`;
+  }
+  return url;
+}
+
 export class Response {
   [key: symbol]: unknown;
   app: Application;
@@ -250,10 +267,7 @@ export class Response {
     if (url === 'back') {
       url = this._getBackReferrer() || alt || '/';
     }
-    if (url.startsWith('https://') || url.startsWith('http://')) {
-      // formatting url again avoid security escapes
-      url = new URL(url).toString();
-    }
+    url = formatRedirectUrl(url);
     this.set('Location', encodeUrl(url));
 
     // status

--- a/packages/koa/test/response/redirect.test.ts
+++ b/packages/koa/test/response/redirect.test.ts
@@ -21,6 +21,27 @@ describe('ctx.redirect(url)', () => {
     assert.equal(ctx.status, 302);
   });
 
+  it('should not redirect to protocol-relative URLs', () => {
+    const ctx = context();
+    ctx.redirect('//evil.com');
+    assert.equal(ctx.response.header.location, '/%2Fevil.com');
+    assert.equal(ctx.status, 302);
+  });
+
+  it('should not redirect to backslash-prefixed URLs', () => {
+    const ctx = context();
+    ctx.redirect(String.raw`/\evil.com`);
+    assert.equal(ctx.response.header.location, '/%5Cevil.com');
+    assert.equal(ctx.status, 302);
+  });
+
+  it('should not redirect to slash and backslash variants', () => {
+    const ctx = context();
+    ctx.redirect(String.raw`\//evil.com`);
+    assert.equal(ctx.response.header.location, '/%2F/evil.com');
+    assert.equal(ctx.status, 302);
+  });
+
   it('should auto fix not encode url', async () => {
     const app = new Koa();
 

--- a/packages/koa/test/response/redirect.test.ts
+++ b/packages/koa/test/response/redirect.test.ts
@@ -42,6 +42,20 @@ describe('ctx.redirect(url)', () => {
     assert.equal(ctx.status, 302);
   });
 
+  it('should not redirect to double-backslash URLs', () => {
+    const ctx = context();
+    ctx.redirect(String.raw`\\evil.com`);
+    assert.equal(ctx.response.header.location, '/%2Fevil.com');
+    assert.equal(ctx.status, 302);
+  });
+
+  it('should not throw on malformed absolute URLs', () => {
+    const ctx = context();
+    ctx.redirect('http://[invalid');
+    assert.equal(ctx.response.header.location, 'http://[invalid');
+    assert.equal(ctx.status, 302);
+  });
+
   it('should auto fix not encode url', async () => {
     const app = new Koa();
 


### PR DESCRIPTION
## Summary
- sanitize ambiguous ctx.redirect() targets that browsers may treat as protocol-relative URLs
- keep existing absolute http(s) formatting behavior
- add regression coverage for //host, /\host, and mixed slash/backslash variants

## Test
- pnpm exec oxfmt --check packages/koa/src/response.ts packages/koa/test/response/redirect.test.ts
- pnpm exec oxlint --type-aware packages/koa/src/response.ts packages/koa/test/response/redirect.test.ts
- pnpm --filter @eggjs/koa run typecheck
- pnpm exec vitest run packages/koa/test/response/redirect.test.ts --bail 1 --retry 0 --testTimeout 20000 --hookTimeout 20000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redirect normalization to sanitize and consistently handle a wider range of URL patterns (protocol-relative //, backslash-prefixed, mixed slash/backslash, double-slash), preventing unsafe redirects and improving stability.

* **Tests**
  * Added tests covering normalization of malformed and edge-case redirect inputs and ensuring redirects set expected status without throwing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->