### PR TITLE
fix(loader-fs): ignore vitest environment-teardown import races

### DIFF
--- a/packages/loader-fs/src/index.ts
+++ b/packages/loader-fs/src/index.ts
@@ -19,6 +19,27 @@ const Module = typeof module !== 'undefined' && module.constructor.length > 1 ? 
 const extensions = (Module as unknown as CommonJSModuleConstructor)._extensions ?? {};
 const extensionNames = Object.keys(extensions).concat(['.js', '.cjs', '.mjs']);
 
+// Detect vitest's "environment was torn down" error, raised when a dynamic
+// import() resolves after the test environment that issued it has already been
+// torn down. It is reported by name (`EnvironmentTeardownError`) and/or message,
+// possibly nested behind a `cause`, so walk a short cause chain.
+//
+// Gated on `process.env.VITEST` so this is unmistakably a test-runner-only
+// accommodation: the condition only exists inside the vitest runner during
+// teardown and never in production, so outside vitest we never swallow.
+function isEnvironmentTeardownError(e: unknown): boolean {
+  if (!process.env.VITEST) return false;
+  let cur = e as { name?: unknown; message?: unknown; cause?: unknown } | undefined | null;
+  for (let depth = 0; cur && depth < 5; depth++) {
+    if (cur.name === 'EnvironmentTeardownError') return true;
+    if (typeof cur.message === 'string' && cur.message.includes('after the environment was torn down')) {
+      return true;
+    }
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
 export type LoaderFSGlobOptions = globby.GlobbyOptions;
 
 export interface LoaderFS {
@@ -63,6 +84,22 @@ export class RealLoaderFS implements LoaderFS {
       }
       return await importModule(filepath, { importDefaultOnly: true });
     } catch (e) {
+      // `isEnvironmentTeardownError` is gated on `process.env.VITEST`, so this
+      // swallow only ever applies inside the vitest runner and can never alter
+      // production loader behavior.
+      if (isEnvironmentTeardownError(e)) {
+        // A dynamic import() that loses the race with a vitest test-environment
+        // teardown throws EnvironmentTeardownError ("Cannot load X ... after the
+        // environment was torn down"). This happens only inside the vitest runner
+        // as a test ends — never in production — and the load result is unusable
+        // anyway. Returning a benign empty value (instead of throwing) keeps the
+        // stray load from surfacing as an unhandled rejection that, under vitest
+        // `isolate: false`, gets blamed on whatever unrelated test file is running
+        // when the import settles. Loaders already treat an empty module as "no
+        // exports", so this is a safe no-op.
+        debug('[loadFile] ignore environment-teardown race for %s', filepath);
+        return undefined;
+      }
       if (!(e instanceof Error)) {
         console.trace(e);
       }

--- a/packages/loader-fs/test/fixtures/loadfile/normal-error.js
+++ b/packages/loader-fs/test/fixtures/loadfile/normal-error.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// A genuine load-time failure must still propagate (wrapped) from loadFile.
+throw new Error('boom: real load failure');

--- a/packages/loader-fs/test/fixtures/loadfile/teardown-error.js
+++ b/packages/loader-fs/test/fixtures/loadfile/teardown-error.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Simulates a module whose import loses the race with a vitest test-environment
+// teardown: the runtime raises an `EnvironmentTeardownError`. `RealLoaderFS.loadFile`
+// should treat this as a benign no-op and resolve `undefined` instead of throwing.
+const err = new Error(
+  "Cannot load 'teardown-error.js' imported from import.ts after the environment was torn down. This is not a bug in Vitest.",
+);
+err.name = 'EnvironmentTeardownError';
+throw err;

--- a/packages/loader-fs/test/loader_fs.test.ts
+++ b/packages/loader-fs/test/loader_fs.test.ts
@@ -35,4 +35,18 @@ describe('test/loader_fs.test.ts', () => {
     assert.deepEqual(await loaderFS.loadFile(path.join(baseDir, 'object.js')), { a: 1 });
     assert.deepEqual(await loaderFS.loadFile(yamlPath), fs.readFileSync(yamlPath));
   });
+
+  it('should treat a vitest environment-teardown import error as a benign no-op', async () => {
+    // A dynamic import() that loses the race with a test-environment teardown
+    // throws `EnvironmentTeardownError` ("...after the environment was torn
+    // down"). loadFile must swallow it (resolve undefined) so the stray load
+    // does not surface as an unhandled rejection that fails an unrelated test.
+    const teardownPath = path.join(baseDir, 'teardown-error.js');
+    assert.equal(await loaderFS.loadFile(teardownPath), undefined);
+  });
+
+  it('should still throw for a genuine load-time failure', async () => {
+    const errorPath = path.join(baseDir, 'normal-error.js');
+    await assert.rejects(loaderFS.loadFile(errorPath), /\[@eggjs\/loader-fs\] load file:.*boom: real load failure/);
+  });
 });


### PR DESCRIPTION
## Motivation

`Test (ubuntu-latest, 24)` flakily fails with:

```
EnvironmentTeardownError: Cannot load '<file>' ... after the environment was torn down. This is not a bug in Vitest.
```

Observed in CI loading `tegg/plugin/controller`'s `duplicate-proto-name-app/.../AppController.ts`, and reproduced locally in the `@eggjs/mock` suite loading `logrotator`'s `rotate_by_file.ts` — failing unrelated tests (e.g. `mock_httpclient_next` "should auto restore after each case").

## Root cause (traced)

The framework loads files via dynamic `import()` through `RealLoaderFS.loadFile`. Instrumenting the dangling load shows it is a **legitimate, fully-awaited boot-time load** — e.g. the schedule plugin loading schedule files during `configDidLoad`:

```
RealLoaderFS.loadFile  ← getExports  ← ScheduleLoader.parse/.load
  ← loadSchedule  ← Scheduler.init (agent) / ScheduleWorker.init (app)  ← Boot.configDidLoad
```

Every link awaits: `loadSchedule` awaits the loader, `configDidLoad` awaits `loadSchedule`, `ready()` awaits `configDidLoad`. Timers / `serverDidReady` / strategy `start()` do **not** import. So there is **no fire-and-forget async leak** to fix at the source.

It outlives teardown because of the suite's `isolate: false` (threads) config: an `import()` issued while constructing an app in one test file's module-runner environment can have follow-up settling (tsx transform / transitive resolution) that completes *after* vitest tears that environment down to move to the next file. vitest itself labels this `"This is not a bug in Vitest"`. `loadFile` wrapped and rethrew it, so it became an **unhandled rejection** that, under `isolate: false`, gets blamed on whatever unrelated test file is running. Same class of teardown race addressed for a different symptom in #5978.

## Fix

Because the load is correct and awaited, there's nothing to fix at the source — the only artifact is the benign vitest-internal error. Detect it in `loadFile` (by `name === 'EnvironmentTeardownError'` and/or the `"after the environment was torn down"` message, walking the `cause` chain) and resolve `undefined` instead of throwing.

- **Gated on `process.env.VITEST`** so it is unmistakably a test-runner-only accommodation that can never alter production loader behavior.
- Loaders already treat an empty module as "no exports", so this is a safe no-op.
- **Genuine load-time failures still propagate unchanged.**

## Test evidence

- **Empirical:** on `next`, `pnpm vitest run plugins/mock/test` fails with the `EnvironmentTeardownError`; with this fix that error is gone. (A separate, pre-existing `mock error` cross-file leak from `app.test.ts`/`agent.test.ts` remains — different root cause, out of scope; it was previously masked by the teardown error.)
- **Unit:** new `loader-fs` regression tests assert `loadFile` resolves `undefined` for a teardown-style import error and still throws (wrapped) for a genuine load failure. Full `@eggjs/loader-fs` suite: 4 passed.
- `oxlint --type-aware`, `oxfmt --check`, and `tsgo --noEmit` clean on the changed files.

> Note: the same `import()`-races-teardown pattern also exists in `@eggjs/tegg-loader`'s `LoaderUtil.loadFile`; observed failures all flowed through `@eggjs/loader-fs`, so this PR fixes that path. The tegg path can get the same guard as a follow-up if it surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module-loading error handling during test runs: if a module import occurs after the test environment has been torn down, the loader now treats it as a benign no-op and resolves `undefined` instead of failing.
  * True load-time failures are still reported as before with the expected loader-fs error message.
* **Tests**
  * Added new fixtures and Vitest coverage to verify teardown-related import races are handled gracefully, while genuine load errors still reject.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->