### PR TITLE
fix(bundler): absolutize tegg manifest paths in bundled runtime

### DIFF
--- a/tegg/plugin/config/src/app.ts
+++ b/tegg/plugin/config/src/app.ts
@@ -40,6 +40,10 @@ export default class App implements ILifecycleBoot {
 
     let moduleReferences: readonly ModuleReference[];
     if (manifestTegg?.moduleReferences?.length) {
+      // Keep manifest reference paths as-is (relative to baseDir) so they match
+      // the manifest `moduleDescriptors[].unitPath` keys used by
+      // `LoaderFactory.loadApp`. Path resolution to an absolute directory is done
+      // in `#loadModuleConfigs` below.
       moduleReferences = manifestTegg.moduleReferences;
       debug('load moduleReferences from manifest: %o', moduleReferences);
     } else {
@@ -68,8 +72,14 @@ export default class App implements ILifecycleBoot {
   #loadModuleConfigs(): void {
     this.app.moduleConfigs = {};
     for (const reference of this.app.moduleReferences) {
+      // Module reference paths from the manifest / ModuleScanner are absolute or
+      // relative to baseDir. `ModuleConfigUtil.resolveModuleDir` resolves a
+      // relative path against `baseDir/config` (the `config/module.json`
+      // convention), which is wrong here, so resolve against baseDir directly. In
+      // bundle mode baseDir is the output dir where the bundler copied each
+      // module's package.json.
       const absoluteRef: ModuleReference = {
-        path: ModuleConfigUtil.resolveModuleDir(reference.path, this.app.baseDir),
+        path: path.isAbsolute(reference.path) ? reference.path : path.resolve(this.app.baseDir, reference.path),
         name: reference.name,
         optional: reference.optional,
       };

--- a/tegg/plugin/config/test/ManifestModuleReference.test.ts
+++ b/tegg/plugin/config/test/ManifestModuleReference.test.ts
@@ -1,0 +1,70 @@
+import path from 'node:path';
+
+import type { Application } from 'egg';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import App from '../src/app.ts';
+import { getFixtures } from './utils.ts';
+
+// `app/module-a` is a real tegg module fixture (package.json -> eggModule.name: moduleA).
+const baseDir = getFixtures('apps/app-with-modules');
+const moduleDir = getFixtures('apps/app-with-modules/app/module-a');
+
+// Build a minimal fake Application that feeds module references straight from a
+// tegg manifest extension, mirroring how a bundled worker entry primes the loader
+// without running the globby module scan.
+function createFakeApp(moduleReferences: { name?: string; path: string; optional?: boolean }[]): Application {
+  return {
+    baseDir,
+    config: { tegg: { readModuleOptions: {} } },
+    loader: {
+      getTypeFiles: () => [],
+      outDir: undefined,
+      manifest: {
+        // Ignore the key: always return the seeded tegg extension.
+        getExtension: () => ({ moduleReferences }),
+      },
+    },
+  } as unknown as Application;
+}
+
+describe('plugin/config/test/ManifestModuleReference.test.ts', () => {
+  afterEach(() => {
+    // App's constructor mutates the shared ModuleConfigUtil config names.
+    // beforeClose() normally restores it, but these tests never call it.
+    return new App(createFakeApp([{ name: 'moduleA', path: moduleDir }])).beforeClose();
+  });
+
+  it('resolves a manifest-relative reference path against baseDir (not baseDir/config)', () => {
+    // A bundled manifest stores the module path relative to baseDir. The previous
+    // `ModuleConfigUtil.resolveModuleDir` would join it under `baseDir/config`,
+    // which does not exist; resolving against baseDir directly is what makes the
+    // bundled `unitPath` <-> moduleReference contract line up.
+    const app = createFakeApp([{ name: 'moduleA', path: 'app/module-a' }]);
+
+    new App(app).configWillLoad();
+
+    expect(app.moduleConfigs).toEqual({
+      moduleA: {
+        config: {},
+        name: 'moduleA',
+        reference: {
+          optional: undefined,
+          name: 'moduleA',
+          path: moduleDir,
+        },
+      },
+    });
+    expect(app.moduleConfigs.moduleA.reference.path).toBe(path.resolve(baseDir, 'app/module-a'));
+  });
+
+  it('keeps an absolute reference path unchanged (non-bundle behavior)', () => {
+    // Non-bundle module references (from ModuleScanner / config/module.json) are
+    // already absolute and must be passed through untouched.
+    const app = createFakeApp([{ name: 'moduleA', path: moduleDir }]);
+
+    new App(app).configWillLoad();
+
+    expect(app.moduleConfigs.moduleA.reference.path).toBe(moduleDir);
+  });
+});

--- a/tools/egg-bundler/src/lib/EntryGenerator.ts
+++ b/tools/egg-bundler/src/lib/EntryGenerator.ts
@@ -315,6 +315,27 @@ for (const [appAbsRequest, targetRel] of __APP_RESOLVE_CACHE_ALIASES) {
   }
 }
 
+// Tegg module reference / descriptor paths are stored relative to baseDir in the
+// manifest. Resolve them to absolute paths under the runtime output dir so every
+// tegg loader consumer (ModuleConfigUtil, EggAppLoader, LoaderFactory.loadApp
+// matching) sees the same absolute-path contract as a non-bundle run. The bundler
+// copies each module's package.json under __outputDir, so these resolve correctly.
+const __teggExt: any = (MANIFEST_DATA as any).extensions?.tegg;
+if (__teggExt) {
+  const __toAbs = (p: unknown) =>
+    typeof p === 'string' ? (path.isAbsolute(p) ? p : path.resolve(__outputDir, p)) : p;
+  if (Array.isArray(__teggExt.moduleReferences)) {
+    for (const __ref of __teggExt.moduleReferences) {
+      if (__ref) __ref.path = __toAbs(__ref.path);
+    }
+  }
+  if (Array.isArray(__teggExt.moduleDescriptors)) {
+    for (const __desc of __teggExt.moduleDescriptors) {
+      if (__desc) __desc.unitPath = __toAbs(__desc.unitPath);
+    }
+  }
+}
+
 const __bundleManifestStore = ManifestStore.fromBundle(MANIFEST_DATA as any, __outputDir);
 const __loaderFS = new ManifestLoaderFS(__bundleManifestStore);
 ManifestStore.setBundleStore(__bundleManifestStore);

--- a/tools/egg-bundler/test/EntryGenerator.test.ts
+++ b/tools/egg-bundler/test/EntryGenerator.test.ts
@@ -184,6 +184,53 @@ describe('EntryGenerator', () => {
     expect(worker).toContain('"path": "app/port"');
   });
 
+  it('emits a runtime block that resolves relative tegg manifest paths to absolute output-dir paths', async () => {
+    // Mirror a bundle artifact whose tegg module paths are stored relative to
+    // baseDir (as normalized by ManifestLoader). The generated worker must
+    // re-absolutize both moduleReferences[].path and moduleDescriptors[].unitPath
+    // against __outputDir so LoaderFactory.loadApp matches them by exact equality
+    // and the precomputed controller/repository decorated files flow into it.
+    const manifest = makeManifest({
+      extensions: {
+        tegg: {
+          moduleReferences: [
+            {
+              name: 'appBiz',
+              path: 'app/biz',
+            },
+          ],
+          moduleDescriptors: [
+            {
+              name: 'appBiz',
+              unitPath: 'app/biz',
+              decoratedFiles: ['controller/HomeController.ts', 'repository/UserRepository.ts'],
+            },
+          ],
+        },
+      },
+    });
+
+    const gen = new EntryGenerator({ baseDir: tmpDir, manifestLoader: createFakeLoader(manifest) });
+    const result = await gen.generate();
+    const worker = await fs.readFile(result.workerEntry, 'utf8');
+
+    // Controller + repository decorated files are collected as imports.
+    expect(extractImports(worker).map((i) => i.specifier)).toEqual([
+      '../../app/biz/controller/HomeController.ts',
+      '../../app/biz/repository/UserRepository.ts',
+    ]);
+
+    // Manifest keeps the matching relative keys so both sides resolve equally.
+    expect(worker).toContain('"path": "app/biz"');
+    expect(worker).toContain('"unitPath": "app/biz"');
+
+    // The absolutization block is emitted with the isAbsolute/resolve contract
+    // that maps both moduleReferences and moduleDescriptors onto __outputDir.
+    expect(worker).toContain('path.isAbsolute(p) ? p : path.resolve(__outputDir, p)');
+    expect(worker).toContain('if (__ref) __ref.path = __toAbs(__ref.path);');
+    expect(worker).toContain('if (__desc) __desc.unitPath = __toAbs(__desc.unitPath);');
+  });
+
   it('skips resolveCache entries whose value is null', async () => {
     const manifest = makeManifest({
       resolveCache: {

--- a/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
+++ b/tools/egg-bundler/test/__snapshots__/EntryGenerator.worker.canonical.snap
@@ -99,6 +99,27 @@ for (const [appAbsRequest, targetRel] of __APP_RESOLVE_CACHE_ALIASES) {
   }
 }
 
+// Tegg module reference / descriptor paths are stored relative to baseDir in the
+// manifest. Resolve them to absolute paths under the runtime output dir so every
+// tegg loader consumer (ModuleConfigUtil, EggAppLoader, LoaderFactory.loadApp
+// matching) sees the same absolute-path contract as a non-bundle run. The bundler
+// copies each module's package.json under __outputDir, so these resolve correctly.
+const __teggExt: any = (MANIFEST_DATA as any).extensions?.tegg;
+if (__teggExt) {
+  const __toAbs = (p: unknown) =>
+    typeof p === 'string' ? (path.isAbsolute(p) ? p : path.resolve(__outputDir, p)) : p;
+  if (Array.isArray(__teggExt.moduleReferences)) {
+    for (const __ref of __teggExt.moduleReferences) {
+      if (__ref) __ref.path = __toAbs(__ref.path);
+    }
+  }
+  if (Array.isArray(__teggExt.moduleDescriptors)) {
+    for (const __desc of __teggExt.moduleDescriptors) {
+      if (__desc) __desc.unitPath = __toAbs(__desc.unitPath);
+    }
+  }
+}
+
 const __bundleManifestStore = ManifestStore.fromBundle(MANIFEST_DATA as any, __outputDir);
 const __loaderFS = new ManifestLoaderFS(__bundleManifestStore);
 ManifestStore.setBundleStore(__bundleManifestStore);


### PR DESCRIPTION
## Motivation

In bundle mode the tegg manifest stores `moduleReferences[].path` and `moduleDescriptors[].unitPath` **relative to baseDir** (normalized by #5932). `LoaderFactory.loadApp` matches a module reference to its descriptor by **exact path equality**, and the descriptor carries the precomputed `decoratedFiles`. For that match to feed the precomputed files into the loader, both sides must agree on the same absolute-path contract that a non-bundle run sees — so the decorated controller/repository files flow through the manifest descriptor into `LoaderFactory.loadApp` without any global-store direct read.

## Scope

Two small, self-contained changes:

1. **`tools/egg-bundler` EntryGenerator** — the generated worker entry now resolves both `extensions.tegg.moduleReferences[].path` and `moduleDescriptors[].unitPath` to absolute paths under the runtime `__outputDir`:
   ```js
   const __toAbs = (p) => (path.isAbsolute(p) ? p : path.resolve(__outputDir, p));
   ```
   The bundler copies each module's `package.json` under `__outputDir`, so these resolve correctly. Canonical worker snapshot updated to match.

2. **`tegg/plugin/config` `App#loadModuleConfigs`** — resolve `reference.path` against `baseDir` directly instead of `ModuleConfigUtil.resolveModuleDir`, which joins relative paths under `baseDir/config` (the `config/module.json` convention) — wrong for manifest-sourced references. Manifest reference paths are kept as-is in `#scanModuleReferences` so they keep matching the descriptor `unitPath` keys.

### Non-bundle behavior is unchanged

Non-bundle module references are always **absolute** (`ModuleScanner` / `config/module.json` are resolved at read time via `path.join(configDir, ...)`), so both the old `resolveModuleDir` and the new code pass them through untouched.

### Out of scope

This deliberately does **not** touch `ModuleLoader.ts` or introduce any global bundle-store direct read; that loader-fs path is handled separately. It also does not overlap with #5932 — that PR normalized the manifest paths to relative form; this PR re-absolutizes them at runtime so every consumer sees the same contract.

## Tests

- `tools/egg-bundler/test/EntryGenerator.test.ts` — relative tegg manifest paths emit the absolutization block and collect controller/repository decorated files.
- `tegg/plugin/config/test/ManifestModuleReference.test.ts` — a manifest-relative reference resolves under `baseDir` (regression: previously `ENOENT` under `baseDir/config`); an absolute reference is passed through unchanged.

Verified locally:
- egg-bundler `EntryGenerator` suite (new + existing tests pass; the 8 pre-existing `/private/var` realpath failures are macOS-local and present on `next`)
- `tegg/plugin/config` (5 tests) and `tegg/core/loader` (16 tests)
- `oxlint --type-aware`, `oxfmt --check`, and `tsgo --noEmit` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module reference path handling during app configuration loading, keeping manifest-relative paths aligned with the configured base directory and preserving absolute paths.
  * Updated bundled worker generation to runtime-absolutize tegg manifest `moduleReferences.path` and `moduleDescriptors.unitPath` under the output directory, without altering already-absolute values.

* **Tests**
  * Added/expanded coverage to verify correct resolution for both relative and absolute manifest module reference paths in configuration loading and bundled worker output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->