### PR TITLE
test: enable vitest isolate:false on safe packages

### DIFF
--- a/packages/cookies/vitest.config.ts
+++ b/packages/cookies/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 10000,
     hookTimeout: 20000,
     exclude: ['test/fixtures/**', 'test/benchmark/**', '**/node_modules/**', '**/dist/**'],

--- a/packages/errors/vitest.config.ts
+++ b/packages/errors/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/extend2/vitest.config.ts
+++ b/packages/extend2/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/koa-static-cache/vitest.config.ts
+++ b/packages/koa-static-cache/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/koa/vitest.config.ts
+++ b/packages/koa/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/loader-fs/vitest.config.ts
+++ b/packages/loader-fs/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/path-matching/vitest.config.ts
+++ b/packages/path-matching/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/router/vitest.config.ts
+++ b/packages/router/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/supertest/vitest.config.ts
+++ b/packages/supertest/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/tsconfig/vitest.config.ts
+++ b/packages/tsconfig/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 15000,
     include: ['test/**/*.test.ts'],
     exclude: ['**/test/fixtures/**', '**/node_modules/**', '**/dist/**'],

--- a/plugins/i18n/vitest.config.ts
+++ b/plugins/i18n/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/plugins/jsonp/vitest.config.ts
+++ b/plugins/jsonp/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/plugins/logrotator/vitest.config.ts
+++ b/plugins/logrotator/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 20000,
     hookTimeout: 20000,
   },

--- a/plugins/onerror/vitest.config.ts
+++ b/plugins/onerror/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 20000,
     hookTimeout: 20000,
   },

--- a/plugins/redis/vitest.config.ts
+++ b/plugins/redis/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, type UserWorkspaceConfig } from 'vitest/config';
 
 const config: UserWorkspaceConfig = defineConfig({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 30000,
     hookTimeout: 30000,
     globals: true,

--- a/plugins/session/vitest.config.ts
+++ b/plugins/session/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/plugins/static/vitest.config.ts
+++ b/plugins/static/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/plugins/tracer/vitest.config.ts
+++ b/plugins/tracer/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/plugins/typebox-validate/vitest.config.ts
+++ b/plugins/typebox-validate/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/plugins/view/vitest.config.ts
+++ b/plugins/view/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 20000,
     hookTimeout: 20000,
   },

--- a/plugins/watcher/vitest.config.ts
+++ b/plugins/watcher/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 20000,
     hookTimeout: 20000,
   },

--- a/tegg/core/agent-runtime/vitest.config.ts
+++ b/tegg/core/agent-runtime/vitest.config.ts
@@ -1,5 +1,10 @@
 import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
 
-const config: UserWorkspaceConfig = defineProject({});
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    pool: 'threads',
+    isolate: false,
+  },
+});
 
 export default config;

--- a/tegg/core/ajv-decorator/vitest.config.ts
+++ b/tegg/core/ajv-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/aop-decorator/vitest.config.ts
+++ b/tegg/core/aop-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/aop-runtime/vitest.config.ts
+++ b/tegg/core/aop-runtime/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/background-task/vitest.config.ts
+++ b/tegg/core/background-task/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/common-util/vitest.config.ts
+++ b/tegg/core/common-util/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/controller-decorator/vitest.config.ts
+++ b/tegg/core/controller-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/core-decorator/vitest.config.ts
+++ b/tegg/core/core-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/dal-decorator/vitest.config.ts
+++ b/tegg/core/dal-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/dal-runtime/vitest.config.ts
+++ b/tegg/core/dal-runtime/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/dynamic-inject-runtime/vitest.config.ts
+++ b/tegg/core/dynamic-inject-runtime/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/dynamic-inject/vitest.config.ts
+++ b/tegg/core/dynamic-inject/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/eventbus-decorator/vitest.config.ts
+++ b/tegg/core/eventbus-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/eventbus-runtime/vitest.config.ts
+++ b/tegg/core/eventbus-runtime/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/langchain-decorator/vitest.config.ts
+++ b/tegg/core/langchain-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/lifecycle/vitest.config.ts
+++ b/tegg/core/lifecycle/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/loader/vitest.config.ts
+++ b/tegg/core/loader/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/mcp-client/vitest.config.ts
+++ b/tegg/core/mcp-client/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/metadata/vitest.config.ts
+++ b/tegg/core/metadata/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/orm-decorator/vitest.config.ts
+++ b/tegg/core/orm-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/runtime/vitest.config.ts
+++ b/tegg/core/runtime/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/schedule-decorator/vitest.config.ts
+++ b/tegg/core/schedule-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/standalone-decorator/vitest.config.ts
+++ b/tegg/core/standalone-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/tegg/vitest.config.ts
+++ b/tegg/core/tegg/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/test-util/vitest.config.ts
+++ b/tegg/core/test-util/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/transaction-decorator/vitest.config.ts
+++ b/tegg/core/transaction-decorator/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/types/vitest.config.ts
+++ b/tegg/core/types/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/core/vitest/vitest.config.ts
+++ b/tegg/core/vitest/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
     ],
   },
   test: {
+    pool: 'threads',
+    isolate: false,
     environment: 'node',
     include: ['test/**/*.test.ts'],
     // Register TS loader (ts-node) before tests so Egg can load .ts via Module._extensions.

--- a/tegg/plugin/ajv/vitest.config.ts
+++ b/tegg/plugin/ajv/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
 
 const config: UserWorkspaceConfig = defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     // app.ready() loads 5 plugins and can take >10s under heavy parallel load
     hookTimeout: 30000,
   },

--- a/tegg/plugin/aop/vitest.config.ts
+++ b/tegg/plugin/aop/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/common/vitest.config.ts
+++ b/tegg/plugin/common/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/config/vitest.config.ts
+++ b/tegg/plugin/config/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/controller/vitest.config.ts
+++ b/tegg/plugin/controller/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/dal/vitest.config.ts
+++ b/tegg/plugin/dal/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/eventbus/vitest.config.ts
+++ b/tegg/plugin/eventbus/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/langchain/vitest.config.ts
+++ b/tegg/plugin/langchain/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/mcp-client/vitest.config.ts
+++ b/tegg/plugin/mcp-client/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/mcp-proxy/vitest.config.ts
+++ b/tegg/plugin/mcp-proxy/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/orm/vitest.config.ts
+++ b/tegg/plugin/orm/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/schedule/vitest.config.ts
+++ b/tegg/plugin/schedule/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/plugin/tegg/vitest.config.ts
+++ b/tegg/plugin/tegg/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across test files in this project (no
+    // per-file isolation) to speed up the suite. Pairs with pool: 'threads';
+    // the root vitest.config.ts cannot set these for glob-matched projects.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tegg/standalone/standalone/vitest.config.ts
+++ b/tegg/standalone/standalone/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineProject, type UserWorkspaceConfig } from 'vitest/config';
+
+const config: UserWorkspaceConfig = defineProject({
+  test: {
+    // Reuse a single worker thread across this project's test files instead of
+    // spawning a fresh worker per file. The root vitest.config.ts cannot set
+    // these for glob-matched projects, so each project opts in explicitly.
+    pool: 'threads',
+    isolate: false,
+  },
+});
+
+export default config;

--- a/tools/create-egg/vitest.config.ts
+++ b/tools/create-egg/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineProject } from 'vitest/config';
 
 export default defineProject({
   test: {
+    pool: 'threads',
+    isolate: false,
     testTimeout: 20000,
     exclude: ['**/node_modules/**', '**/dist/**', '**/templates/**/test/**'],
   },


### PR DESCRIPTION
## Motivation

Run test files within a project in a single reused worker thread (`pool: 'threads'`, `isolate: false`) instead of spawning a fresh worker per file, to speed up the suite.

The root `vitest.config.ts` already declared `isolate: false` / `pool: 'threads'`, but **in Vitest 4 root `test` options are not inherited by glob-referenced projects** — every project was silently running with the defaults (`isolate: true`, `forks`). This sets the options explicitly on each project that is verified safe.

On the tegg-plugin pilot this cut wall-clock from ~25s to ~18s.

## Scope

**66 projects** confirmed green under `isolate: false` + `threads` (each run individually via its committed config, 0 failures).

## Deliberately excluded (follow-up)

- **`packages/cluster`, `plugins/schedule`, `plugins/mock`, `packages/egg`, `plugins/development`, `plugins/view-nunjucks`** — these spawn real Egg cluster/app child processes via `mm.cluster`, whose fixed-port allocation in `plugins/mock/src/lib/cluster.ts` (`globalThis.eggMockMasterPort = 17000 + (process.pid % 1000)`) assumes **one OS process per test file**. Sharing a worker resets/collides that counter → flaky `EADDRINUSE`. These can opt in after the mock port allocation is made isolation-safe (idempotent seed via `??=`, or bind an ephemeral `port: 0` and read it back from the existing `egg-ready` message).
- **`packages/logger`** — sets `fileParallelism: false` (→ `maxWorkers: 1`); under `isolate: false` Vitest 4 requires a uniform `maxWorkers` per `sequence.groupOrder`, which would abort whole-suite collection.

The root `vitest.config.ts` is intentionally left unchanged in this PR (its dead `isolate`/`pool` options can be cleaned up separately).

## Test evidence

- Full-suite collection verified clean (`vitest list` → 3280 tests, no `sequence.groupOrder` error).
- All 66 included projects run green via their committed configs (`vitest run --project=<name>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized testing infrastructure across all packages and plugins by configuring test worker thread pooling. Test files now reuse shared worker resources instead of spawning isolated workers, improving resource utilization and reducing test execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->