### PR TITLE
fix(tegg-loader): align supportExtensions with isSupportTypeScript semantics

### DIFF
--- a/tegg/core/loader/src/LoaderUtil.ts
+++ b/tegg/core/loader/src/LoaderUtil.ts
@@ -28,8 +28,24 @@ export class LoaderUtil {
 
   static supportExtensions(): string[] {
     const extensions = Object.keys((Module as any)._extensions);
-    if (process.env.VITEST === 'true' && !extensions.includes('.ts')) {
-      extensions.push('.ts');
+    // TypeScript loaders such as tsx and Node's native type stripping register
+    // via ESM loader hooks rather than `Module._extensions`, so `_extensions`
+    // may not list `.ts` even when TS files are loadable (e.g. during manifest
+    // generation under tsx). Mirror `@eggjs/utils.isSupportTypeScript()` so the
+    // glob pattern still discovers `.ts`/`.mts`/`.cts` source files in those
+    // environments.
+    const nodeMajorVersion = parseInt(process.versions.node.split('.', 1)[0], 10);
+    const supportTypeScript =
+      process.env.EGG_TS_ENABLE !== 'false' &&
+      (extensions.includes('.ts') ||
+        process.env.VITEST === 'true' ||
+        process.env.EGG_TS_ENABLE === 'true' ||
+        // Node.js >= 22 supports native TypeScript type stripping.
+        nodeMajorVersion >= 22);
+    if (supportTypeScript) {
+      for (const ext of ['.ts', '.mts', '.cts']) {
+        if (!extensions.includes(ext)) extensions.push(ext);
+      }
     }
     // Respect EGG_TS_ENABLE=false to disable TypeScript file loading
     // (e.g., production deployment with compiled .js files)

--- a/tegg/core/loader/test/LoaderUtil.test.ts
+++ b/tegg/core/loader/test/LoaderUtil.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+
+import { afterEach, beforeEach, describe, it } from 'vitest';
+
+import { LoaderUtil } from '../src/index.ts';
+
+const nodeMajorVersion = parseInt(process.versions.node.split('.', 1)[0], 10);
+
+describe('core/loader/test/LoaderUtil.test.ts', () => {
+  let originalVitest: string | undefined;
+  let originalTsEnable: string | undefined;
+
+  beforeEach(() => {
+    originalVitest = process.env.VITEST;
+    originalTsEnable = process.env.EGG_TS_ENABLE;
+  });
+
+  afterEach(() => {
+    restore('VITEST', originalVitest);
+    restore('EGG_TS_ENABLE', originalTsEnable);
+  });
+
+  function restore(key: string, value: string | undefined) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  describe('supportExtensions()', () => {
+    it('should not include TypeScript extensions when EGG_TS_ENABLE=false', () => {
+      process.env.EGG_TS_ENABLE = 'false';
+      const extensions = LoaderUtil.supportExtensions();
+      assert(!extensions.includes('.ts'));
+      assert(!extensions.includes('.mts'));
+      assert(!extensions.includes('.cts'));
+    });
+
+    it.skipIf(nodeMajorVersion < 22)('should include .ts/.mts/.cts by default on Node >= 22', () => {
+      // Clear the explicit enable flags so the result depends on Node version.
+      delete process.env.VITEST;
+      delete process.env.EGG_TS_ENABLE;
+      const extensions = LoaderUtil.supportExtensions();
+      assert(extensions.includes('.ts'));
+      assert(extensions.includes('.mts'));
+      assert(extensions.includes('.cts'));
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

`LoaderUtil.supportExtensions()` previously only appended `.ts` when running under `VITEST`. TypeScript loaders such as **tsx** and **Node's native type stripping** register via ESM loader hooks rather than `Module._extensions`, so `_extensions` may not list `.ts` even when TS files are loadable. During manifest generation under tsx this caused the loader glob pattern to **miss `.ts` source files**.

## Scope

Align `supportExtensions()` with `@eggjs/utils.isSupportTypeScript()` semantics:

- Enable `.ts` / `.mts` / `.cts` when `EGG_TS_ENABLE !== 'false'` **and** any of:
  - `Module._extensions` already lists `.ts`
  - `process.env.VITEST === 'true'`
  - `process.env.EGG_TS_ENABLE === 'true'`
  - Node.js major version `>= 22` (native type stripping)
- Preserve the existing `EGG_TS_ENABLE='false'` opt-out that strips TS extensions (e.g. production deployments running compiled `.js`).

Self-contained, low-risk change limited to `@eggjs/tegg-loader`.

## Test evidence

Added `tegg/core/loader/test/LoaderUtil.test.ts` covering:
- `EGG_TS_ENABLE=false` → result excludes `.ts/.mts/.cts`
- Node `>= 22` default (no VITEST / EGG_TS_ENABLE) → includes `.ts/.mts/.cts`

```
$ npx vitest run tegg/core/loader/
 Test Files  5 passed (5)
      Tests  18 passed (18)
```

`pnpm --filter @eggjs/tegg-loader run typecheck`, `oxlint --type-aware`, and `oxfmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript extension detection so `.ts`, `.mts`, and `.cts` are correctly recognized in newer runtimes and environments that register loaders via ESM.
  * Respects the TypeScript enable/disable setting to exclude TypeScript extensions when disabled.
* **Tests**
  * Added automated coverage for extension detection behavior across TypeScript enabled vs. disabled scenarios (including runtime version gating).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->