### PR TITLE
fix(release): skip git hooks on the version-bump commit

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -135,9 +135,13 @@ try {
 
 ${updatedVersions.map((pkg) => `- ${pkg.name}@${pkg.newVersion}`).join('\n')}`;
 
-  // Commit changes
+  // Commit changes.
+  // Use --no-verify to skip git hooks: this commit only bumps version numbers in
+  // package.json files, which has nothing to lint. Running the husky pre-commit
+  // hook (lint-staged -> `oxlint --type-aware`) on a package.json-only changeset
+  // makes oxlint exit non-zero ("0 files" but failed), which aborts the release.
   console.log('\n💾 Creating version commit...');
-  execSync(`git commit -m "${commitMessage}"`, { stdio: 'inherit' });
+  execSync(`git commit --no-verify -m "${commitMessage}"`, { stdio: 'inherit' });
 
   // Create tag using the main egg version
   const tagName = `v${eggVersion}`;


### PR DESCRIPTION
## Problem

The Manual Release workflow currently fails at the **Version bump** step (e.g. [run on 2026-06-22](https://github.com/eggjs/egg/actions/runs/27926057424)):

```
[FAILED] oxlint --type-aware --fix
✖ oxlint --type-aware --fix:
Finished in 5ms on 0 files with 111 rules using 4 threads.
husky - pre-commit script failed (code 1)
❌ Error during git operations: Command failed: git commit -m "chore(release): prerelease version bump ...
##[error]Process completed with exit code 1.
```

`scripts/version.js` runs `git commit` (without `--no-verify`) for the version bump. That triggers husky's `pre-commit` hook → `lint-staged` (`"*": ["oxfmt ...", "oxlint --type-aware --fix"]`). The bump only stages `package.json` files, so oxlint has **0 lintable files** — and since the `oxlint` upgrade (`^1.32` → `^1.60`) it now **exits non-zero in that case**, aborting the commit and the whole release.

This is why releases succeeded before (e.g. 2026-04-01 on oxlint `^1.32`) but the first release attempt after the oxlint bump fails. No release has been published from `next` since.

## Fix

Add `--no-verify` to the version-bump commit in `scripts/version.js`. That commit only changes version numbers in `package.json` (its message already carries `[skip ci]`), so there is nothing to lint. This only affects the automated release commit — normal developer commits still run the hooks.

```diff
- execSync(`git commit -m "${commitMessage}"`, { stdio: 'inherit' });
+ execSync(`git commit --no-verify -m "${commitMessage}"`, { stdio: 'inherit' });
```

## Verification

After this lands, re-running Manual Release should get past the Version bump step and publish the pending `beta.10` (which includes #5969).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process stability by updating version-bump commit creation logic to prevent potential failures during automated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->