### PR TITLE
docs(bundler): sync manifest loader fs notes

### DIFF
--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -100,8 +100,12 @@ cd dist-bundle
 node worker.js
 ```
 
-The generated worker entry runs the app in Egg's single-process mode and serves
-framework file discovery/module resolution from the inlined bundle map.
+The generated worker entry runs the app in Egg's single-process mode. It
+installs the bundle manifest store, exposes the inlined bundle map through
+`globalThis.__EGG_BUNDLE_MODULE_LOADER__`, creates a manifest-backed loader FS,
+and passes that loader FS into `startEgg()` so Egg loader file discovery and
+module loading resolve through the bundle before falling back to the real
+filesystem.
 
 See [output-structure.md](./docs/output-structure.md) for artifact layout,
 externals behavior, and current limitations.

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -33,14 +33,17 @@ node worker.js
 ```
 
 The worker entry installs `ManifestStore.setBundleStore(...)` and
-`globalThis.__EGG_BUNDLE_MODULE_LOADER__` before calling
-`startEgg({ baseDir: outputDir, framework, mode: 'single' })`, so framework
-specifier lookup is served by the already imported bundled framework module,
-without adding framework path aliases. Runtime lookup keeps
-the deploy output directory separate from the original app paths: the bundle map
-is keyed by relKey, output-dir absolute paths, precomputed original app absolute
-paths, and manifest `resolveCache` request aliases. Application code and plugins
-may still use `fs` for resources such as config, views, or assets.
+`globalThis.__EGG_BUNDLE_MODULE_LOADER__`, creates `ManifestLoaderFS` from the
+bundle manifest, then calls
+`startEgg({ baseDir: outputDir, framework, mode: 'single', loaderFS })`. This
+lets Egg loader file discovery and module loading resolve through the inlined
+bundle map before falling back to the real filesystem, while framework specifier
+lookup is served by the already imported bundled framework module without adding
+framework path aliases. Runtime lookup keeps the deploy output directory
+separate from the original app paths: the bundle map is keyed by relKey,
+output-dir absolute paths, precomputed original app absolute paths, and manifest
+`resolveCache` request aliases. Application code and plugins may still use `fs`
+for resources such as config, views, or assets.
 
 ## Runtime assets
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-05-29] package | sync manifest-backed bundled loader FS
+
+- sources touched: `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/egg_loader.ts`, `packages/core/src/egg.ts`, `tools/egg-bundler/src/lib/EntryGenerator.ts`
+- pages updated: `tools/egg-bundler/README.md`, `tools/egg-bundler/docs/output-structure.md`, `wiki/log.md`, `wiki/packages/core.md`, `wiki/packages/egg-bundler.md`
+- note: Recorded `ManifestLoaderFS` as the bundle-aware loader filesystem and documented that generated workers pass it into `startEgg()` while serving manifest paths through the inlined bundle module loader.
+
 ## [2026-05-10] package | extract shared LoaderFS package
 
 - sources touched: `packages/loader-fs/src/index.ts`, `packages/loader-fs/package.json`, `packages/core/src/index.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/egg_loader.ts`

--- a/wiki/packages/core.md
+++ b/wiki/packages/core.md
@@ -35,4 +35,5 @@ loading without changing the public loader call sites.
 `exists`, `stat`, `realpath`, and `glob` from `fileDiscovery` and `resolveCache`
 manifest data when possible, loads bundled modules through
 `globalThis.__EGG_BUNDLE_MODULE_LOADER__`, unwraps default exports for JSON and
-file loads, and falls back to `RealLoaderFS` when a path is outside the manifest.
+file loads, and falls back to the configured fallback loader FS, defaulting to
+`RealLoaderFS`, when a path is outside the manifest.

--- a/wiki/packages/core.md
+++ b/wiki/packages/core.md
@@ -7,7 +7,8 @@ source_files:
   - packages/core/src/loader/file_loader.ts
   - packages/core/src/loader/context_loader.ts
   - packages/core/src/loader/egg_loader.ts
-updated_at: 2026-05-10
+  - packages/core/src/loader/loader_fs.ts
+updated_at: 2026-05-29
 status: active
 ---
 
@@ -20,7 +21,8 @@ support, lifecycle, and base context classes.
 ## LoaderFS
 
 `@eggjs/core` consumes and re-exports `LoaderFS` and `RealLoaderFS` from
-`@eggjs/loader-fs`. The abstraction remains the minimal filesystem boundary for
+`@eggjs/loader-fs`, and also exports the core-owned `ManifestLoaderFS` runtime
+implementation. The abstraction remains the minimal filesystem boundary for
 loader-facing file access: `exists`, `stat`, `realpath`, `readJSON`, `glob`, and
 `loadFile`, without trying to polyfill the full Node.js `fs` module.
 
@@ -28,3 +30,9 @@ loader-facing file access: `exists`, `stat`, `realpath`, `readJSON`, `glob`, and
 custom `loaderFS`. `EggLoader` passes its loader FS into `loadToApp()` and
 `loadToContext()` so later bundled loaders can replace file discovery and module
 loading without changing the public loader call sites.
+
+`ManifestLoaderFS` wraps a `ManifestStore` plus a fallback loader FS. It answers
+`exists`, `stat`, `realpath`, and `glob` from `fileDiscovery` and `resolveCache`
+manifest data when possible, loads bundled modules through
+`globalThis.__EGG_BUNDLE_MODULE_LOADER__`, unwraps default exports for JSON and
+file loads, and falls back to `RealLoaderFS` when a path is outside the manifest.

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -9,7 +9,7 @@ source_files:
   - tools/egg-bundler/src/lib/ExternalsResolver.ts
   - tools/egg-bin/src/commands/bundle.ts
   - tools/egg-bundler/docs/output-structure.md
-updated_at: 2026-05-06
+updated_at: 2026-05-29
 status: active
 ---
 
@@ -48,9 +48,11 @@ CommonJS artifact from an Egg application.
 - The generated app runs in Egg single-process mode. Its worker entry treats the
   deploy output directory as the runtime Egg `baseDir`, passes the framework
   specifier explicitly to `startEgg`, maps that specifier to the already bundled
-  framework module, and precomputes original app absolute aliases so bundled
-  module lookup can serve relKeys, output-dir absolute paths, original app
-  absolute paths, and manifest `resolveCache` request aliases.
+  framework module, creates `ManifestLoaderFS` from the bundle manifest, and
+  passes that loader FS into `startEgg` so loader file discovery and module
+  loading consult the bundle map before falling back to the real filesystem. The
+  bundle map can serve relKeys, output-dir absolute paths, original app absolute
+  paths, and manifest `resolveCache` request aliases.
 - Explicit `externals.force` entries are external, and `ExternalsResolver`
   auto-detects root `peerDependencies`, root `optionalDependencies`, root
   dependency packages with native addons, root dependency packages whose optional


### PR DESCRIPTION
## Summary

- Document that bundled workers create and pass `ManifestLoaderFS` into `startEgg()`.
- Update bundle output docs and wiki package notes for manifest-backed loader file discovery/module loading.
- Add a wiki log entry for the 2026-05-29 doc sync.

## Verification

- `pnpm exec oxfmt --check tools/egg-bundler/README.md tools/egg-bundler/docs/output-structure.md wiki/log.md wiki/packages/core.md wiki/packages/egg-bundler.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified bundler and runtime docs to explain how bundled apps initialize module loading: the bundle’s manifest is consulted first for module resolution, with a transparent fallback to the real filesystem.
  * Updated core and bundler guides to describe the bundle-aware loader integration and how runtime module discovery and path resolution behave for deployed bundles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->