### PR TITLE
fix: relocate bundle-mode framework/plugin eggPaths to output node_modules

### DIFF
--- a/packages/core/src/loader/egg_loader.ts
+++ b/packages/core/src/loader/egg_loader.ts
@@ -780,7 +780,7 @@ export class EggLoader {
 
   // Get the real plugin path
   protected getPluginPath(plugin: EggPluginInfo): string {
-    if (plugin.path) {
+    if (plugin.path && !this.#isBundlePluginPathArtifact(plugin.path)) {
       return plugin.path;
     }
 
@@ -790,7 +790,75 @@ export class EggLoader {
         `plugin ${plugin.name} invalid, use 'path' instead of package: "${plugin.package}"`,
       );
     }
+
+    // In bundle mode, a plugin declared via `definePluginFactory({ path: import.meta.dirname })`
+    // had its `path` rewritten by the bundler to the bundle output dir (= baseDir). The original
+    // value was the directory of the plugin package's entry module (e.g. `<pkg>/dist`), not the
+    // package root, so re-resolve to the entry module's directory rather than the package.json dir.
+    if (plugin.path && this.#isBundlePluginPathArtifact(plugin.path)) {
+      return this.#resolveBundlePluginPath(plugin);
+    }
+
     return this.#resolvePluginPath(plugin);
+  }
+
+  /**
+   * In bundle mode a plugin declared via `definePluginFactory({ path: import.meta.dirname })`
+   * carries a `path` rewritten by the bundler to the bundle output directory (= baseDir),
+   * which does not contain the plugin's own files. Detect that case so the plugin is
+   * re-resolved by package name instead.
+   */
+  #isBundlePluginPathArtifact(pluginPath: string): boolean {
+    const bundleStore = ManifestStore.getBundleStore();
+    // Only treat a path as a bundle artifact when the active bundle store belongs
+    // to this app. The store is shared via globalThis across @eggjs/core copies,
+    // so one registered for a different app must not reinterpret this app's plugin
+    // paths — mirror `ManifestStore.load()`'s `bundleStore.baseDir === baseDir` gate.
+    if (!bundleStore || path.resolve(bundleStore.baseDir) !== path.resolve(this.options.baseDir)) {
+      return false;
+    }
+    return path.resolve(pluginPath) === path.resolve(this.options.baseDir);
+  }
+
+  /**
+   * Re-resolve a bundle-artifact plugin path to the directory of the plugin package's entry
+   * module — the same directory `definePluginFactory` captured via `import.meta.dirname` at
+   * build time. Built-in framework plugins only carry a `name` (no `package`), so fall back to
+   * the conventional `@eggjs/<name>` package name in addition to the bare name.
+   */
+  #resolveBundlePluginPath(plugin: EggPluginInfo): string {
+    const candidates = plugin.package
+      ? [plugin.package]
+      : plugin.name.includes('/')
+        ? [plugin.name]
+        : [plugin.name, `@eggjs/${plugin.name}`];
+    let lastErr: unknown;
+    for (const name of candidates) {
+      try {
+        // Resolve the package entry module (not package.json) so the returned directory matches
+        // the plugin package's runtime entry directory (e.g. `<pkg>/dist`).
+        const entry = utils.resolvePath(name, { paths: [...this.lookupDirs] });
+        const realDir = path.dirname(entry);
+        // Rebase under the bundle output baseDir so the manifest-backed loader fs
+        // (keyed relative to baseDir) resolves the bundled plugin config/extend/app
+        // files, mirroring how the framework eggPaths are rebased. Match the last
+        // `node_modules` by path segment (not a substring) so directories like
+        // `my_node_modules` are not mistaken for the package root marker.
+        const segments = realDir.split(/[/\\]/);
+        const nmIdx = segments.lastIndexOf('node_modules');
+        if (nmIdx !== -1) {
+          return path.join(this.options.baseDir, ...segments.slice(nmIdx));
+        }
+        return realDir;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    const name = plugin.package || plugin.name;
+    debug('[resolveBundlePluginPath] error: %o, plugin info: %o', lastErr, plugin);
+    throw new Error(`Can not find plugin ${name} in "${[...this.lookupDirs].join(', ')}"`, {
+      cause: lastErr,
+    });
   }
 
   #resolvePluginPath(plugin: EggPluginInfo): string {

--- a/packages/core/test/fixtures/bundle-plugin-paths/node_modules/@eggjs/bundle-builtin/dist/index.js
+++ b/packages/core/test/fixtures/bundle-plugin-paths/node_modules/@eggjs/bundle-builtin/dist/index.js
@@ -1,0 +1,5 @@
+// Bundle output entry for the built-in plugin fixture. The plugin is declared
+// with only a `name`, so the loader must fall back to the `@eggjs/<name>`
+// package when re-resolving the bundle-rewritten path.
+'use strict';
+module.exports = {};

--- a/packages/core/test/fixtures/bundle-plugin-paths/node_modules/@eggjs/bundle-builtin/package.json
+++ b/packages/core/test/fixtures/bundle-plugin-paths/node_modules/@eggjs/bundle-builtin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@eggjs/bundle-builtin",
+  "version": "1.0.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "eggPlugin": {
+    "name": "bundle-builtin"
+  }
+}

--- a/packages/core/test/fixtures/bundle-plugin-paths/node_modules/bundle-plugin-pkg/dist/index.js
+++ b/packages/core/test/fixtures/bundle-plugin-paths/node_modules/bundle-plugin-pkg/dist/index.js
@@ -1,0 +1,3 @@
+// Bundle output entry for the `package`-declared plugin fixture.
+'use strict';
+module.exports = {};

--- a/packages/core/test/fixtures/bundle-plugin-paths/node_modules/bundle-plugin-pkg/package.json
+++ b/packages/core/test/fixtures/bundle-plugin-paths/node_modules/bundle-plugin-pkg/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bundle-plugin-pkg",
+  "version": "1.0.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "eggPlugin": {
+    "name": "bundlePluginPkg"
+  }
+}

--- a/packages/core/test/fixtures/bundle-plugin-paths/package.json
+++ b/packages/core/test/fixtures/bundle-plugin-paths/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bundle-plugin-paths",
+  "version": "1.0.0"
+}

--- a/packages/core/test/loader/bundle_plugin_path.test.ts
+++ b/packages/core/test/loader/bundle_plugin_path.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+
+import { afterEach, describe, it } from 'vitest';
+
+import { EggLoader, ManifestStore } from '../../src/index.ts';
+import { getFilepath } from '../helper.ts';
+
+// Regression coverage for bundle-mode plugin path relocation.
+//
+// In bundle mode the bundler rewrites `import.meta.dirname` (used by
+// `definePluginFactory({ path: import.meta.dirname })`) to the bundle output
+// directory (= baseDir). The loader must detect that rewritten artifact and
+// re-resolve the plugin to its package entry directory, rebased under the
+// output `node_modules`, so the manifest-backed loader fs can find the bundled
+// plugin files. Non-bundle behavior must stay byte-for-byte identical.
+describe('test/loader/bundle_plugin_path.test.ts', () => {
+  const baseDir = getFilepath('bundle-plugin-paths');
+
+  function createLoader() {
+    const loader = new EggLoader({
+      baseDir,
+      app: {},
+      logger: console,
+    } as any);
+    // `lookupDirs` is normally populated by `loadPlugin()`; set it directly so
+    // `getPluginPath` can be exercised in isolation without a full plugin load.
+    (loader as any).lookupDirs = (loader as any).getLookupDirs();
+    return loader;
+  }
+
+  function registerBundleStore() {
+    const data = ManifestStore.createCollector(baseDir).generateManifest({
+      serverEnv: 'prod',
+      serverScope: '',
+      typescriptEnabled: false,
+    });
+    ManifestStore.setBundleStore(ManifestStore.fromBundle(data, baseDir));
+  }
+
+  afterEach(() => {
+    ManifestStore.setBundleStore(undefined);
+  });
+
+  describe('with a registered bundle store', () => {
+    it('should re-resolve a built-in plugin declared with only a name', () => {
+      registerBundleStore();
+      const loader = createLoader();
+      // The bundler rewrote the plugin path to the output baseDir; the plugin
+      // only carries `name`, so it falls back to the `@eggjs/<name>` package.
+      const resolved = (loader as any).getPluginPath({
+        name: 'bundle-builtin',
+        path: baseDir,
+      });
+      assert.equal(resolved, path.join(baseDir, 'node_modules', '@eggjs', 'bundle-builtin', 'dist'));
+    });
+
+    it('should re-resolve a plugin declared with a package name', () => {
+      registerBundleStore();
+      const loader = createLoader();
+      const resolved = (loader as any).getPluginPath({
+        name: 'bundlePluginPkg',
+        package: 'bundle-plugin-pkg',
+        path: baseDir,
+      });
+      assert.equal(resolved, path.join(baseDir, 'node_modules', 'bundle-plugin-pkg', 'dist'));
+    });
+
+    it('should keep an explicit path that is not the bundle artifact', () => {
+      registerBundleStore();
+      const loader = createLoader();
+      // path !== baseDir => not a rewritten artifact, return verbatim.
+      const explicit = path.join(baseDir, 'node_modules', 'bundle-plugin-pkg');
+      const resolved = (loader as any).getPluginPath({
+        name: 'bundlePluginPkg',
+        path: explicit,
+      });
+      assert.equal(resolved, explicit);
+    });
+  });
+
+  describe('with a bundle store registered for a *different* app', () => {
+    it('should not treat this app’s paths as bundle artifacts', () => {
+      // The bundle store is shared via globalThis across @eggjs/core copies, so a
+      // store registered for another app must not redirect this app's plugin
+      // resolution. Register a store whose baseDir differs from this loader's.
+      const otherBaseDir = path.join(baseDir, '..', 'some-other-app');
+      const data = ManifestStore.createCollector(otherBaseDir).generateManifest({
+        serverEnv: 'prod',
+        serverScope: '',
+        typescriptEnabled: false,
+      });
+      ManifestStore.setBundleStore(ManifestStore.fromBundle(data, otherBaseDir));
+      const loader = createLoader();
+      // path === this app's baseDir, but the store is for another app, so the
+      // artifact gate stays off and the explicit path is returned verbatim.
+      assert.equal((loader as any).getPluginPath({ name: 'x', path: baseDir }), baseDir);
+    });
+  });
+
+  describe('without a bundle store (non-bundle, zero behavior change)', () => {
+    it('should return an explicit path verbatim, even when it equals baseDir', () => {
+      const loader = createLoader();
+      // Without a bundle store the artifact gate is off, so the original
+      // `plugin.path` short-circuit applies unchanged.
+      assert.equal((loader as any).getPluginPath({ name: 'x', path: baseDir }), baseDir);
+      const other = path.join(baseDir, 'node_modules', 'bundle-plugin-pkg');
+      assert.equal((loader as any).getPluginPath({ name: 'x', path: other }), other);
+    });
+  });
+});

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -657,6 +657,29 @@ export class EggApplicationCore extends EggCore {
   }
 
   protected override customEggPaths(): string[] {
+    const bundleStore = ManifestStore.getBundleStore();
+    // Only rebase when the active bundle store belongs to *this* app. A global
+    // bundle store (shared via globalThis across @eggjs/core copies) may have
+    // been registered for a different app; mirror `ManifestStore.load()`'s
+    // `bundleStore.baseDir === baseDir` gate so an unrelated store never
+    // redirects this app's framework paths.
+    if (bundleStore && path.resolve(bundleStore.baseDir) === path.resolve(this.baseDir)) {
+      // In bundle mode `import.meta.dirname` is rewritten by the bundler to the
+      // bundle output directory, not the egg package directory, so it can no
+      // longer locate the framework `config/*` files. Rebase the framework dir
+      // under the output baseDir (`<output>/node_modules/egg/dist`) so the
+      // manifest-backed loader fs (keyed relative to the output baseDir)
+      // resolves the bundled framework config files.
+      const bundledFrameworkDir = path.join(bundleStore.baseDir, 'node_modules', 'egg', 'dist');
+      // Guard on existence: a real bundler output physically copies egg here, but
+      // a bundle-mode app booted without the copied framework (e.g. integration
+      // tests that only inject a manifest-backed loaderFS) does not. In that case
+      // fall back to `import.meta.dirname`, which — when not actually rewritten by
+      // a bundler — still points at the real egg package dir.
+      if (fs.existsSync(bundledFrameworkDir)) {
+        return [bundledFrameworkDir, ...super.customEggPaths()];
+      }
+    }
     return [path.dirname(import.meta.dirname), ...super.customEggPaths()];
   }
 


### PR DESCRIPTION
## Motivation

In bundle mode the bundler rewrites `import.meta.dirname` to the **bundle output directory** rather than the originating package directory. Two path-resolution sites depend on `import.meta.dirname` and therefore break under bundling:

1. **Framework `config/*`** — `EggApplicationCore.customEggPaths()` derives the framework dir from `import.meta.dirname`, which now points at the output dir instead of the `egg` package.
2. **Plugin own files** — a plugin declared via `definePluginFactory({ path: import.meta.dirname })` carries a `path` rewritten to the output dir (= `baseDir`), which does not contain the plugin's files.

Root cause is unified: bundler-rewritten paths must be **rebased under the output `node_modules`**, where the manifest-backed loader fs (keyed relative to the output `baseDir`) can resolve the bundled assets.

## Scope

- **`packages/egg/src/lib/egg.ts`** (`fix(egg)`) — under a registered bundle store, `customEggPaths()` returns `<bundleStore.baseDir>/node_modules/egg/dist` ahead of `super.customEggPaths()`.
- **`packages/core/src/loader/egg_loader.ts`** (`fix(core)`) — `getPluginPath()` detects the bundle-rewritten artifact (`#isBundlePluginPathArtifact`: path equals `baseDir` while a bundle store is registered) and re-resolves via `#resolveBundlePluginPath`, which resolves the plugin package entry directory and rebases it under the output `node_modules`. Built-in plugins carry only a `name`, so resolution falls back to `@eggjs/<name>` in addition to the bare name.

The two commits are split by package, so a reviewer can land them independently if preferred (the higher-risk loader change in `core` carries the fixture + tests).

## Non-bundle safety

Every new branch is gated on `ManifestStore.getBundleStore()`. When no bundle store is registered, both files fall through to the **original, byte-for-byte unchanged** logic (`import.meta.dirname` for the framework dir; the `plugin.path` short-circuit and `#resolvePluginPath` for plugins). This is asserted explicitly in the new tests.

## Test evidence

New fixture `packages/core/test/fixtures/bundle-plugin-paths/` simulates a bundle output `node_modules` containing a built-in (name-only) plugin and a `package`-declared plugin. New suite `packages/core/test/loader/bundle_plugin_path.test.ts`:

- built-in plugin (name-only) re-resolves to `<baseDir>/node_modules/@eggjs/bundle-builtin/dist`
- package-declared plugin re-resolves to `<baseDir>/node_modules/bundle-plugin-pkg/dist`
- explicit non-artifact path is returned verbatim
- with **no** bundle store, an explicit path (even one equal to `baseDir`) is returned verbatim

```
$ pnpm --filter=@eggjs/core run test  (vitest)
 Test Files  41 passed (41)
      Tests  453 passed | 25 skipped (479)
```

`@eggjs/core` and `egg` typecheck (`tsgo --noEmit`), `oxlint --type-aware`, and `oxfmt --check` all pass on the changed files.

> Note: the full `egg` suite shows pre-existing `TEGG_MULTI_PROTO_FOUND` (duplicate-proto) failures in a local non-CI checkout; these reproduce identically on `next` with these changes stashed, so they are unrelated to this PR (see `AGENTS.md` › Local CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin resolution in bundle mode so rewritten plugin artifact paths (where `path` equals the app `baseDir`) are re-resolved to the runtime `node_modules` location.
  * Enhanced framework path discovery in bundle deployments by preferring `<bundle baseDir>/node_modules/egg/dist` when present; otherwise falling back to existing behavior.
* **Tests**
  * Added regression tests for bundle-mode plugin path re-resolution (built-in `name`, `name` + `package`, and cross-app bundle-store non-impact), plus non-bundle behavior coverage.
  * Added a fixture package used by the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->