### PR TITLE
fix(ci): stabilize mock server emit checks

### DIFF
--- a/packages/egg/src/lib/application.ts
+++ b/packages/egg/src/lib/application.ts
@@ -148,40 +148,28 @@ export class Application extends EggApplicationCore {
   onServer(server: http.Server): void {
     // expose app.server
     this.server = server;
+    // set ignore code
+    const serverGracefulIgnoreCode = this.config.serverGracefulIgnoreCode || [];
 
-    // `graceful` installs a process-wide `uncaughtException` handler that takes
-    // over process shutdown (close servers, then `process.exit`). That is right
-    // for a real production worker, but harmful under unittest: when an app is
-    // booted via `@eggjs/mock` (e.g. egg-bin forks a child process per test),
-    // graceful's shutdown path keeps the forked child from exiting cleanly. On
-    // Windows — which has no real POSIX signals and slower named-pipe/socket
-    // handle teardown — the child then hangs until a kill timeout instead of
-    // exiting promptly, so every egg-bin test times out. Skip graceful in
-    // unittest; the clientError logging / serverTimeout below still apply.
-    if (this.config.env !== 'unittest') {
-      // set ignore code
-      const serverGracefulIgnoreCode = this.config.serverGracefulIgnoreCode || [];
-
-      graceful({
-        server: [server],
-        error: (err: Error, throwErrorCount: number) => {
-          const originMessage = err.message;
-          if (originMessage) {
-            // shouldjs will override error property but only getter
-            // https://github.com/shouldjs/should.js/blob/889e22ebf19a06bc2747d24cf34b25cc00b37464/lib/assertion-error.js#L26
-            Object.defineProperty(err, 'message', {
-              get() {
-                return `${originMessage} (uncaughtException throw ${throwErrorCount} times on pid: ${process.pid})`;
-              },
-              configurable: true,
-              enumerable: false,
-            });
-          }
-          this.coreLogger.error(err);
-        },
-        ignoreCode: serverGracefulIgnoreCode,
-      });
-    }
+    graceful({
+      server: [server],
+      error: (err: Error, throwErrorCount: number) => {
+        const originMessage = err.message;
+        if (originMessage) {
+          // shouldjs will override error property but only getter
+          // https://github.com/shouldjs/should.js/blob/889e22ebf19a06bc2747d24cf34b25cc00b37464/lib/assertion-error.js#L26
+          Object.defineProperty(err, 'message', {
+            get() {
+              return `${originMessage} (uncaughtException throw ${throwErrorCount} times on pid: ${process.pid})`;
+            },
+            configurable: true,
+            enumerable: false,
+          });
+        }
+        this.coreLogger.error(err);
+      },
+      ignoreCode: serverGracefulIgnoreCode,
+    });
 
     server.on('clientError', (err, socket) => this.onClientError(err, socket as Socket));
 

--- a/packages/egg/src/lib/application.ts
+++ b/packages/egg/src/lib/application.ts
@@ -148,28 +148,40 @@ export class Application extends EggApplicationCore {
   onServer(server: http.Server): void {
     // expose app.server
     this.server = server;
-    // set ignore code
-    const serverGracefulIgnoreCode = this.config.serverGracefulIgnoreCode || [];
 
-    graceful({
-      server: [server],
-      error: (err: Error, throwErrorCount: number) => {
-        const originMessage = err.message;
-        if (originMessage) {
-          // shouldjs will override error property but only getter
-          // https://github.com/shouldjs/should.js/blob/889e22ebf19a06bc2747d24cf34b25cc00b37464/lib/assertion-error.js#L26
-          Object.defineProperty(err, 'message', {
-            get() {
-              return `${originMessage} (uncaughtException throw ${throwErrorCount} times on pid: ${process.pid})`;
-            },
-            configurable: true,
-            enumerable: false,
-          });
-        }
-        this.coreLogger.error(err);
-      },
-      ignoreCode: serverGracefulIgnoreCode,
-    });
+    // `graceful` installs a process-wide `uncaughtException` handler that takes
+    // over process shutdown (close servers, then `process.exit`). That is right
+    // for a real production worker, but harmful under unittest: when an app is
+    // booted via `@eggjs/mock` (e.g. egg-bin forks a child process per test),
+    // graceful's shutdown path keeps the forked child from exiting cleanly. On
+    // Windows — which has no real POSIX signals and slower named-pipe/socket
+    // handle teardown — the child then hangs until a kill timeout instead of
+    // exiting promptly, so every egg-bin test times out. Skip graceful in
+    // unittest; the clientError logging / serverTimeout below still apply.
+    if (this.config.env !== 'unittest') {
+      // set ignore code
+      const serverGracefulIgnoreCode = this.config.serverGracefulIgnoreCode || [];
+
+      graceful({
+        server: [server],
+        error: (err: Error, throwErrorCount: number) => {
+          const originMessage = err.message;
+          if (originMessage) {
+            // shouldjs will override error property but only getter
+            // https://github.com/shouldjs/should.js/blob/889e22ebf19a06bc2747d24cf34b25cc00b37464/lib/assertion-error.js#L26
+            Object.defineProperty(err, 'message', {
+              get() {
+                return `${originMessage} (uncaughtException throw ${throwErrorCount} times on pid: ${process.pid})`;
+              },
+              configurable: true,
+              enumerable: false,
+            });
+          }
+          this.coreLogger.error(err);
+        },
+        ignoreCode: serverGracefulIgnoreCode,
+      });
+    }
 
     server.on('clientError', (err, socket) => this.onClientError(err, socket as Socket));
 

--- a/plugins/mock/src/lib/app.ts
+++ b/plugins/mock/src/lib/app.ts
@@ -102,6 +102,13 @@ class MockApplicationWorker extends Base {
     debug('http server instantiate');
     createServer(app);
     await app.ready();
+    // emit `server` after ready: egg core registers its `once('server', ...)`
+    // listener inside `Application.load()` (during `app.ready()` above), and
+    // `onServer` reads loaded config, so the event must be emitted now rather
+    // than at createServer() time. Mirrors @eggjs/cluster's post-ready emit.
+    if (app.server) {
+      app.emit('server', app.server);
+    }
     // work for config ready
     setCustomLoader(app);
 

--- a/plugins/mock/src/lib/app.ts
+++ b/plugins/mock/src/lib/app.ts
@@ -100,15 +100,13 @@ class MockApplicationWorker extends Base {
     debug('this[APP_INIT] = true');
     this.#bindEvent();
     debug('http server instantiate');
-    createServer(app);
+    const server = createServer(app);
     await app.ready();
     // emit `server` after ready: egg core registers its `once('server', ...)`
     // listener inside `Application.load()` (during `app.ready()` above), and
     // `onServer` reads loaded config, so the event must be emitted now rather
     // than at createServer() time. Mirrors @eggjs/cluster's post-ready emit.
-    if (app.server) {
-      app.emit('server', app.server);
-    }
+    app.emit('server', server);
     // work for config ready
     setCustomLoader(app);
 

--- a/plugins/mock/src/lib/mock_http_server.ts
+++ b/plugins/mock/src/lib/mock_http_server.ts
@@ -11,9 +11,12 @@ export function createServer(app: any): Server {
     if (!app.server) {
       app.server = server;
     }
-    // emit server event just like egg-cluster does
-    // https://github.com/eggjs/egg-cluster/blob/master/lib/app_worker.js#L52
-    app.emit('server', server);
   }
+  // NOTE: don't emit the `server` event here. egg core registers its
+  // `once('server', ...)` listener inside `Application.load()` (during
+  // `app.ready()`), so emitting at server-creation time (before ready) would be
+  // missed and `onServer` (clientError logging / graceful / timeout / websocket)
+  // never runs. The caller emits `server` after `app.ready()` instead — just
+  // like @eggjs/cluster, which emits it after the app is ready.
   return server;
 }

--- a/plugins/mock/src/lib/parallel/app.ts
+++ b/plugins/mock/src/lib/parallel/app.ts
@@ -56,6 +56,11 @@ export class MockParallelApplication extends Base {
     debug('http server instantiate');
     createServer(app);
     await app.ready();
+    // emit `server` after ready so egg core's onServer listener (registered in
+    // Application.load()) is wired up; createServer no longer emits it.
+    if (app.server) {
+      app.emit('server', app.server);
+    }
 
     const msg = {
       action: 'egg-ready',

--- a/plugins/mock/src/lib/parallel/app.ts
+++ b/plugins/mock/src/lib/parallel/app.ts
@@ -47,20 +47,18 @@ export class MockParallelApplication extends Base {
 
     // egg-mock plugin need to override egg context
     Object.assign(app.context, context);
-    setCustomLoader(app);
 
     debug('app instantiate');
     this.__APP_INIT__ = true;
     debug('this[APP_INIT] = true');
     this.#bindEvents();
     debug('http server instantiate');
-    createServer(app);
+    const server = createServer(app);
     await app.ready();
     // emit `server` after ready so egg core's onServer listener (registered in
     // Application.load()) is wired up; createServer no longer emits it.
-    if (app.server) {
-      app.emit('server', app.server);
-    }
+    app.emit('server', server);
+    setCustomLoader(app);
 
     const msg = {
       action: 'egg-ready',

--- a/plugins/mock/test/app.test.ts
+++ b/plugins/mock/test/app.test.ts
@@ -79,6 +79,30 @@ describe.sequential('test/app.test.ts', () => {
     await app.close();
   });
 
+  it('should run onServer after ready (server event not lost)', async () => {
+    // @eggjs/mock emits the `server` event before `app.ready()`, while egg core
+    // registers its `once("server", ...)` listener inside Application.load()
+    // (during app.ready()). egg core re-emits `server` after the listener is
+    // registered so onServer still runs and wires up the `clientError` handler
+    // (plus graceful shutdown / server timeout / websocket). Regression guard:
+    // assert the clientError listener is wired after ready.
+    const baseDir = getFixtures('server');
+    const app = mm.app({
+      baseDir,
+      cache: false,
+    });
+    try {
+      await app.ready();
+      assert(app.server, 'app.server not exists');
+      assert(
+        app.server.listenerCount('clientError') > 0,
+        'onServer should have attached a clientError listener after ready',
+      );
+    } finally {
+      await app.close();
+    }
+  });
+
   it('support options.beforeInit', async () => {
     const baseDir = getFixtures('app');
     const app = mm.app({

--- a/plugins/mock/test/app.test.ts
+++ b/plugins/mock/test/app.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it, beforeAll, afterAll, afterEach } from 'vitest';
 
 import mm, { type MockApplication } from '../src/index.ts';
+import { createApp as createParallelApp } from '../src/lib/parallel/app.ts';
 import { getFixtures } from './helper.ts';
 
 describe.sequential('test/app.test.ts', () => {
@@ -98,6 +99,33 @@ describe.sequential('test/app.test.ts', () => {
         app.server.listenerCount('clientError') > 0,
         'onServer should have attached a clientError listener after ready',
       );
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('should emit server after ready in parallel app', async () => {
+    const baseDir = getFixtures('server');
+    let emittedServer: unknown;
+    let emittedAfterReady = false;
+    const app = createParallelApp({
+      baseDir,
+      framework: getFixtures('parallel-framework'),
+      cache: false,
+      clean: false,
+      beforeInit: async (parallelApp) => {
+        parallelApp.options.clusterPort = 1;
+      },
+    });
+    app.once('server', (server: unknown) => {
+      emittedServer = server;
+      emittedAfterReady = app.readyAt === true;
+    });
+    try {
+      await app.ready();
+      assert(app.server, 'app.server not exists');
+      assert.equal(emittedServer, app.server);
+      assert.equal(emittedAfterReady, true);
     } finally {
       await app.close();
     }

--- a/plugins/mock/test/fixtures/parallel-framework/index.js
+++ b/plugins/mock/test/fixtures/parallel-framework/index.js
@@ -1,0 +1,26 @@
+const { EventEmitter } = require('node:events');
+
+class Application extends EventEmitter {
+  constructor(options) {
+    super();
+    this.options = options;
+    this.context = {};
+    this.config = {};
+    this.messenger = {
+      messages: [],
+      onMessage: (msg) => this.messenger.messages.push(msg),
+    };
+  }
+
+  callback() {
+    return (_req, res) => res.end('ok');
+  }
+
+  async ready() {
+    this.readyAt = true;
+  }
+
+  async close() {}
+}
+
+exports.Application = Application;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@eggjs/redis': ^3.0.0
   '@eggjs/scripts': ^4.0.0
   '@fengmk2/ps-tree': ^2.0.1
-  '@oclif/core': ^4.2.0
+  '@oclif/core': 4.11.4
   '@oxc-node/core': ^0.0.35
   '@swc-node/register': ^1.11.1
   '@swc/core': ^1.15.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ catalog:
   '@types/vary': ^1.1.3
   '@typescript/native-preview': 7.0.0-dev.20260117.1
   '@utoo/pack': ^1.2.7
-  '@vitest/coverage-v8': ^4.0.15
+  '@vitest/coverage-v8': 4.1.8
   '@vitest/ui': ^4.0.15
   accepts: ^1.3.8
   address: '2'
@@ -218,7 +218,7 @@ catalog:
   vary: ^1.1.2
   vitepress: 2.0.0-alpha.15
   vitepress-plugin-llms: ^1.10.0
-  vitest: ^4.0.15
+  vitest: 4.1.8
   xss: ^1.0.15
   ylru: ^2.0.0
   zod: ^3.24.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,7 +65,7 @@ catalog:
   '@types/vary': ^1.1.3
   '@typescript/native-preview': 7.0.0-dev.20260117.1
   '@utoo/pack': ^1.2.7
-  '@vitest/coverage-v8': 4.1.8
+  '@vitest/coverage-v8': ^4.0.15
   '@vitest/ui': ^4.0.15
   accepts: ^1.3.8
   address: '2'
@@ -218,7 +218,7 @@ catalog:
   vary: ^1.1.2
   vitepress: 2.0.0-alpha.15
   vitepress-plugin-llms: ^1.10.0
-  vitest: 4.1.8
+  vitest: ^4.0.15
   xss: ^1.0.15
   ylru: ^2.0.0
   zod: ^3.24.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@eggjs/redis': ^3.0.0
   '@eggjs/scripts': ^4.0.0
   '@fengmk2/ps-tree': ^2.0.1
-  '@oclif/core': 4.11.4
+  '@oclif/core': ^4.2.0
   '@oxc-node/core': ^0.0.35
   '@swc-node/register': ^1.11.1
   '@swc/core': ^1.15.1


### PR DESCRIPTION
## Summary

- keep the original mock server-event fix, but emit the exact server returned by `createServer()` after `app.ready()` so there is no defensive uncovered branch
- align the parallel mock app path with the single app path by running `setCustomLoader(app)` after config is available
- pin `@oclif/core` to `4.11.4`, matching the latest green `next` Windows bin run and avoiding the `4.11.7` fork timeout regression
- add a narrow parallel wrapper regression fixture/test so Codecov patch covers the post-ready `server` emit path

## CI investigation

- Original failing PR run: `Test bin (windows-latest, 24)` timed out while forked `egg-bin` CLI child processes waited to exit, including `--help`/`--version` cases that do not boot an Egg app.
- Failing run resolved `@oclif/core@4.11.7`; latest green `next` run used `@oclif/core@4.11.4`.
- A prior PR attempt with floating Vitest but `@oclif/core@4.11.4` had the Windows bin job green, while pinning Vitest alone did not fix the hang.
- The broad `packages/egg/src/lib/application.ts` unittest/graceful workaround is removed from the final diff; it was not on the `egg-bin --help`/`--version` path and caused Codecov patch risk.

## Local verification

- `utx utoo@1.0.32 install --from pnpm` -> `8 workspaces, 1 overrides, 214 catalogs`
- dependency resolution confirmed locally: `@oclif/core@4.11.4`, `rolldown-vite@7.3.1`, `vitest@4.1.9`, `@vitest/coverage-v8@4.1.9`
- `utx utoo@1.0.32 run build -- --workspace ./tools/egg-bin`
- `utx utoo@1.0.32 run ci --workspace @eggjs/bin`
- `utx utoo@1.0.32 run test -- plugins/mock/test/app.test.ts`
- `utx utoo@1.0.32 run typecheck --workspace @eggjs/mock`

## Remote verification

Draft PR #5976 is green on commit `1c6db712e3fec02ed27fd2e3d15dabfe3a19d499`.

- CI run `27836491515`: passed, including `Test bin (windows-latest, 24)` in 3m23s and all normal test matrix jobs
- E2E run `27836491493`: passed (`examples` and `cnpmcore`)
- CodeQL: passed
- Codecov: `codecov/patch` passed and `codecov/project` passed
- External checks: Cloudflare Pages, License Compliance, Socket Project Report, Snyk passed; Socket PR Alerts is neutral
