### PR TITLE
fix(bundler): rely on @utoo/pack upstream CJS/ESM require interop fix

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,7 +64,7 @@ catalog:
   '@types/urijs': ^1.19.25
   '@types/vary': ^1.1.3
   '@typescript/native-preview': 7.0.0-dev.20260117.1
-  '@utoo/pack': ^1.2.7
+  '@utoo/pack': ^1.4.16
   '@vitest/coverage-v8': ^4.0.15
   '@vitest/ui': ^4.0.15
   accepts: ^1.3.8
@@ -237,6 +237,7 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - typebox
   - '@eggjs/*'
+  - '@utoo/*'
   - '@vitest/*'
   - '@rolldown/*'
   - '@vitejs/*'

--- a/tools/egg-bundler/test/cjs-esm-interop.realbuild.test.ts
+++ b/tools/egg-bundler/test/cjs-esm-interop.realbuild.test.ts
@@ -1,0 +1,135 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+// REAL @utoo/pack build regression test guarding the EGG-69 CJS/ESM require resolution.
+//
+// This is intentionally a real build (not a mocked one): the bug was entirely about how
+// @utoo/pack (Turbopack, target node) resolves a CJS `require('pkg')` for a dual package.
+// Older @utoo/pack resolved it to the package's ESM `module` entry; when that entry exposed
+// ONLY a `default` export (json5's dist/index.mjs shape), `require('pkg').parse` was
+// undefined — the production `JSON5.parse is not a function` crash. @utoo/pack >= 1.4.16
+// fixed this upstream (utooland/utoo#3185): a CJS `require()` of such a dual package now
+// resolves to its CommonJS `main`, matching Node's own CommonJS resolution.
+//
+// A mock cannot catch a @utoo/pack upgrade that regresses that resolution, so this real
+// build is the guard. The fixture mirrors json5: a dual package (`main` + `module`, no
+// `exports` field) whose ESM entry exports only `default`, required from authored CJS via a
+// named member. Node would resolve the require to `main`, so the bundle must print the CJS
+// implementation's output, proving the named member is reachable (no crash).
+
+// ManifestLoader / ExternalsResolver / EntryGenerator are stubbed so the test can drive a
+// real @utoo/pack build over a hand-written worker entry. Only the build is exercised for real.
+const mocks = vi.hoisted(() => ({
+  workerEntry: '',
+  entryDir: '',
+}));
+
+vi.mock('../src/lib/ManifestLoader.ts', () => ({
+  ManifestLoader: vi.fn().mockImplementation(function () {
+    return {
+      load: async () => undefined,
+      get manifest() {
+        return {
+          version: 1,
+          generatedAt: '2026-01-01T00:00:00.000Z',
+          invalidation: {
+            lockfileFingerprint: '',
+            configFingerprint: '',
+            serverEnv: 'prod',
+            serverScope: '',
+            typescriptEnabled: true,
+          },
+          extensions: {},
+          resolveCache: {},
+          fileDiscovery: {},
+        };
+      },
+      get store() {
+        return {};
+      },
+      getAllDiscoveredFiles: () => [],
+      getTeggDecoratedFiles: () => [],
+    };
+  }),
+}));
+
+vi.mock('../src/lib/ExternalsResolver.ts', () => ({
+  ExternalsResolver: vi.fn().mockImplementation(function () {
+    return { resolve: async () => ({}) };
+  }),
+}));
+
+vi.mock('../src/lib/EntryGenerator.ts', () => ({
+  EntryGenerator: vi.fn().mockImplementation(function () {
+    return {
+      generate: async () => ({ workerEntry: mocks.workerEntry, entryDir: mocks.entryDir }),
+    };
+  }),
+}));
+
+import { bundle } from '../src/index.ts';
+
+describe('CJS require of a dual ESM-only-default dependency — real @utoo/pack build (EGG-69)', () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    // realpath: on macOS os.tmpdir() is a /var -> /private/var symlink and Turbopack's
+    // path math rejects the mismatch.
+    baseDir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'egg-bundler-interop-')));
+  });
+
+  afterEach(async () => {
+    await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('resolves require("pkg") to the CommonJS main so the named member is callable in the bundle', async () => {
+    await fs.writeFile(path.join(baseDir, 'package.json'), JSON.stringify({ name: 'interop-app' }));
+
+    // Dual package shaped exactly like json5: CJS `main` + ESM `module` whose only export
+    // is `default`, no `exports` field. Older @utoo/pack mis-resolved require() to the ESM
+    // entry here; the upstream fix resolves it to `main` like Node.
+    const pkgDir = path.join(baseDir, 'node_modules', 'esm-default-pkg');
+    await fs.mkdir(pkgDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({ name: 'esm-default-pkg', main: 'index.js', module: 'index.mjs' }),
+    );
+    await fs.writeFile(path.join(pkgDir, 'index.js'), 'module.exports = { parse: (s) => `cjs:${s}` };\n');
+    await fs.writeFile(path.join(pkgDir, 'index.mjs'), 'export default { parse: (s) => `esm:${s}` };\n');
+
+    // Authored-CJS consumer that requires the dual package and uses a NAMED member.
+    const consumerDir = path.join(baseDir, 'node_modules', 'cjs-consumer');
+    await fs.mkdir(consumerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(consumerDir, 'package.json'),
+      JSON.stringify({ name: 'cjs-consumer', main: 'index.js' }),
+    );
+    await fs.writeFile(
+      path.join(consumerDir, 'index.js'),
+      "const pkg = require('esm-default-pkg');\nmodule.exports = { run: () => pkg.parse('ok') };\n",
+    );
+
+    const entryDir = path.join(baseDir, '.egg-bundle', 'entries');
+    await fs.mkdir(entryDir, { recursive: true });
+    const entry = path.join(entryDir, 'worker.entry.ts');
+    await fs.writeFile(entry, "import consumer from 'cjs-consumer';\nprocess.stdout.write(consumer.run());\n");
+    mocks.workerEntry = entry;
+    mocks.entryDir = entryDir;
+
+    const outputDir = path.join(baseDir, 'dist');
+    await bundle({ baseDir, outputDir });
+
+    // Runtime proof: the named member is reachable in the bundle (no `parse is not a
+    // function` crash). @utoo/pack resolves the CJS require to the package's CommonJS `main`
+    // — exactly like Node — so the CJS implementation's output is what runs.
+    const { stdout } = await execFileAsync(process.execPath, [path.join(outputDir, 'worker.js')], { cwd: outputDir });
+    expect(stdout).toBe('cjs:ok');
+  }, 60_000);
+});

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,11 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-06-22] package | egg-bundler CJS/ESM require interop fixed upstream in @utoo/pack (EGG-69)
+
+- sources touched: `pnpm-workspace.yaml`, `tools/egg-bundler/src/lib/Bundler.ts`, `tools/egg-bundler/test/Bundler.test.ts`, `tools/egg-bundler/test/cjsEsmInterop.realbuild.test.ts`
+- note: Bundled cnpmcore crashed at runtime with `<path>/tsconfig.json is malformed JSON5.parse is not a function`. Root cause: older `@utoo/pack` (Turbopack, target node) resolved a CJS `require('json5')` to json5's ESM `module` entry (`dist/index.mjs`, default-only), so `commonJsRequire` returned the `{ __esModule, default }` namespace and `JSON5.parse` was undefined. This is now **fixed upstream** (utooland/utoo#3185): `@utoo/pack` >= 1.4.16 resolves a CJS `require()` of such a dual package to its CommonJS `main`, matching Node's own CommonJS resolution. The earlier in-repo workaround (a post-build patch of `_turbopack__runtime.js` that unwrapped the lone `default`) is **removed** in favour of the upstream fix; the catalog `@utoo/pack` range is bumped to `^1.4.16`. Verified by a real `@utoo/pack` build over a json5-shaped dual fixture (`main`+`module`, ESM exports only `default`) required from authored CJS via a named member: the bundled worker runs the CJS implementation (`cjs:ok`) with no crash, confirming `require('pkg').member` resolves like Node. NB: the internal registry (`registry.antgroup-inc.cn`) still tops out at 1.4.14 (which lacks the fix); the OSS repo/CI uses the public registry where 1.4.16 is available.
+
 ## [2026-06-20] concept | fix Windows-flaky session test (teardown close/load race)
 
 - sources touched: `packages/core/src/lifecycle.ts`, `packages/egg/src/lib/egg.ts`, `packages/core/test/lifecycle.test.ts`


### PR DESCRIPTION
## Background

A bundled egg app crashed at runtime with `<path>/tsconfig.json is malformed JSON5.parse is not a function`, and only started if the user passed `--pack-alias json5=<lib/index.js>` (EGG-69).

Root cause: `@utoo/pack` (Turbopack, `target: node`) resolved the CJS `require('json5')` inside `tsconfig-paths` to json5's **ESM** `module` entry (`dist/index.mjs`, default-only). `commonJsRequire` returned the ESM namespace `{ __esModule: true, default: JSON5 }`, so `JSON5.parse` was `undefined`. Node would instead resolve such dual packages to their CommonJS `main`.

## This is already fixed upstream

`@utoo/pack` >= 1.4.16 fixes the root cause (utooland/utoo#3185): a CJS `require()` of such a dual package now resolves to its CommonJS `main`, matching Node's own CommonJS resolution. **The real fix lives upstream; this PR does not fix anything itself.**

An earlier version of this PR carried an in-repo workaround (a post-build patch of `_turbopack__runtime.js`). That workaround is now removed in favor of the upstream fix.

## What this PR actually does

This is hygiene, not a functional fix:

- **Raise the `@utoo/pack` floor**: catalog range `^1.2.7` → `^1.4.16`, so the fixed version is the documented minimum and nobody can pin a pre-fix version. (The repo ships no lockfile, so fresh installs already resolve to the latest `1.4.x`; this just makes the requirement explicit.)
- **Add a regression guard**: `tools/egg-bundler/test/cjsEsmInterop.realbuild.test.ts` runs a **real `@utoo/pack` build** over a json5-shaped dual fixture (`main` + `module`, ESM exports only `default`, no `exports` field) required from authored CJS via a named member, then executes the bundled `worker.js`. It prints the CJS implementation's output (`cjs:ok`) with no crash, proving `require('pkg').member` resolves like Node. A future `@utoo/pack` regression of that resolution fails this test.

## Test evidence

`cjsEsmInterop.realbuild.test.ts` passes against `@utoo/pack` 1.4.16; the same fixture crashes (`pkg.parse is not a function`) on 1.4.14, confirming the test exercises the real behavior.

> Note: the public npm registry has `@utoo/pack@1.4.16`; some internal mirrors may still lag at 1.4.14 (no fix) until they sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CommonJS/ESM interoperability issue in the bundler that caused runtime crashes when resolving dual-entry packages.

* **Tests**
  * Added regression test to verify correct CommonJS/ESM package resolution behavior in the bundler.

* **Chores**
  * Updated bundler dependency to address the interoperability issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->