### PR TITLE
fix(utils): resolve bundle-inlined modules in importResolve

### DIFF
--- a/packages/utils/src/import.ts
+++ b/packages/utils/src/import.ts
@@ -373,6 +373,17 @@ export function importResolve(filepath: string, options?: ImportResolveOptions):
     }
   }
 
+  // In bundle mode a module's source may not exist on disk (it is inlined into the
+  // bundle). After on-disk resolution has failed, if the registered bundle module
+  // loader recognizes the path, treat it as already resolved and return it as the
+  // canonical key, mirroring importModule. This must run before import.meta.resolve
+  // (which is unavailable in the bundled runtime).
+  const bundleModuleLoader = globalThis.__EGG_BUNDLE_MODULE_LOADER__;
+  if (bundleModuleLoader && bundleModuleLoader(normalizeBundleModulePath(filepath)) !== undefined) {
+    debug('[importResolve:bundle] %o => %o', filepath, filepath);
+    return filepath;
+  }
+
   const extname = path.extname(filepath);
   if ((!isAbsolute && extname === '.json') || !isESM) {
     moduleFilePath = getRequire().resolve(filepath, {

--- a/packages/utils/test/bundle-import.test.ts
+++ b/packages/utils/test/bundle-import.test.ts
@@ -164,7 +164,7 @@ describe('test/bundle-import.test.ts', () => {
     });
 
     const resolved = importResolve(getFilepath('esm'));
-    assert.ok(resolved.endsWith('/fixtures/esm/index.js'));
+    assert.match(resolved, /[\\/]fixtures[\\/]esm[\\/]index\.js$/);
     assert.equal(called, false);
   });
 

--- a/packages/utils/test/bundle-import.test.ts
+++ b/packages/utils/test/bundle-import.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import coffee from 'coffee';
 import { afterEach, describe, it } from 'vitest';
 
-import { importModule, setBundleModuleLoader } from '../src/import.ts';
+import { importModule, importResolve, setBundleModuleLoader } from '../src/import.ts';
 import { getFilepath } from './helper.ts';
 
 describe('test/bundle-import.test.ts', () => {
@@ -134,5 +134,41 @@ describe('test/bundle-import.test.ts', () => {
 
     const result = await importModule(filepath);
     assert.deepEqual(result, fakeModule);
+  });
+
+  it('importResolve returns the path as canonical key for bundle-only modules', () => {
+    const seen: string[] = [];
+    setBundleModuleLoader((p) => {
+      seen.push(p);
+      return p === 'virtual/not-on-disk' ? { virtual: true } : undefined;
+    });
+
+    // The module is inlined into the bundle and has no source on disk, but the
+    // loader recognizes it, so importResolve hands it back unchanged.
+    assert.equal(importResolve('virtual/not-on-disk'), 'virtual/not-on-disk');
+    assert.ok(seen.includes('virtual/not-on-disk'));
+  });
+
+  it('importResolve normalizes Windows-style paths before the bundle lookup', () => {
+    setBundleModuleLoader((p) => (p === 'virtual/win/mod' ? { windows: true } : undefined));
+
+    const filepath = 'virtual/win/mod'.split(path.posix.sep).join(path.win32.sep);
+    assert.equal(importResolve(filepath), filepath);
+  });
+
+  it('importResolve does not consult the loader once on-disk resolution succeeds', () => {
+    let called = false;
+    setBundleModuleLoader(() => {
+      called = true;
+      return { hit: true };
+    });
+
+    const resolved = importResolve(getFilepath('esm'));
+    assert.ok(resolved.endsWith('/fixtures/esm/index.js'));
+    assert.equal(called, false);
+  });
+
+  it('importResolve still throws for missing modules when no loader is registered', () => {
+    assert.throws(() => importResolve('virtual/not-on-disk'));
   });
 });


### PR DESCRIPTION
## Motivation

In bundle mode a module's source may not exist on disk — it is inlined into the bundle. `importResolve` runs through its on-disk resolution paths (absolute / relative / `node_modules`), and on failure falls into `import.meta.resolve`, which is **unavailable in the bundled runtime**. As a result, resolving a bundle-only module throws even though `importModule` itself already knows how to serve it via the registered bundle module loader.

## Scope

Add a bundle fallback to `importResolve`, symmetric with the existing one in `importModule`:

- It runs **after** on-disk resolution has failed and **before** `import.meta.resolve`.
- When `globalThis.__EGG_BUNDLE_MODULE_LOADER__` is registered and recognizes `normalizeBundleModulePath(filepath)`, the path is treated as already resolved and returned unchanged as the canonical key.
- Paths are POSIX-normalized before the loader lookup, matching `importModule`.

The fallback only takes effect when a loader is registered. **When no loader is registered, behavior is unchanged** (the unregistered case still throws / falls back exactly as before) — covered by an explicit assertion.

## Test evidence

Added `importResolve` coverage to `packages/utils/test/bundle-import.test.ts`:

- returns the path as the canonical key for a bundle-only (not-on-disk) module
- normalizes Windows-style paths before the bundle lookup
- does **not** consult the loader once on-disk resolution succeeds
- still throws for missing modules when no loader is registered

```
npx vitest run packages/utils/  →  70 passed | 13 skipped, 0 failed
npx oxlint --type-aware packages/utils → clean
tsgo --noEmit (packages/utils) → clean
```

This PR has no dependency on the other bundle-startup PRs and can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bundle-mode resolution step for module imports, enabling support for virtual modules available only in bundled environments.

* **Tests**
  * Added coverage for bundle module resolution, including canonical key behavior, Windows-style path normalization, correct skipping when on-disk resolution succeeds, and error handling when no loader is registered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->