### PR TITLE
fix(security): use CSPRNG for CSP nonce generation

### DIFF
--- a/plugins/security/src/app/extend/context.ts
+++ b/plugins/security/src/app/extend/context.ts
@@ -2,7 +2,7 @@ import { debuglog } from 'node:util';
 
 import Tokens from 'csrf';
 import { Context } from 'egg';
-import { nanoid } from 'nanoid/non-secure';
+import { nanoid } from 'nanoid';
 
 import type { SecurityConfig } from '../../config/config.default.ts';
 import type { HttpClientRequestURL, HttpClientOptions, HttpClientResponse } from '../../lib/extend/safe_curl.ts';

--- a/plugins/security/test/csp.test.ts
+++ b/plugins/security/test/csp.test.ts
@@ -94,6 +94,26 @@ describe.skipIf(process.platform === 'win32')('test/csp.test.ts', () => {
       const nonce = res.text;
       expect(res.headers['x-csp-nonce']).toBe(nonce);
     });
+
+    it('should generate unpredictable nonce even when Math.random is fixed', async () => {
+      // The CSP nonce must come from a cryptographically secure RNG.
+      // `nanoid/non-secure` derives every char from `Math.random()`, so pinning
+      // `Math.random` to a constant would make the nonce fully predictable.
+      // A CSPRNG-backed nonce stays random regardless of `Math.random`.
+      mm(Math, 'random', () => 0);
+      try {
+        const res1 = await app.httpRequest().get('/testcsp').expect(200);
+        const res2 = await app.httpRequest().get('/testcsp').expect(200);
+        expect(res1.text.length).toBe(16);
+        expect(res2.text.length).toBe(16);
+        // not constant across requests
+        expect(res1.text).not.toBe(res2.text);
+        // not the predictable value Math.random()===0 would produce
+        expect(res1.text).not.toBe('u'.repeat(16));
+      } finally {
+        mm.restore();
+      }
+    });
   });
 
   it('should ignore path', async () => {


### PR DESCRIPTION
## Problem

The CSP nonce (`ctx.nonce`) was generated with `nanoid/non-secure`, which derives every character from `Math.random()`. `Math.random()` is not cryptographically secure and its internal state can be recovered from observed outputs, making the nonce predictable. A predictable nonce weakens nonce-based CSP as a defense against XSS.

## Fix

Import `nanoid` from its crypto-backed entry point instead of `nanoid/non-secure`, so the nonce stays unpredictable. No API or output-shape change (still a 16-char URL-safe string).

## Test

Added a regression test that pins `Math.random` to a constant and asserts the nonce is still unpredictable across requests. It fails on the old `non-secure` import (nonce collapses to a constant value) and passes with the crypto-backed RNG.

`plugins/security` suite: 199 passed, 4 skipped.