### PR TITLE
fix(ci): skip oxlint error when no staged files match

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   "lint-staged": {
     "*": [
       "oxfmt --no-error-on-unmatched-pattern",
-      "oxlint --type-aware --fix"
+      "oxlint --type-aware --fix --no-error-on-unmatched-pattern"
     ]
   },
   "engines": {


### PR DESCRIPTION
## Motivation

The **Manual Release** workflow fails at the **Version bump** step. Example: [run 27926057424](https://github.com/eggjs/egg/actions/runs/27926057424/job/82628579304).

The release script bumps every package's `package.json` version and then runs `git commit`. That commit triggers the husky `pre-commit` → `lint-staged` hook. When the staged set contains **only `package.json` files**, `oxlint --type-aware --fix` matches nothing and exits with code 1:

```
✖ oxlint --type-aware --fix:
No files found to lint. Please check your paths and ignore patterns.
husky - pre-commit script failed (code 1)
❌ Error during git operations: Command failed: git commit -m "chore(release): prerelease version bump ...
```

This fails the commit and the whole step.

## Scope

`oxfmt` in the same `lint-staged` config already passes `--no-error-on-unmatched-pattern`; this just mirrors that flag on `oxlint` so commits touching only non-lintable files (like a pure version bump) succeed.

```diff
   "lint-staged": {
     "*": [
       "oxfmt --no-error-on-unmatched-pattern",
-      "oxlint --type-aware --fix"
+      "oxlint --type-aware --fix --no-error-on-unmatched-pattern"
     ]
   },
```

## Test evidence

Verified the flag is supported by the pinned oxlint (`--version` 1.70.0): `oxlint --help` lists `--no-error-on-unmatched-pattern`. One-line config change, no behavior change for normal commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to improve handling of file pattern matching during development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->