### PR TITLE
docs(agents): add local CI guidance for duplicate proto issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ Egg is maintained as a pnpm monorepo.
 - `pnpm run typecheck` runs TypeScript checking.
 - use filtered commands for focused work, for example `pnpm --filter=egg run test` or `pnpm --filter=site run dev`.
 
+### Local CI
+
+Run tests **without building first**. The CI workflow (`ut install → ut run ci`) never runs `build` before tests. If `dist/` directories exist from a prior build, tegg plugin tests will fail with `duplicate proto` errors because globby scans both `src/*.ts` and `dist/*.js`, loading the same decorated class twice.
+
+When you see `duplicate proto` failures locally:
+
+```bash
+find tegg packages plugins tools -name dist -type d \
+  -not -path '*/node_modules/*' -not -path '*/test/*' -not -path '*/fixtures/*' \
+  -exec rm -rf {} +
+```
+
+Then re-run tests.
+
 ## Coding Conventions
 
 - prefer existing repo patterns over inventing new ones


### PR DESCRIPTION
## Summary

- Add a "Local CI" section to AGENTS.md documenting why `pnpm run build` before tests causes `duplicate proto` failures in tegg plugin tests
- Provide the cleanup command to remove stale `dist/` directories
- Root cause: globby scans both `src/*.ts` and `dist/*.js` when `.ts` is supported, loading the same decorated class twice via `import()`

## Context

CI never runs `build` before tests (the workflow is `install → ci`), so this only affects local development. Without this guidance, developers who run `build` then `test` will see confusing failures that don't reproduce in CI.

## Test plan

- [x] Verified locally: clean dist → run tests → 510 passed (matches CI)
- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on local testing workflow, including instructions for resolving build artifact issues that may cause test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->