### PR TITLE
refactor(egg-bin): remove dead --no-tegg bundle flag

### DIFF
--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -212,8 +212,6 @@ node worker.js
   `package.json#egg.framework` or `egg`. Absolute framework paths are not
   supported by the bundled runtime.
 - `--mode` build mode, `production` or `development`, default to `production`
-- `--no-tegg` accepted by the CLI, but not applied by the current bundler
-  implementation yet
 - `--force-external` package name to always keep external, supports multiple
 - `--inline-external` package name to force inline, supports multiple
 - `--pack-alias` `@utoo/pack` resolve alias in `<specifier>=<target>` form,

--- a/tools/egg-bin/src/commands/bundle.ts
+++ b/tools/egg-bin/src/commands/bundle.ts
@@ -76,10 +76,6 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
       options: [...bundleModes],
       default: 'production',
     }),
-    'no-tegg': Flags.boolean({
-      description: 'disable tegg decoratedFile collection',
-      default: false,
-    }),
     'force-external': Flags.string({
       description: 'package name to always mark as external (repeatable)',
       multiple: true,
@@ -107,14 +103,7 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
         : path.join(baseDir, flags.manifest)
       : undefined;
 
-    debug(
-      'bundle: baseDir=%s, outputDir=%s, framework=%s, mode=%s, tegg=%s',
-      baseDir,
-      outputDir,
-      flags.framework,
-      flags.mode,
-      !flags['no-tegg'],
-    );
+    debug('bundle: baseDir=%s, outputDir=%s, framework=%s, mode=%s', baseDir, outputDir, flags.framework, flags.mode);
 
     const { bundle } = await import('@eggjs/egg-bundler');
     const packAlias = parsePackAliases(flags['pack-alias'], baseDir);
@@ -124,7 +113,6 @@ export default class Bundle extends BaseCommand<typeof Bundle> {
       manifestPath,
       framework: await getBundleFrameworkSpecifier(baseDir, flags.framework),
       mode: getBundleMode(flags.mode),
-      tegg: !flags['no-tegg'],
       externals: {
         force: flags['force-external'],
         inline: flags['inline-external'],

--- a/tools/egg-bin/test/commands/bundle.test.ts
+++ b/tools/egg-bin/test/commands/bundle.test.ts
@@ -33,7 +33,6 @@ describe('test/commands/bundle.test.ts', () => {
       manifestPath: undefined,
       framework: 'aliyun-egg',
       mode: 'production',
-      tegg: true,
       externals: {
         force: [],
         inline: [],
@@ -51,7 +50,6 @@ describe('test/commands/bundle.test.ts', () => {
       '.egg/custom-manifest.json',
       '--mode',
       'development',
-      '--no-tegg',
       '--force-external',
       '@scope/foo',
       '--force-external',
@@ -67,7 +65,6 @@ describe('test/commands/bundle.test.ts', () => {
       manifestPath: path.join(baseDir, '.egg/custom-manifest.json'),
       framework: 'aliyun-egg',
       mode: 'development',
-      tegg: false,
       externals: {
         force: ['@scope/foo', 'bar'],
         inline: ['baz'],
@@ -92,7 +89,6 @@ describe('test/commands/bundle.test.ts', () => {
       manifestPath: undefined,
       framework: 'aliyun-egg',
       mode: 'production',
-      tegg: true,
       externals: {
         force: [],
         inline: [],
@@ -118,7 +114,6 @@ describe('test/commands/bundle.test.ts', () => {
       manifestPath: undefined,
       framework: '@my-org/framework',
       mode: 'production',
-      tegg: true,
       externals: {
         force: [],
         inline: [],

--- a/tools/egg-bundler/src/index.ts
+++ b/tools/egg-bundler/src/index.ts
@@ -54,8 +54,6 @@ export interface BundlerConfig {
   readonly pack?: BundlerPackConfig;
   /** Runtime asset copy tuning. */
   readonly runtimeAssets?: BundlerRuntimeAssetsConfig;
-  /** Enable tegg decoratedFile collection. Defaults to `true`. */
-  readonly tegg?: boolean;
 }
 
 export interface BundleResult {


### PR DESCRIPTION
## Motivation

The `bundle` command's `--no-tegg` flag was plumbed from the CLI into `@eggjs/egg-bundler`'s `tegg` option, but `Bundler.run()` never reads that option. tegg decoratedFile collection is driven entirely by whether the manifest (`<baseDir>/.egg/manifest.json`) contains a populated `extensions.tegg` block — passing `--no-tegg` did **not** change the bundle output at all.

So the flag was a dead no-op that only misled users into thinking they could disable tegg processing.

## Scope

- Remove the `--no-tegg` flag from `tools/egg-bin/src/commands/bundle.ts` (and the now-unused `tegg` field it passed through, plus the debug arg).
- Remove the `tegg?: boolean` option from `BundlerConfig` in `tools/egg-bundler/src/index.ts` (it was never consumed by the bundler).
- Drop the README note that already documented the flag as "not applied by the current bundler".
- Remove the related `tegg:` assertions and `--no-tegg` arg from `tools/egg-bin/test/commands/bundle.test.ts`.

If a real "force-skip tegg" escape hatch is ever needed, it should be wired properly into `Bundler.run()` rather than left as an unconsumed option.

## Test evidence

- `vitest run test/commands/bundle.test.ts` → 4 passed
- `tsgo --noEmit` clean for both `egg-bin` and `egg-bundler`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed `--no-tegg` CLI flag documentation from bundle command options.

* **Refactor**
  * The `--no-tegg` CLI flag has been removed from the bundle command.
  * The `tegg` configuration option is no longer supported in the bundler configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->