### PR TITLE
fix(dal-runtime): define __dirname for ESM in CodeGenerator

### DIFF
--- a/tegg/core/dal-runtime/src/CodeGenerator.ts
+++ b/tegg/core/dal-runtime/src/CodeGenerator.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { PrototypeUtil } from '@eggjs/core-decorator';
 import { ColumnModel, TableModel } from '@eggjs/dal-decorator';
@@ -11,6 +12,11 @@ import nunjucks, { type Environment } from 'nunjucks';
 
 import { SqlGenerator } from './SqlGenerator.ts';
 import { TemplateUtil } from './TemplateUtil.ts';
+
+// This package is ESM (type: module), so the CJS `__dirname` global is not
+// available. Restore it from import.meta.url to locate the ./templates dir
+// shipped alongside the built output.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export class CodeGenerator {
   private readonly moduleDir: string;

--- a/tegg/core/dal-runtime/test/CodeGenerator.test.ts
+++ b/tegg/core/dal-runtime/test/CodeGenerator.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
 import { TableModel } from '@eggjs/dal-decorator';
 import { describe, it } from 'vitest';
@@ -9,7 +12,60 @@ import { CodeGenerator } from '../src/CodeGenerator.js';
 import { Foo } from './fixtures/modules/generate_codes/Foo.js';
 import { MultiPrimaryKey } from './fixtures/modules/generate_codes/MultiPrimaryKey.js';
 
+const execFileAsync = promisify(execFile);
+
 describe('test/CodeGenerator.test.ts', () => {
+  it('should load templates under native ESM runtime', async () => {
+    const repoDir = path.resolve(__dirname, '../../../..');
+    const moduleDir = path.join(__dirname, './fixtures/modules/generate_codes');
+    const codeGeneratorUrl = pathToFileURL(path.join(__dirname, '../src/CodeGenerator.ts')).href;
+    const script = `
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { PrototypeUtil } from '@eggjs/core-decorator';
+import { ColumnModel, TableModel } from '@eggjs/dal-decorator';
+import { ColumnType, Templates } from '@eggjs/tegg-types';
+import { CodeGenerator } from ${JSON.stringify(codeGeneratorUrl)};
+
+class Foo {}
+PrototypeUtil.setFilePath(Foo, path.join(${JSON.stringify(moduleDir)}, 'Foo.ts'));
+
+const generator = new CodeGenerator({
+  moduleDir: ${JSON.stringify(moduleDir)},
+  moduleName: 'dal',
+  dalPkg: '@eggjs/dal-decorator',
+});
+const tableModel = new TableModel({
+  clazz: Foo,
+  name: 'egg_foo',
+  dataSourceName: 'default',
+  columns: [
+    new ColumnModel({
+      columnName: 'id',
+      propertyName: 'id',
+      type: { type: ColumnType.INT },
+      canNull: false,
+      primaryKey: true,
+    }),
+  ],
+  indices: [],
+});
+const code = generator.genCode(
+  Templates.DAO,
+  path.join(${JSON.stringify(moduleDir)}, 'dal/dao/FooDAO.ts'),
+  tableModel,
+);
+assert.match(code, /class FooDAO extends BaseFooDAO/);
+`;
+    const env = { ...process.env };
+    delete env.NODE_OPTIONS;
+
+    await execFileAsync(process.execPath, ['--import=tsx/esm', '--input-type=module', '-e', script], {
+      cwd: repoDir,
+      env,
+    });
+  });
+
   it('BaseDao should work', async () => {
     const generator = new CodeGenerator({
       moduleDir: path.join(__dirname, './fixtures/modules/generate_codes'),


### PR DESCRIPTION
## What

`@eggjs/dal-runtime` is ESM (`type: module`), so the CJS `__dirname` global is undefined at runtime. `CodeGenerator.createNunjucksEnv()` did:

```ts
this.njkEnv = nunjucks.configure(path.join(__dirname, './templates'), { autoescape: false });
```

which throws `ReferenceError: __dirname is not defined` whenever the dal code generator runs (e.g. `egg-bin generate dal code <module>`).

## Fix

Restore `__dirname` from `import.meta.url`:

```ts
import { fileURLToPath } from 'node:url';
const __dirname = path.dirname(fileURLToPath(import.meta.url));
```

Verified the built output keeps `import.meta.url` and resolves `./templates` next to the emitted file; reproduced the original crash and confirmed it's gone after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template lookup to work correctly when running as a native ESM package.
* **Tests**
  * Added an integration-style test to verify template loading and generated output under an ESM runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->