### PR TITLE
fix: stabilize Windows-flaky tests (lifecycle teardown race + egg-bin timeouts)

### DIFF
--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -105,6 +105,7 @@ export class Lifecycle extends EventEmitter {
   #bootHooks: (BootImplClass | ILifecycleBoot)[];
   #boots: ILifecycleBoot[];
   #isClosed: boolean;
+  #isClosing: boolean;
   #metadataOnly: boolean;
   #snapshotBuilding: boolean;
   #closeFunctionSet: Set<FunWithFullPath>;
@@ -122,6 +123,7 @@ export class Lifecycle extends EventEmitter {
     this.#boots = [];
     this.#closeFunctionSet = new Set();
     this.#isClosed = false;
+    this.#isClosing = false;
     this.#metadataOnly = false;
     this.#snapshotBuilding = false;
     this.#init = false;
@@ -174,6 +176,16 @@ export class Lifecycle extends EventEmitter {
    */
   get isClosed(): boolean {
     return this.#isClosed;
+  }
+
+  /**
+   * Whether `close()` is currently running (started but not yet finished). A
+   * close hook registered during this window would be added after the close
+   * callback snapshot is taken and would never run, so `registerBeforeClose()`
+   * also refuses registration while closing.
+   */
+  get isClosing(): boolean {
+    return this.#isClosing;
   }
 
   get logger(): EggConsoleLogger {
@@ -251,27 +263,39 @@ export class Lifecycle extends EventEmitter {
     });
   }
 
-  registerBeforeClose(fn: FunWithFullPath, fullPath?: string): void {
+  /**
+   * Register a function to run during `close()`. Returns `false` when the
+   * registration is refused because the app/agent is already closing or closed
+   * (the hook would never run); `true` otherwise.
+   */
+  registerBeforeClose(fn: FunWithFullPath, fullPath?: string): boolean {
     assert(typeof fn === 'function', 'argument should be function');
-    // A close hook may be registered after the app/agent was already closed when
-    // teardown races an in-flight load — common under vitest `isolate: false` on
-    // slow/Windows CI, where lazy logger creation (`coreLogger` access during
-    // `dumpTiming` or the unhandledRejection handler) reaches here post-close.
-    // Throwing "app has been closed" turned a benign late call into an unhandled
-    // rejection that failed an unrelated test. The close already ran, so a new
-    // hook would never fire — skip it instead of crashing.
-    if (this.#isClosed) {
-      debug('%s skip registerBeforeClose at %o, app has been closed', this.app.type, fullPath);
-      return;
+    // A close hook may be registered after the app/agent has started closing
+    // when teardown races an in-flight load — common under vitest `isolate:
+    // false` on slow/Windows CI, where lazy logger creation (`coreLogger` access
+    // during `dumpTiming` or the unhandledRejection handler) reaches here while
+    // close is running or already done. Throwing "app has been closed" turned a
+    // benign late call into an unhandled rejection that failed an unrelated test.
+    // Once closing has begun the close-callback snapshot is fixed, so a new hook
+    // would never fire — refuse it (returning false) instead of crashing, and
+    // let the caller clean up its own resources.
+    if (this.#isClosing || this.#isClosed) {
+      debug('%s skip registerBeforeClose at %o, app is closing or has been closed', this.app.type, fullPath);
+      return false;
     }
     if (fullPath) {
       fn.fullPath = fullPath;
     }
     this.#closeFunctionSet.add(fn);
     debug('%s register beforeClose at %o, count: %d', this.app.type, fullPath, this.#closeFunctionSet.size);
+    return true;
   }
 
   async close(): Promise<void> {
+    // Mark closing before the close-callback snapshot is taken, so any hook
+    // registered while close() is in flight (e.g. an in-flight load racing
+    // teardown) is refused by registerBeforeClose() instead of being stranded.
+    this.#isClosing = true;
     if (this.#metadataOnly || this.#snapshotBuilding) {
       debug('%s skip beforeClose functions in early-exit lifecycle mode', this.app.type);
       this.#closeFunctionSet.clear();

--- a/packages/core/src/lifecycle.ts
+++ b/packages/core/src/lifecycle.ts
@@ -168,6 +168,14 @@ export class Lifecycle extends EventEmitter {
     return this.options.app;
   }
 
+  /**
+   * Whether `close()` has finished. Useful to guard lazy work (logger creation,
+   * close-hook registration) that may run after the app/agent was torn down.
+   */
+  get isClosed(): boolean {
+    return this.#isClosed;
+  }
+
   get logger(): EggConsoleLogger {
     return this.options.logger;
   }
@@ -245,7 +253,17 @@ export class Lifecycle extends EventEmitter {
 
   registerBeforeClose(fn: FunWithFullPath, fullPath?: string): void {
     assert(typeof fn === 'function', 'argument should be function');
-    assert(this.#isClosed === false, 'app has been closed');
+    // A close hook may be registered after the app/agent was already closed when
+    // teardown races an in-flight load — common under vitest `isolate: false` on
+    // slow/Windows CI, where lazy logger creation (`coreLogger` access during
+    // `dumpTiming` or the unhandledRejection handler) reaches here post-close.
+    // Throwing "app has been closed" turned a benign late call into an unhandled
+    // rejection that failed an unrelated test. The close already ran, so a new
+    // hook would never fire — skip it instead of crashing.
+    if (this.#isClosed) {
+      debug('%s skip registerBeforeClose at %o, app has been closed', this.app.type, fullPath);
+      return;
+    }
     if (fullPath) {
       fn.fullPath = fullPath;
     }

--- a/packages/core/test/lifecycle.test.ts
+++ b/packages/core/test/lifecycle.test.ts
@@ -34,7 +34,7 @@ describe('test/lifecycle.test.ts', () => {
     }, /do not add hook when lifecycle has been initialized/);
   });
 
-  it('should not throw when registerBeforeClose is called after close', async () => {
+  it('should refuse (not throw) registerBeforeClose after close', async () => {
     const lifecycle = new Lifecycle({
       baseDir: '.',
       app: new EggCore(),
@@ -45,14 +45,43 @@ describe('test/lifecycle.test.ts', () => {
 
     // A teardown race may register a close hook after close() has finished
     // (e.g. lazy logger creation under vitest isolate:false on Windows CI).
-    // It must be a no-op instead of throwing "app has been closed".
+    // It must be a no-op that returns false instead of throwing "app has been
+    // closed".
     let called = false;
+    let registered: boolean | undefined;
     assert.doesNotThrow(() => {
-      lifecycle.registerBeforeClose(() => {
+      registered = lifecycle.registerBeforeClose(() => {
         called = true;
       });
     });
-    // the hook is skipped, never invoked, since close already ran
+    // the hook is refused and never invoked, since close already ran
+    assert.equal(registered, false);
     assert.equal(called, false);
+  });
+
+  it('should refuse registerBeforeClose while close is in progress', async () => {
+    const lifecycle = new Lifecycle({
+      baseDir: '.',
+      app: new EggCore(),
+    });
+
+    // a slow close hook that tries to register another hook mid-close, mimicking
+    // an in-flight load reaching registerBeforeClose after the close-callback
+    // snapshot is taken but before close() finishes.
+    let stranded = false;
+    let registeredWhileClosing: boolean | undefined;
+    lifecycle.registerBeforeClose(async () => {
+      assert.equal(lifecycle.isClosing, true);
+      registeredWhileClosing = lifecycle.registerBeforeClose(() => {
+        stranded = true;
+      });
+    });
+
+    await lifecycle.close();
+
+    // the late hook must be refused so it is not silently stranded
+    assert.equal(registeredWhileClosing, false);
+    assert.equal(stranded, false);
+    assert.equal(lifecycle.isClosed, true);
   });
 });

--- a/packages/core/test/lifecycle.test.ts
+++ b/packages/core/test/lifecycle.test.ts
@@ -33,4 +33,26 @@ describe('test/lifecycle.test.ts', () => {
       });
     }, /do not add hook when lifecycle has been initialized/);
   });
+
+  it('should not throw when registerBeforeClose is called after close', async () => {
+    const lifecycle = new Lifecycle({
+      baseDir: '.',
+      app: new EggCore(),
+    });
+
+    await lifecycle.close();
+    assert.equal(lifecycle.isClosed, true);
+
+    // A teardown race may register a close hook after close() has finished
+    // (e.g. lazy logger creation under vitest isolate:false on Windows CI).
+    // It must be a no-op instead of throwing "app has been closed".
+    let called = false;
+    assert.doesNotThrow(() => {
+      lifecycle.registerBeforeClose(() => {
+        called = true;
+      });
+    });
+    // the hook is skipped, never invoked, since close already ran
+    assert.equal(called, false);
+  });
 });

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -243,18 +243,8 @@ export class EggApplicationCore extends EggCore {
     this._unhandledRejectionHandler = this._unhandledRejectionHandler.bind(this);
     process.on('unhandledRejection', this._unhandledRejectionHandler);
 
-    // Teardown may race ahead of this in-flight load (common on slow/Windows CI
-    // under vitest `isolate: false`). If `close()` already finished, the close
-    // hook below would never run: undo the process listener we just added so it
-    // does not leak across files, and stop — there is nothing left to load for a
-    // closed app.
-    if (this.lifecycle.isClosed) {
-      process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
-      return;
-    }
-
     // register close function
-    this.lifecycle.registerBeforeClose(async () => {
+    const registered = this.lifecycle.registerBeforeClose(async () => {
       // close all cluster clients
       for (const clusterClient of this.#clusterClients) {
         await closeClusterClient(clusterClient);
@@ -273,6 +263,24 @@ export class EggApplicationCore extends EggCore {
       this.messenger.close();
       process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
     });
+
+    // Teardown may race ahead of this in-flight load (common on slow/Windows CI
+    // under vitest `isolate: false`). When close() is already running/finished,
+    // registerBeforeClose() refuses the hook above (returns false) — it would
+    // never fire. Clean up the resources this load already created so their
+    // process-level listeners (unhandledRejection, messenger IPC) and file
+    // descriptors (loggers) do not leak across files, then stop: there is
+    // nothing left to load for a torn-down app.
+    if (!registered) {
+      process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
+      this.messenger.close();
+      if (this.#loggers) {
+        for (const logger of this.#loggers.values()) {
+          logger.close();
+        }
+      }
+      return;
+    }
 
     await this.loader.load();
   }

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -243,6 +243,16 @@ export class EggApplicationCore extends EggCore {
     this._unhandledRejectionHandler = this._unhandledRejectionHandler.bind(this);
     process.on('unhandledRejection', this._unhandledRejectionHandler);
 
+    // Teardown may race ahead of this in-flight load (common on slow/Windows CI
+    // under vitest `isolate: false`). If `close()` already finished, the close
+    // hook below would never run: undo the process listener we just added so it
+    // does not leak across files, and stop — there is nothing left to load for a
+    // closed app.
+    if (this.lifecycle.isClosed) {
+      process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
+      return;
+    }
+
     // register close function
     this.lifecycle.registerBeforeClose(async () => {
       // close all cluster clients

--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -130,6 +130,7 @@ export class EggApplicationCore extends EggCore {
 
   #httpClient?: HttpClient;
   #loggers?: EggLoggers;
+  #startTimeoutTimer?: ReturnType<typeof setTimeout>;
   #clusterClients: any[] = [];
   #loadFinishedResolve!: () => void;
   #loadFinishedReject!: (err: unknown) => void;
@@ -272,6 +273,7 @@ export class EggApplicationCore extends EggCore {
     // descriptors (loggers) do not leak across files, then stop: there is
     // nothing left to load for a torn-down app.
     if (!registered) {
+      this.#clearStartTimeoutTimer();
       process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
       this.messenger.close();
       if (this.#loggers) {
@@ -658,8 +660,15 @@ export class EggApplicationCore extends EggCore {
     return [path.dirname(import.meta.dirname), ...super.customEggPaths()];
   }
 
+  #clearStartTimeoutTimer(): void {
+    if (this.#startTimeoutTimer) {
+      clearTimeout(this.#startTimeoutTimer);
+      this.#startTimeoutTimer = undefined;
+    }
+  }
+
   #setupTimeoutTimer(): void {
-    const startTimeoutTimer = setTimeout(() => {
+    this.#startTimeoutTimer = setTimeout(() => {
       this.coreLogger.error(this.timing.toString());
       this.coreLogger.error(`${this.type} still doesn't ready after ${this.config.workerStartTimeout} ms.`);
       // log unfinished
@@ -677,7 +686,7 @@ export class EggApplicationCore extends EggCore {
       this.dumpConfig();
       this.dumpTiming();
     }, this.config.workerStartTimeout);
-    this.ready(() => clearTimeout(startTimeoutTimer));
+    this.ready(() => this.#clearStartTimeoutTimer());
   }
 
   get config() {

--- a/tools/egg-bin/test/my-egg-bin.test.ts
+++ b/tools/egg-bin/test/my-egg-bin.test.ts
@@ -19,21 +19,29 @@ describe('test/my-egg-bin.test.ts', () => {
       .end();
   });
 
-  it('should my-egg-bin nsp success', async () => {
+  // Each forked `egg-bin` spawn pays a slow ts-node/esm startup (~50s on
+  // Windows CI). Keep these as one fork per case so no single test sums multiple
+  // sequential spawns and blows the timeout — splitting was the fix for the
+  // flaky `Test bin (windows-latest)` job.
+  it('should my-egg-bin nsp -h success', async () => {
     await coffee
       .fork(eggBin, ['nsp', '-h'], { cwd })
       // .debug()
       .expect('stdout', /nsp check/)
       .expect('code', 0)
       .end();
+  });
 
+  it('should my-egg-bin nsp success', async () => {
     await coffee
       .fork(eggBin, ['nsp'], { cwd })
       // .debug()
       .expect('stdout', /run nsp check at baseDir: .+test-files-my-egg-bin, with/)
       .expect('code', 0)
       .end();
+  });
 
+  it('should my-egg-bin nsp with extra args success', async () => {
     await coffee
       .fork(eggBin, ['nsp', '--foo'], { cwd })
       // .debug()
@@ -53,7 +61,9 @@ describe('test/my-egg-bin.test.ts', () => {
       .expect('stdout', /nsp {3}nsp check/)
       .expect('code', 0)
       .end();
+  });
 
+  it('should show dev help', async () => {
     await coffee
       .fork(eggBin, ['dev', '-h'], { cwd })
       // .debug()

--- a/tools/egg-bin/vitest.config.ts
+++ b/tools/egg-bin/vitest.config.ts
@@ -5,12 +5,20 @@ import type { ViteUserConfig } from 'vitest/config';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// These tests spawn child `egg-bin` processes (vitest-in-vitest), which are slow
+// on Windows CI. Run fewer test files at once to cut child-process contention
+// and give each case more headroom, mirroring the root config's Windows
+// handling — otherwise cases routinely exceed the 60s timeout and flake.
+const isWindowsCI = process.env.CI && process.platform === 'win32';
+
 const config: ViteUserConfig = {
   root: __dirname,
   test: {
     include: ['test/**/*.test.ts'],
     exclude: ['**/test/fixtures/**', '**/node_modules/**', '**/dist/**'],
-    testTimeout: 60000,
+    testTimeout: isWindowsCI ? 120000 : 60000,
+    hookTimeout: isWindowsCI ? 120000 : 60000,
+    ...(isWindowsCI ? { maxWorkers: 2 } : {}),
     globals: true,
   },
 };

--- a/wiki/concepts/vitest-isolate-false-state-leaks.md
+++ b/wiki/concepts/vitest-isolate-false-state-leaks.md
@@ -9,7 +9,9 @@ source_files:
   - plugins/mock/src/app/extend/application.ts
   - plugins/mock/src/lib/mock_agent.ts
   - plugins/multipart/test/file-mode.test.ts
-updated_at: 2026-06-08
+  - packages/core/src/lifecycle.ts
+  - packages/egg/src/lib/egg.ts
+updated_at: 2026-06-20
 status: active
 ---
 
@@ -71,6 +73,29 @@ signature of this class of bug, not flaky tests per se.
    (`__globalDispatcher`, `__mockAgent`) and `__globalDispatcher` is captured
    once and never cleared. Mitigated in practice by the global
    `afterEach(mock.restore)` in `setup_vitest.ts`; noted as a latent risk.
+
+4. **Teardown / in-flight-load race surfacing as a cross-file unhandled
+   rejection** (the Windows-flaky `@eggjs/session` failure). `mm.app()` loads an
+   app **and** an agent; `load()` runs as a `registerBeforeStart` hook on
+   `process.nextTick`, so it can still be in flight when `close()` runs (slow
+   Windows fs widens the window). `Lifecycle.close()` does **not** wait for the
+   in-flight load, so it flips `#isClosed = true` while `load()` is mid-flight.
+   The still-loading code then calls `Lifecycle.registerBeforeClose()` —
+   directly (`egg.ts` `load()`) or lazily via `coreLogger` →
+   `createLoggers()` reached from `dumpTiming` or `_unhandledRejectionHandler` —
+   which `assert(#isClosed === false)` turned into a thrown "app has been
+   closed". That throw became a **process-level unhandled rejection**, which
+   under `isolate:false` is attributed to whatever test is currently running
+   (here `plugins/session/.../session.test.ts:18`), failing an unrelated file.
+   The error message "Can't find viewEngine" / "app has been closed" naming a
+   foreign app/plugin is the tell that the rejection leaked from another file.
+   **Fix:** `registerBeforeClose()` now **skips (no-op + debug log) when already
+   closed** instead of throwing — a hook registered after close would never fire
+   anyway, so the assert was a flaky liability, not a useful invariant. `load()`
+   additionally short-circuits when `lifecycle.isClosed` is already true: it
+   removes the `unhandledRejection` listener it just added (so it does not leak
+   across files) and returns without loading a torn-down app. A new
+   `Lifecycle.isClosed` getter exposes the state for these guards.
 
 ## Not isolate bugs (do not chase as such)
 

--- a/wiki/concepts/vitest-isolate-false-state-leaks.md
+++ b/wiki/concepts/vitest-isolate-false-state-leaks.md
@@ -89,13 +89,17 @@ signature of this class of bug, not flaky tests per se.
    (here `plugins/session/.../session.test.ts:18`), failing an unrelated file.
    The error message "Can't find viewEngine" / "app has been closed" naming a
    foreign app/plugin is the tell that the rejection leaked from another file.
-   **Fix:** `registerBeforeClose()` now **skips (no-op + debug log) when already
-   closed** instead of throwing — a hook registered after close would never fire
-   anyway, so the assert was a flaky liability, not a useful invariant. `load()`
-   additionally short-circuits when `lifecycle.isClosed` is already true: it
-   removes the `unhandledRejection` listener it just added (so it does not leak
-   across files) and returns without loading a torn-down app. A new
-   `Lifecycle.isClosed` getter exposes the state for these guards.
+   **Fix:** `registerBeforeClose()` now **refuses (returns `false`, no throw)
+   when the app is closing or closed** instead of asserting — a hook registered
+   then would never fire anyway, so the assert was a flaky liability, not a
+   useful invariant. The guard covers close _in progress_ too (a `#isClosing`
+   flag set at the top of `close()`, before the close-callback snapshot is
+   taken), so a hook registered mid-close is not silently stranded. `load()`
+   checks the return value: when registration is refused it cleans up the
+   resources it already created — the `unhandledRejection` listener, the
+   messenger (IPC listeners) and any lazily-created loggers (file descriptors) —
+   so they do not leak across files, then returns without loading a torn-down
+   app. New `Lifecycle.isClosed` / `isClosing` getters expose the state.
 
 ## Not isolate bugs (do not chase as such)
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -7,7 +7,7 @@ Read this file before exploring raw sources.
 ## Concepts
 
 - [Repository Map](./concepts/repository-map.md) - High-level map of the main repository areas and where to look first.
-- [Vitest isolate:false state leaks](./concepts/vitest-isolate-false-state-leaks.md) - Why pool:threads + isolate:false exposes cross-file/cross-project state leaks, the concrete leaks (import.ts snapshot loader, mock mockContext), and how to triage them.
+- [Vitest isolate:false state leaks](./concepts/vitest-isolate-false-state-leaks.md) - Why pool:threads + isolate:false exposes cross-file/cross-project state leaks, the concrete leaks (import.ts snapshot loader, mock mockContext, teardown close/load race), and how to triage them.
 
 ## Workflows
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-06-20] concept | fix Windows-flaky session test (teardown close/load race)
+
+- sources touched: `packages/core/src/lifecycle.ts`, `packages/egg/src/lib/egg.ts`, `packages/core/test/lifecycle.test.ts`
+- pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/concepts/vitest-isolate-false-state-leaks.md`
+- note: Windows CI flakily failed `@eggjs/session` `session.test.ts` with "app has been closed" / "Can't find viewEngine". Root cause: a still-loading `mm.app()` app/agent (load runs on `process.nextTick` as a `registerBeforeStart` hook) calls `Lifecycle.registerBeforeClose()` after `close()` already set `#isClosed`, directly in `egg.ts` `load()` or lazily via `coreLogger`→`createLoggers()` from `dumpTiming` / `_unhandledRejectionHandler`. The `assert(#isClosed === false)` threw, becoming a process unhandled rejection that `isolate:false` attributes to whatever file is running. Fix: `registerBeforeClose()` now skips (no-op + debug) when already closed instead of throwing; `load()` short-circuits when `lifecycle.isClosed` (removes the just-added unhandledRejection listener, returns); added `Lifecycle.isClosed` getter + regression test. Continuation of the isolate:false work (root cause #4 on the concept page).
+
 ## [2026-06-08] concept | vitest isolate:false state leaks diagnosed and fixed
 
 - sources touched: `packages/utils/src/import.ts`, `packages/utils/test/snapshot-import.test.ts`, `plugins/mock/src/app/extend/application.ts`


### PR DESCRIPTION
Fixes two independent sources of Windows CI test flakiness on `next`.

## 1. `fix(core)`: teardown close/load race (the `@eggjs/session` flake)

### Symptom
Windows CI flakily failed `@eggjs/session` `test/app/middleware/session.test.ts` with `app has been closed` / `Can't find viewEngine` unhandled rejections (e.g. CI run [27204947537](https://github.com/eggjs/egg/actions/runs/27204947537)). The failing assertion points at an unrelated file — the signature of a process-level unhandled rejection leaking across files under vitest `isolate: false` (continuation of #5964).

### Root cause
`mm.app()` loads an **app and an agent**, and `load()` runs as a `registerBeforeStart` hook on `process.nextTick`, so it can still be in flight when `close()` runs (slow Windows fs widens the race). `Lifecycle.close()` does not wait for the in-flight load, so it flips `#isClosed` while `load()` is still running. The still-loading code then reaches `Lifecycle.registerBeforeClose()` — directly in `egg.ts` `load()`, or lazily via `coreLogger` → `createLoggers()` from `dumpTiming` / `_unhandledRejectionHandler` — which `assert`-threw `app has been closed`. Inside an async load / rejection handler that becomes a process-level unhandled rejection, which `isolate: false` attributes to whatever test file is currently running.

### Fix
- `Lifecycle.registerBeforeClose()` now **refuses (returns `false`, no throw) when the app is closing or closed** instead of asserting. The guard covers close *in progress* too (new `#isClosing` flag set at the top of `close()`, before the close-callback snapshot is taken), so a hook registered mid-close is not silently stranded.
- `EggApplicationCore.load()` checks that return value: when registration is refused by a teardown race, it cleans up the resources it already created — the `unhandledRejection` listener, the messenger (IPC listeners) and any lazily-created loggers (file descriptors) — so none leak across files, then returns without loading a torn-down app.
- New `Lifecycle.isClosed` / `isClosing` getters + regression tests (after-close and during-close).

## 2. `test(egg-bin)`: Windows CI timeouts

`Test bin (windows-latest, 24)` flakily timed out (every failure was `Test timed out in 60000ms`, no assertion failures). The egg-bin command tests spawn child `egg-bin` processes (vitest-in-vitest) that run 50s+ each on Windows; under full parallelism + coverage they tip over the 60s timeout. This reproduces on plain `next` (run [27863137812](https://github.com/eggjs/egg/actions/runs/27863137812)), independent of fix #1.

Mirror the root config's Windows handling in `tools/egg-bin/vitest.config.ts`: on Windows CI, raise `testTimeout`/`hookTimeout` to 120s and cap `maxWorkers` to 2 so fewer child-process trees compete. No effect off Windows.

## Test evidence
- `packages/core` full suite (incl. new lifecycle regression tests) — 476 pass; typecheck + lint + format clean.
- `plugins/session/.../session.test.ts` — pass.
- `tools/egg-bin/test/commands/dev.test.ts` — pass locally (≈43s for one file, confirming the subprocess slowness).
- **CI after fix #1: the main Test matrix incl. `Test (windows-latest, 22/24)` passed** — only the pre-existing egg-bin Windows timeout remained, which fix #2 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle state visibility via `isClosed` and `isClosing`; `registerBeforeClose` now returns success/failure.
* **Bug Fixes**
  * Prevent late close-hook registration during in-flight/finished shutdown, avoiding stranded hooks.
  * Improved load/close race safety by short-circuiting teardown when close-hook registration can’t be accepted.
* **Tests**
  * Added coverage for close-in-flight and post-close hook registration races.
* **Documentation**
  * Updated guidance for `vitest` `isolate:false` state leak scenarios.
* **Chores**
  * Tuned Vitest timeouts/worker limits for Windows CI and split a slow CLI test to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->