### PR TITLE
fix(bundler): erase ORM-shadowing class fields via project-dir tsconfig

### DIFF
--- a/tools/egg-bundler/src/lib/Bundler.ts
+++ b/tools/egg-bundler/src/lib/Bundler.ts
@@ -365,8 +365,16 @@ export class Bundler {
       entries: [{ name: 'worker', filepath: entries.workerEntry }],
       outputDir: absOutputDir,
       externals: externalsMap,
-      projectPath: absBaseDir,
-      rootPath: mergedPack?.rootPath,
+      // Use the generated entry dir as the project root so PackRunner's
+      // compiler tsconfig (useDefineForClassFields:false, decorator metadata)
+      // is the one @utoo/pack resolves — Turbopack reads tsconfig from the
+      // project dir, not the output dir or the app's own tsconfig. rootPath
+      // stays at the app baseDir (or a caller-supplied monorepo root) so the
+      // app sources and node_modules above the entry dir still resolve.
+      projectPath: entries.entryDir,
+      // Resolve a caller-supplied rootPath against absBaseDir so a relative value
+      // does not depend on cwd; default to the app baseDir.
+      rootPath: mergedPack?.rootPath ? path.resolve(absBaseDir, mergedPack.rootPath) : absBaseDir,
       mode,
       buildFunc: mergedPack?.buildFunc,
       resolve: mergedPack?.resolve,

--- a/tools/egg-bundler/src/lib/PackRunner.ts
+++ b/tools/egg-bundler/src/lib/PackRunner.ts
@@ -30,19 +30,46 @@ export interface PackRunnerResult {
   readonly files: readonly string[];
 }
 
-// SWC decorator compilation picks up tsconfig from the OUTPUT dir, not the
-// project. Without this, tegg decorator metadata silently drops. (T0 blocker.)
-const OUTPUT_TSCONFIG = {
+// @utoo/pack (Turbopack) resolves the tsconfig that governs compilation from the
+// PROJECT directory (the `projectPath` passed to `build()`), NOT the output dir and
+// NOT via per-file find-up to the nearest tsconfig. Verified against @utoo/pack
+// 1.4.13/1.4.14: a tsconfig in the output dir is ignored, and a tsconfig nearer the
+// source than projectPath is ignored — only `projectPath/tsconfig.json` wins.
+//
+// So PackRunner writes this tsconfig into `projectPath`. The Bundler points
+// `projectPath` at the generated entry dir (a build-managed `.egg-bundle/entries`
+// directory) with `rootPath` at the app baseDir, so this config governs the whole
+// build without touching the application's own tsconfig.
+//
+// `experimentalDecorators` / `emitDecoratorMetadata`: required so tegg decorator
+// metadata is emitted (design:type).
+//
+// `useDefineForClassFields: false` matches how Egg apps compile (target <= ES2021):
+// declared-but-uninitialized TypeScript class fields (e.g. `createdAt: Date;` on a
+// leoric `Bone` model) must NOT become native own class fields. At `target: es2022`
+// TS/SWC default this to `true`, emitting own `undefined` properties that shadow the
+// getter/setter accessors ORMs like leoric install on the prototype for decorated
+// attributes — silently breaking attribute writes (observed as omitted columns such
+// as `gmt_create` on INSERT). With this tsconfig in the resolved location the bare
+// field declarations are erased, so no output post-processing is needed.
+const COMPILER_TSCONFIG = {
   compilerOptions: {
     experimentalDecorators: true,
     emitDecoratorMetadata: true,
     target: 'es2022',
+    useDefineForClassFields: false,
   },
 };
 
 // @utoo/pack emits CJS files; a nested `type: commonjs` package.json
 // prevents the parent ESM package from forcing these into ESM parse mode.
 const OUTPUT_PACKAGE_JSON = { type: 'commonjs' };
+
+// A directory egg-bundler owns and may freely write the compiler tsconfig into
+// (the generated entry dir lives under `.egg-bundle`).
+function isBuildManaged(dir: string): boolean {
+  return dir.split(path.sep).includes('.egg-bundle');
+}
 
 const require = createRequire(import.meta.url);
 
@@ -75,8 +102,28 @@ export class PackRunner {
     } = this.#options;
 
     await fs.mkdir(outputDir, { recursive: true });
-    await fs.writeFile(path.join(outputDir, 'tsconfig.json'), JSON.stringify(OUTPUT_TSCONFIG, null, 2));
     await fs.writeFile(path.join(outputDir, 'package.json'), JSON.stringify(OUTPUT_PACKAGE_JSON, null, 2));
+
+    // Write the compiler tsconfig into the PROJECT dir, where @utoo/pack resolves
+    // it (see COMPILER_TSCONFIG). projectPath must be a build-managed directory
+    // (the Bundler passes the generated `.egg-bundle/entries` dir). Guard against
+    // an API misuse that points projectPath at a real project: never silently
+    // overwrite a tsconfig.json egg-bundler did not create.
+    const projectTsconfigPath = path.join(projectPath, 'tsconfig.json');
+    const desiredTsconfig = JSON.stringify(COMPILER_TSCONFIG, null, 2);
+    if (!isBuildManaged(projectPath)) {
+      const existing = await fs.readFile(projectTsconfigPath, 'utf8').catch(() => undefined);
+      // Overwrite only what we produced ourselves (idempotent re-runs); never
+      // clobber a different, user-authored tsconfig.
+      if (existing !== undefined && existing !== desiredTsconfig) {
+        throw new Error(
+          `PackRunner: refusing to overwrite an existing tsconfig.json at ${projectPath}. ` +
+            'projectPath must be a build-managed directory (e.g. the generated .egg-bundle/entries dir).',
+        );
+      }
+    }
+    await fs.mkdir(projectPath, { recursive: true });
+    await fs.writeFile(projectTsconfigPath, desiredTsconfig);
 
     // UMD-form externals ({ commonjs, root }) make @utoo/pack's standalone
     // output emit a `require(name)` branch under `typeof exports === 'object'`,

--- a/tools/egg-bundler/test/Bundler.test.ts
+++ b/tools/egg-bundler/test/Bundler.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   manifestLoaderOptions: [] as unknown[],
   manifestLoad: vi.fn(async () => undefined),
   externalsResolve: vi.fn(async () => ({})),
-  entryGenerate: vi.fn(async () => ({ workerEntry: '/tmp/worker.entry.ts' })),
+  entryGenerate: vi.fn(async () => ({ workerEntry: '/tmp/worker.entry.ts', entryDir: '/tmp' })),
 }));
 
 vi.mock('../src/lib/ManifestLoader.ts', () => ({
@@ -72,6 +72,13 @@ describe('Bundler', () => {
     tmpApp = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-unit-app-'));
     tmpOutput = await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-unit-out-'));
     await fs.writeFile(path.join(tmpApp, 'package.json'), JSON.stringify({ name: 'unit-app' }));
+    // PackRunner writes the compiler tsconfig into the entry dir (= projectPath),
+    // so it must be a real, writable directory under the app temp dir.
+    const entryDir = path.join(tmpApp, '.egg-bundle', 'entries');
+    mocks.entryGenerate.mockResolvedValue({
+      workerEntry: path.join(entryDir, 'worker.entry.ts'),
+      entryDir,
+    });
   });
 
   afterEach(async () => {

--- a/tools/egg-bundler/test/PackRunner.test.ts
+++ b/tools/egg-bundler/test/PackRunner.test.ts
@@ -51,19 +51,42 @@ describe('PackRunner', () => {
     });
   }
 
-  it('writes the output tsconfig.json with decorator metadata flags set before invoking the build', async () => {
-    let tsconfigAtBuildTime: string | undefined;
+  it('writes the compiler tsconfig.json into the PROJECT dir (where @utoo/pack resolves it) with decorator metadata flags before invoking the build', async () => {
+    let projectTsconfig: string | undefined;
+    let outputHasTsconfig = true;
     const buildFunc: BuildFunc = async () => {
-      tsconfigAtBuildTime = await fs.readFile(path.join(tmpDir, 'out', 'tsconfig.json'), 'utf8');
+      // @utoo/pack reads tsconfig from the project dir, not the output dir.
+      projectTsconfig = await fs.readFile(path.join(tmpDir, 'tsconfig.json'), 'utf8');
+      outputHasTsconfig = await fs
+        .stat(path.join(tmpDir, 'out', 'tsconfig.json'))
+        .then(() => true)
+        .catch(() => false);
     };
 
     await makeRunner({ buildFunc }).run();
 
-    expect(tsconfigAtBuildTime).toBeDefined();
-    const parsed = JSON.parse(tsconfigAtBuildTime!);
+    expect(projectTsconfig).toBeDefined();
+    const parsed = JSON.parse(projectTsconfig!);
     expect(parsed.compilerOptions.experimentalDecorators).toBe(true);
     expect(parsed.compilerOptions.emitDecoratorMetadata).toBe(true);
     expect(parsed.compilerOptions.target).toBe('es2022');
+    // The output dir tsconfig is gone — it never governed compilation.
+    expect(outputHasTsconfig).toBe(false);
+  });
+
+  it('writes useDefineForClassFields:false into the project tsconfig so declared-but-uninitialized class fields are not emitted as shadowing own fields', async () => {
+    let projectTsconfig: string | undefined;
+    const buildFunc: BuildFunc = async () => {
+      projectTsconfig = await fs.readFile(path.join(tmpDir, 'tsconfig.json'), 'utf8');
+    };
+
+    await makeRunner({ buildFunc }).run();
+
+    const parsed = JSON.parse(projectTsconfig!);
+    // With target es2022, TS/SWC default this to true, which would emit own
+    // class fields that shadow ORM prototype accessors (leoric Bone models),
+    // silently dropping columns on INSERT. Must be explicitly disabled.
+    expect(parsed.compilerOptions.useDefineForClassFields).toBe(false);
   });
 
   it('writes package.json { "type": "commonjs" } into the output dir so @utoo/pack CJS output parses correctly', async () => {
@@ -165,18 +188,23 @@ describe('PackRunner', () => {
 
   it('defaults rootPath to projectPath when the caller omits rootPath', async () => {
     const buildFunc = vi.fn<BuildFunc>(async () => {});
-    await makeRunner({ buildFunc, projectPath: '/custom/project' }).run();
+    // PackRunner writes the compiler tsconfig into projectPath, so it must be a
+    // real, writable directory.
+    const customProject = path.join(tmpDir, 'custom-project');
+    await makeRunner({ buildFunc, projectPath: customProject }).run();
     const [, projectPath, rootPath] = buildFunc.mock.calls[0]!;
-    expect(projectPath).toBe('/custom/project');
-    expect(rootPath).toBe('/custom/project');
+    expect(projectPath).toBe(customProject);
+    expect(rootPath).toBe(customProject);
   });
 
   it('forwards a distinct rootPath when the caller provides it', async () => {
     const buildFunc = vi.fn<BuildFunc>(async () => {});
-    await makeRunner({ buildFunc, projectPath: '/proj', rootPath: '/monorepo/root' }).run();
+    const proj = path.join(tmpDir, 'proj');
+    const monorepoRoot = path.join(tmpDir, 'monorepo-root');
+    await makeRunner({ buildFunc, projectPath: proj, rootPath: monorepoRoot }).run();
     const [, projectPath, rootPath] = buildFunc.mock.calls[0]!;
-    expect(projectPath).toBe('/proj');
-    expect(rootPath).toBe('/monorepo/root');
+    expect(projectPath).toBe(proj);
+    expect(rootPath).toBe(monorepoRoot);
   });
 
   it('returns the outputDir and a sorted list of files that @utoo/pack produced', async () => {
@@ -191,8 +219,9 @@ describe('PackRunner', () => {
     const result = await makeRunner({ buildFunc }).run();
 
     expect(result.outputDir).toBe(outputDir);
-    // tsconfig.json + package.json are pre-written, then buildFunc adds worker/agent/nested/chunk
-    const expected = ['agent.js', path.join('nested', 'chunk.js'), 'package.json', 'tsconfig.json', 'worker.js'].sort();
+    // package.json is pre-written into the output dir (the compiler tsconfig now
+    // goes into the project dir, not the output), then buildFunc adds the chunks.
+    const expected = ['agent.js', path.join('nested', 'chunk.js'), 'package.json', 'worker.js'].sort();
     expect([...result.files]).toEqual(expected);
   });
 

--- a/tools/egg-bundler/test/classFieldShadowing.realbuild.test.ts
+++ b/tools/egg-bundler/test/classFieldShadowing.realbuild.test.ts
@@ -1,0 +1,102 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { PackRunner } from '../src/lib/PackRunner.ts';
+
+const execFileAsync = promisify(execFile);
+
+// REAL @utoo/pack build regression test for the ORM class-field shadowing fix.
+//
+// This is intentionally a real build (not a mocked one): the fix relies entirely
+// on where the `useDefineForClassFields: false` tsconfig lands relative to how
+// @utoo/pack resolves it. A mock cannot catch a @utoo/pack upgrade that changes
+// that behavior, nor a regression that moves the tsconfig back to the output dir.
+//
+// The model mirrors a leoric `Bone`: a base class installs a get/set accessor on
+// the prototype whose setter has a side effect (records the column for INSERT),
+// and the subclass declares the attribute without an initializer. If the bare
+// field survives as a native own property it shadows the setter and the column is
+// silently dropped — exactly the production bug. No decorators are used so the
+// build needs no `@swc/helpers` (unresolvable under the pnpm test sandbox).
+const MODEL = `
+class Base {
+  #columns = {};
+  get createdAt() { return this.#columns.createdAt; }
+  set createdAt(value) { this.#columns.createdAt = value; }
+  toSQLValues() { return { ...this.#columns }; }
+}
+export class User extends Base {
+  createdAt;
+}
+`;
+
+const CREATED_AT = '2020-01-01T00:00:00.000Z';
+
+describe('class field shadowing — real @utoo/pack build', () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    // realpath: on macOS os.tmpdir() is a /var -> /private/var symlink and
+    // Turbopack's path math rejects the mismatch.
+    baseDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-classfields-')));
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('erases the shadowing class field and preserves the prototype setter (column kept on INSERT)', async () => {
+    await fs.mkdir(path.join(baseDir, 'app'), { recursive: true });
+    const entryDir = path.join(baseDir, '.egg-bundle', 'entries');
+    await fs.mkdir(entryDir, { recursive: true });
+    await fs.writeFile(path.join(baseDir, 'app', 'model.ts'), MODEL);
+
+    // The application's OWN tsconfig — target es2022, NO useDefineForClassFields.
+    // This is the bug condition: it must be left untouched and must be ignored
+    // in favour of the compiler tsconfig PackRunner writes into the project dir.
+    await fs.writeFile(
+      path.join(baseDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { target: 'es2022' } }, null, 2),
+    );
+
+    const entry = path.join(entryDir, 'worker.entry.ts');
+    await fs.writeFile(
+      entry,
+      `import { User } from '../../app/model.ts';\n` +
+        `const u = new User();\n` +
+        `u.createdAt = '${CREATED_AT}';\n` +
+        `process.stdout.write(JSON.stringify(u.toSQLValues()));\n`,
+    );
+
+    const outputDir = path.join(baseDir, 'dist');
+    const result = await new PackRunner({
+      entries: [{ name: 'worker', filepath: entry }],
+      outputDir,
+      externals: {},
+      projectPath: entryDir, // build-managed; PackRunner writes the compiler tsconfig here
+      rootPath: baseDir, // app sources + node_modules above the entry dir stay resolvable
+    }).run();
+
+    // The application's own tsconfig must NOT have been overwritten.
+    const appTsconfig = JSON.parse(await fs.readFile(path.join(baseDir, 'tsconfig.json'), 'utf8'));
+    expect(appTsconfig.compilerOptions.useDefineForClassFields).toBeUndefined();
+
+    // The emitted class body must not carry the shadowing own field.
+    let combined = '';
+    for (const rel of result.files.filter((f) => f.endsWith('.js'))) {
+      combined += await fs.readFile(path.join(outputDir, rel), 'utf8');
+    }
+    expect(combined).toMatch(/class\s+User\s+extends\s+Base\s*\{\s*\}/);
+    expect(combined).not.toMatch(/class\s+User\b[\s\S]{0,80}?\bcreatedAt\s*;/);
+
+    // Runtime proof: executing the bundle, the setter ran and the column is
+    // present in toSQLValues() (the INSERT payload).
+    const { stdout } = await execFileAsync(process.execPath, [path.join(outputDir, 'worker.js')], { cwd: outputDir });
+    expect(JSON.parse(stdout)).toEqual({ createdAt: CREATED_AT });
+  }, 60_000);
+});

--- a/tools/egg-bundler/test/deterministic.test.ts
+++ b/tools/egg-bundler/test/deterministic.test.ts
@@ -26,7 +26,8 @@ const FIXTURE_SOURCE = path.join(__dirname, 'fixtures/apps/minimal-app');
 //   * Bundler sorts externals and chunks in the bundle-manifest.
 //   * Bundler writes bundle-manifest.json with JSON.stringify(_, null, 2) —
 //     stable key order because the object is constructed as a literal.
-//   * PackRunner pre-writes tsconfig.json and package.json with stable content.
+//   * PackRunner pre-writes package.json (output dir) and the compiler
+//     tsconfig.json (project/entry dir) with stable content.
 //   * The outputDir absolute path must NOT leak into any artifact (two tmpdirs
 //     with different names would cause drift if it did).
 //

--- a/tools/egg-bundler/test/integration.test.ts
+++ b/tools/egg-bundler/test/integration.test.ts
@@ -97,13 +97,13 @@ describe('bundle() integration — minimal-app (Phase 1: mocked @utoo/pack)', ()
     expect(result.outputDir).toBe(tmpOutput);
     expect(result.manifestPath).toBe(path.join(tmpOutput, 'bundle-manifest.json'));
     // files must include all mock chunks + PackRunner pre-writes + bundle-manifest
+    // (the compiler tsconfig now goes into the project dir, not the output dir)
     expect(result.files).toEqual(
       expect.arrayContaining([
         path.join(tmpOutput, 'worker.js'),
         path.join(tmpOutput, 'worker.js.map'),
         path.join(tmpOutput, '_turbopack__runtime.js'),
         path.join(tmpOutput, '_root-of-the-server___abc123.js'),
-        path.join(tmpOutput, 'tsconfig.json'),
         path.join(tmpOutput, 'package.json'),
         path.join(tmpOutput, 'bundle-manifest.json'),
       ]),
@@ -112,11 +112,14 @@ describe('bundle() integration — minimal-app (Phase 1: mocked @utoo/pack)', ()
     expect([...result.files]).toEqual(sortStrings(result.files));
   });
 
-  it('PackRunner pre-writes tsconfig.json (with decorator flags) and package.json (type: commonjs) BEFORE the build step runs', async () => {
+  it('pre-writes the compiler tsconfig.json into the project (entry) dir and package.json into the output dir BEFORE the build step runs', async () => {
+    // @utoo/pack resolves tsconfig from the project dir (the generated entry dir),
+    // not the output dir, so PackRunner writes it there.
+    const entryTsconfigPath = path.join(tmpApp, '.egg-bundle', 'entries', 'tsconfig.json');
     let tsconfigAtBuildTime: string | undefined;
     let pkgAtBuildTime: string | undefined;
     const buildFunc: BuildFunc = async () => {
-      tsconfigAtBuildTime = await fs.readFile(path.join(tmpOutput, 'tsconfig.json'), 'utf8');
+      tsconfigAtBuildTime = await fs.readFile(entryTsconfigPath, 'utf8');
       pkgAtBuildTime = await fs.readFile(path.join(tmpOutput, 'package.json'), 'utf8');
       await fs.writeFile(path.join(tmpOutput, 'worker.js'), '// mock\n');
     };
@@ -132,9 +135,28 @@ describe('bundle() integration — minimal-app (Phase 1: mocked @utoo/pack)', ()
     expect(tsconfig.compilerOptions.experimentalDecorators).toBe(true);
     expect(tsconfig.compilerOptions.emitDecoratorMetadata).toBe(true);
     expect(tsconfig.compilerOptions.target).toBe('es2022');
+    expect(tsconfig.compilerOptions.useDefineForClassFields).toBe(false);
 
     expect(pkgAtBuildTime).toBeDefined();
     expect(JSON.parse(pkgAtBuildTime!)).toEqual({ type: 'commonjs' });
+  });
+
+  it('builds with projectPath = the generated entry dir (not the app baseDir) so the compiler tsconfig governs without touching the app tsconfig', async () => {
+    let projectPathAtBuild: string | undefined;
+    let rootPathAtBuild: string | undefined;
+    const buildFunc: BuildFunc = async (_wrapped, projectPath, rootPath) => {
+      projectPathAtBuild = projectPath;
+      rootPathAtBuild = rootPath;
+      await fs.writeFile(path.join(tmpOutput, 'worker.js'), '// mock\n');
+    };
+
+    await bundle({ baseDir: tmpApp, outputDir: tmpOutput, pack: { buildFunc } });
+
+    // projectPath must be the build-managed entry dir (where PackRunner wrote the
+    // useDefineForClassFields:false tsconfig), NOT the app baseDir — otherwise the
+    // app's own tsconfig would govern (bug) or be overwritten (pollution).
+    expect(projectPathAtBuild).toBe(path.join(tmpApp, '.egg-bundle', 'entries'));
+    expect(rootPathAtBuild).toBe(tmpApp);
   });
 
   it('leaves output package.json as the pack runtime package instead of patching app metadata into it', async () => {
@@ -170,7 +192,6 @@ describe('bundle() integration — minimal-app (Phase 1: mocked @utoo/pack)', ()
     // chunks should be sorted and contain worker.js
     expect([...bm.chunks]).toEqual(sortStrings(bm.chunks));
     expect(bm.chunks).toContain('worker.js');
-    expect(bm.chunks).toContain('tsconfig.json');
     expect(bm.chunks).toContain('package.json');
   });
 


### PR DESCRIPTION
## Motivation

Declared-but-uninitialized TypeScript class fields (e.g. `createdAt: Date;` on a leoric `Bone` model) compiled with `useDefineForClassFields: true` become native **own** `undefined` properties at runtime. They shadow the get/set accessors ORMs install on the prototype for decorated attributes, so writes never reach the setter and the column is **silently dropped on INSERT** (observed as a missing `gmt_create`).

The bundle must compile these with `useDefineForClassFields: false` (matching how Egg apps build with `target <= ES2021`) so the bare declarations are erased and the prototype accessors stay effective.

## Why the obvious placement does not work

`@utoo/pack` (Turbopack) resolves the governing tsconfig from the **project dir** (the `projectPath` passed to `build()`) — **not** the output dir, and **not** via per-file find-up to the nearest tsconfig. Verified against `@utoo/pack` 1.4.13/1.4.14 with an isolated repro:

| tsconfig location | shadowing field |
| --- | --- |
| output dir | ❌ kept |
| nearer the source than projectPath | ❌ kept (ignored) |
| `projectPath/tsconfig.json` | ✅ erased |

This is not an upstream bug — see [utooland/utoo#2450](https://github.com/utooland/utoo/issues/2450) (confirmed and closed COMPLETED): the option works, only placement matters. Bundler passed `projectPath = app baseDir`, whose own tsconfig extends `@eggjs/tsconfig` (`target: ES2024` → `useDefineForClassFields` defaults to `true`), so the field survived.

## Scope

- **PackRunner** writes the compiler tsconfig (`experimentalDecorators`, `emitDecoratorMetadata`, `target`, `useDefineForClassFields:false`) into the **project dir** instead of the output dir.
- **Bundler** passes `projectPath = the generated entry dir` (build-managed `.egg-bundle/entries`) and `rootPath = app baseDir`, so the compiler tsconfig is the one `@utoo/pack` resolves; the app's own tsconfig is **neither read nor overwritten**, and app sources + `node_modules` above the entry dir still resolve.

Diff is limited to `tools/egg-bundler`.

## Test evidence

A real `@utoo/pack` build regression test (decorator-free leoric-like model, so no `@swc/helpers` needed) asserts:
- the bare field is erased (empty class body);
- the prototype setter side effect survives — `toSQLValues()` keeps the column (runtime proof by executing the bundle under `node`);
- the app's own tsconfig is left untouched.

It is intentionally a **real** build so a future `@utoo/pack` upgrade or a tsconfig-placement regression is caught (a mock cannot). Unit/integration tests are updated for the new tsconfig location and a guard pins `projectPath = entry dir`.

`pnpm --filter=@eggjs/egg-bundler run test` is green (local-only macOS `/private/var` symlink failures in `EntryGenerator`/`ManifestLoader` are pre-existing and unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ORM class field shadowing during bundle builds so derived classes no longer break base `createdAt` getter/setter behavior.
  * Improved bundling TypeScript configuration placement and behavior: `tsconfig.json` is generated in the project/entry directory, includes the expected compiler options (including `useDefineForClassFields: false`), and avoids clobbering an existing configuration unexpectedly.

* **Tests / Documentation**
  * Updated and added regression and integration tests, plus refreshed determinism notes to reflect the new `tsconfig.json` location and pre-write ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->