### PR TITLE
docs(bundler): document manifest loader fs runtime

### DIFF
--- a/tools/egg-bundler/README.md
+++ b/tools/egg-bundler/README.md
@@ -101,7 +101,8 @@ node worker.js
 ```
 
 The generated worker entry runs the app in Egg's single-process mode and serves
-framework file discovery/module resolution from the inlined bundle map.
+framework file discovery/module resolution from the inlined bundle map through
+Egg's manifest-backed loader filesystem.
 
 See [output-structure.md](./docs/output-structure.md) for artifact layout,
 externals behavior, and current limitations.

--- a/tools/egg-bundler/docs/output-structure.md
+++ b/tools/egg-bundler/docs/output-structure.md
@@ -32,15 +32,17 @@ cd <outputDir>
 node worker.js
 ```
 
-The worker entry installs `ManifestStore.setBundleStore(...)` and
-`globalThis.__EGG_BUNDLE_MODULE_LOADER__` before calling
-`startEgg({ baseDir: outputDir, framework, mode: 'single' })`, so framework
-specifier lookup is served by the already imported bundled framework module,
-without adding framework path aliases. Runtime lookup keeps
-the deploy output directory separate from the original app paths: the bundle map
-is keyed by relKey, output-dir absolute paths, precomputed original app absolute
-paths, and manifest `resolveCache` request aliases. Application code and plugins
-may still use `fs` for resources such as config, views, or assets.
+The worker entry builds a `ManifestStore` from the bundled startup manifest,
+installs `ManifestStore.setBundleStore(...)` and
+`globalThis.__EGG_BUNDLE_MODULE_LOADER__`, creates a `ManifestLoaderFS`, and
+passes it to
+`startEgg({ baseDir: outputDir, framework, mode: 'single', loaderFS })`.
+Framework specifier lookup is served by the already imported bundled framework
+module, without adding framework path aliases. Runtime lookup keeps the deploy
+output directory separate from the original app paths: the bundle map is keyed
+by relKey, output-dir absolute paths, precomputed original app absolute paths,
+and manifest `resolveCache` request aliases. Application code and plugins may
+still use `fs` for resources such as config, views, or assets.
 
 ## Runtime assets
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-05-30] package | document manifest-backed loader fs runtime
+
+- sources touched: `packages/core/src/loader/loader_fs.ts`, `packages/core/src/loader/egg_loader.ts`, `tools/egg-bundler/src/lib/EntryGenerator.ts`, `packages/egg/src/lib/start.ts`
+- pages updated: `tools/egg-bundler/README.md`, `tools/egg-bundler/docs/output-structure.md`, `wiki/log.md`, `wiki/packages/core.md`, `wiki/packages/egg-bundler.md`
+- note: Recorded that bundled workers now create `ManifestLoaderFS` from the bundled manifest and pass it to `startEgg`, letting loader file discovery and module loading resolve through the bundle map before falling back to the real filesystem.
+
 ## [2026-05-10] package | extract shared LoaderFS package
 
 - sources touched: `packages/loader-fs/src/index.ts`, `packages/loader-fs/package.json`, `packages/core/src/index.ts`, `packages/core/src/loader/file_loader.ts`, `packages/core/src/loader/egg_loader.ts`

--- a/wiki/packages/core.md
+++ b/wiki/packages/core.md
@@ -4,10 +4,11 @@ type: package
 summary: Loader, lifecycle, and application core primitives used by Egg runtime packages.
 source_files:
   - packages/core/src/index.ts
+  - packages/core/src/loader/loader_fs.ts
   - packages/core/src/loader/file_loader.ts
   - packages/core/src/loader/context_loader.ts
   - packages/core/src/loader/egg_loader.ts
-updated_at: 2026-05-10
+updated_at: 2026-05-30
 status: active
 ---
 
@@ -20,11 +21,20 @@ support, lifecycle, and base context classes.
 ## LoaderFS
 
 `@eggjs/core` consumes and re-exports `LoaderFS` and `RealLoaderFS` from
-`@eggjs/loader-fs`. The abstraction remains the minimal filesystem boundary for
-loader-facing file access: `exists`, `stat`, `realpath`, `readJSON`, `glob`, and
-`loadFile`, without trying to polyfill the full Node.js `fs` module.
+`@eggjs/loader-fs`. It also exports `ManifestLoaderFS`, the bundled-runtime
+implementation backed by an Egg startup manifest. The abstraction remains the
+minimal filesystem boundary for loader-facing file access: `exists`, `stat`,
+`realpath`, `readJSON`, `glob`, and `loadFile`, without trying to polyfill the
+full Node.js `fs` module.
 
 `EggLoaderOptions`, `FileLoaderOptions`, and `ContextLoaderOptions` can carry a
 custom `loaderFS`. `EggLoader` passes its loader FS into `loadToApp()` and
 `loadToContext()` so later bundled loaders can replace file discovery and module
 loading without changing the public loader call sites.
+
+`ManifestLoaderFS` answers loader filesystem calls from
+`ManifestStore.data.fileDiscovery` and `ManifestStore.data.resolveCache` before
+falling back to `RealLoaderFS`. When the bundled module loader is installed on
+`globalThis.__EGG_BUNDLE_MODULE_LOADER__`, manifest-backed `readJSON()` and
+`loadFile()` can return modules from the bundle map instead of reading the
+original source file from disk.

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -9,7 +9,7 @@ source_files:
   - tools/egg-bundler/src/lib/ExternalsResolver.ts
   - tools/egg-bin/src/commands/bundle.ts
   - tools/egg-bundler/docs/output-structure.md
-updated_at: 2026-05-06
+updated_at: 2026-05-30
 status: active
 ---
 
@@ -47,10 +47,12 @@ CommonJS artifact from an Egg application.
   not run.
 - The generated app runs in Egg single-process mode. Its worker entry treats the
   deploy output directory as the runtime Egg `baseDir`, passes the framework
-  specifier explicitly to `startEgg`, maps that specifier to the already bundled
-  framework module, and precomputes original app absolute aliases so bundled
-  module lookup can serve relKeys, output-dir absolute paths, original app
-  absolute paths, and manifest `resolveCache` request aliases.
+  specifier explicitly to `startEgg`, creates `ManifestLoaderFS` from the
+  bundled startup manifest, and passes that loader FS into Egg startup.
+  Framework lookup is mapped to the already bundled framework module, and
+  original app absolute aliases are precomputed so bundled module lookup can
+  serve relKeys, output-dir absolute paths, original app absolute paths, and
+  manifest `resolveCache` request aliases.
 - Explicit `externals.force` entries are external, and `ExternalsResolver`
   auto-detects root `peerDependencies`, root `optionalDependencies`, root
   dependency packages with native addons, root dependency packages whose optional


### PR DESCRIPTION
## Summary
- document that bundled workers create and pass `ManifestLoaderFS` into Egg startup
- update the LLM wiki pages for core and egg-bundler with the manifest-backed loader FS behavior
- add a wiki log entry for the 2026-05-30 doc sync

## Verification
- `git diff --check`
- `XDG_CACHE_HOME=/tmp/xdg-cache XDG_DATA_HOME=/tmp/xdg-data PNPM_HOME=/tmp/pnpm-home pnpm dlx oxfmt@0.46.0 --check tools/egg-bundler/README.md tools/egg-bundler/docs/output-structure.md wiki/log.md wiki/packages/core.md wiki/packages/egg-bundler.md`

Note: `pnpm run fmtcheck` could not run directly before install because dependencies were absent. `pnpm install --frozen-lockfile` could not proceed because this checkout has no `pnpm-lock.yaml` and pnpm reported a frozen lockfile/config mismatch, so I ran the same formatter version via `pnpm dlx` on the touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how framework file discovery and module resolution work in the bundler system.
  * Updated descriptions of bundled worker initialization flow and loader filesystem behavior.
  * Added changelog entry documenting runtime changes to worker initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eggjs/egg/pull/5956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->