### PR TITLE
fix(koa): handle Content-Length overflow and NaN

### DIFF
--- a/packages/koa/src/request.ts
+++ b/packages/koa/src/request.ts
@@ -328,7 +328,8 @@ export class Request {
     if (len === '') {
       return;
     }
-    return Number.parseInt(len);
+    const parsed = Number.parseInt(len, 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
   }
 
   /**

--- a/packages/koa/src/response.ts
+++ b/packages/koa/src/response.ts
@@ -189,7 +189,7 @@ export class Response {
    */
   get length(): number | undefined {
     if (this.has('Content-Length')) {
-      return Number.parseInt(this.get('Content-Length')) || 0;
+      return Number.parseInt(this.get('Content-Length'), 10) || 0;
     }
 
     const body = this.body;

--- a/packages/koa/test/request/length.test.ts
+++ b/packages/koa/test/request/length.test.ts
@@ -15,4 +15,40 @@ describe('ctx.length', () => {
     const req = request();
     assert.strictEqual(req.length, undefined);
   });
+
+  it('should handle zero content-length', () => {
+    const req = request();
+    req.header['content-length'] = '0';
+    assert.strictEqual(req.length, 0);
+  });
+
+  it('should handle Content-Length > 2GB (2147483648)', () => {
+    const req = request();
+    req.header['content-length'] = '2147483648';
+    assert.strictEqual(req.length, 2147483648);
+  });
+
+  it('should handle very large Content-Length (10GB)', () => {
+    const req = request();
+    req.header['content-length'] = '10000000000';
+    assert.strictEqual(req.length, 10000000000);
+  });
+
+  it('should handle floating-point-like strings (truncate decimal)', () => {
+    const req = request();
+    req.header['content-length'] = '10.5';
+    assert.strictEqual(req.length, 10);
+  });
+
+  it('should return undefined for non-numeric strings', () => {
+    const req = request();
+    req.header['content-length'] = 'invalid';
+    assert.strictEqual(req.length, undefined);
+  });
+
+  it('should return undefined for empty string', () => {
+    const req = request();
+    req.header['content-length'] = '';
+    assert.strictEqual(req.length, undefined);
+  });
 });


### PR DESCRIPTION
## Summary

- Port [koajs/koa#1961](https://github.com/koajs/koa/pull/1961) into our maintained `@eggjs/koa`.
- Add explicit radix `10` to `Number.parseInt` so `Content-Length` is always parsed as base 10.
- Return `undefined` (instead of `NaN`) for non-numeric `Content-Length` values, matching the documented `number | undefined` contract.

## Why

The upstream koa bug was `~~len` truncating to a signed 32-bit integer, silently producing wrong sizes for payloads > 2GB. Our fork already moved off `~~` to `Number.parseInt`, but two gaps remained:

1. No explicit radix — surprising parsing for leading `0`/`0x` inputs.
2. Non-numeric headers leaked `NaN` to callers instead of `undefined`.

## Test plan

- [x] `npx vitest run packages/koa/test/request/length.test.ts` — 8/8 passing
- [ ] Ported all six regression cases from upstream: zero, 2GB+, 10GB, decimal truncation, non-numeric, empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content-Length parsing now returns undefined for invalid or non-numeric values instead of NaN, and consistently parses numeric values using a fixed decimal radix for more predictable behavior.
* **Tests**
  * Expanded length parsing tests to cover zero, very large values, decimal-like truncation, empty and non-numeric inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->