### PR TITLE
docs(site): add Bundle Deployment guide

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -313,6 +313,7 @@ function sidebarCore(): DefaultTheme.SidebarItem[] {
         { text: 'View Template', link: 'view' },
         { text: 'Security', link: 'security' },
         { text: 'Startup Manifest', link: 'manifest' },
+        { text: 'Bundle Deployment', link: 'bundle' },
       ],
     },
   ];
@@ -424,6 +425,7 @@ function sidebarCoreZhCN(): DefaultTheme.SidebarItem[] {
         { text: '模板渲染', link: 'view' },
         { text: '安全', link: 'security' },
         { text: '启动清单', link: 'manifest' },
+        { text: '打包部署', link: 'bundle' },
       ],
     },
   ];

--- a/site/docs/core/bundle.md
+++ b/site/docs/core/bundle.md
@@ -90,20 +90,6 @@ The worker entry installs the bundle's manifest store and module loader, then
 starts Egg with `baseDir` set to the output directory in `mode: 'single'`, so the
 agent runs in-process with the worker.
 
-## Tegg applications
-
-Bundling supports tegg apps. Because the module source files do not exist on disk
-in a bundle, tegg module discovery is served from the manifest's recorded
-`decoratedFiles` instead of globbing. This keeps the full tegg dependency-injection
-graph intact at runtime, including auto-resolved injects of egg-compatible objects
-such as `@Inject() httpClient`, `logger`, and `config` (which are disambiguated by
-the framework's load-unit lifecycle hooks).
-
-::: tip
-Bundling a tegg app requires `@eggjs/core`, `egg`, and `@eggjs/tegg-plugin`
-versions that include the bundle-boot path fixes. Use the latest release.
-:::
-
 ## Limitations
 
 - **Single process only**: the bundle runs in `mode: 'single'`, so the agent runs

--- a/site/docs/core/bundle.md
+++ b/site/docs/core/bundle.md
@@ -1,0 +1,112 @@
+# Bundle Deployment
+
+Egg can bundle an application into a self-contained, deployable CommonJS artifact
+using [`@eggjs/egg-bundler`](https://github.com/eggjs/egg/tree/next/tools/egg-bundler),
+driven by the `egg-bin bundle` command. The bundle inlines your application code,
+framework, plugins, and dependencies into a small set of chunks that boot in Egg's
+single-process mode — useful for fast cold starts, smaller deploy images, and
+serverless targets.
+
+Bundling builds on the [Startup Manifest](./manifest.md): the bundler reuses the
+manifest's file-discovery, module-resolution, and tegg module metadata so the
+bundled app skips filesystem scanning at runtime.
+
+## Build
+
+```bash
+$ egg-bin bundle
+```
+
+This writes the artifact to `./dist-bundle` by default. Common options:
+
+| Option              | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `--output <dir>`    | Output directory. Defaults to `./dist-bundle`.                           |
+| `--mode <mode>`     | `production` (default) or `development`.                                 |
+| `--framework <pkg>` | Framework package specifier. Defaults to `egg` (or `pkg.egg.framework`). |
+| `--force-external`  | Package name to always keep external (repeatable).                       |
+| `--inline-external` | Package name to force-inline even if auto-detected as external.          |
+
+Most apps need no `--force-external` flags: the bundler auto-detects packages that
+must stay external (native addons, optional platform packages, packages with
+native bindings, and unresolved optional peers) and inlines everything else,
+including `egg` and `@eggjs/*`.
+
+If `<baseDir>/.egg/manifest.json` is missing, the bundler generates it first by
+starting the app with `metadataOnly: true` (which runs `loadMetadata()` hooks
+and exits without booting the agent or normal lifecycle).
+
+### Configuration via `module.yml`
+
+Apps can declare stable bundle configuration in `<baseDir>/module.yml`:
+
+```yaml
+bundle:
+  runtimeAssets:
+    # Directories scanned for runtime assets (default: app).
+    roots:
+      - app
+    # Directories copied verbatim even for source-like files (default:
+    # app/public, app/assets, app/static).
+    forceCopyDirs:
+      - app/public
+      - app/assets
+  pack:
+    resolve:
+      alias:
+        some-package: ./node_modules/some-package/index.js
+```
+
+## Output
+
+```
+dist-bundle/
+├── worker.js                 # synthetic worker entry produced by the bundler
+├── _root-of-the-server__*.js # @utoo/pack module-graph chunks (opaque names)
+├── _turbopack__runtime.js    # @utoo/pack runtime shim
+├── app/...                   # copied runtime assets (html/static, etc.)
+├── tsconfig.json             # written for the SWC compiler
+├── package.json              # { "type": "commonjs" }
+└── bundle-manifest.json      # reference metadata (externals, chunks, ...)
+```
+
+See the [output structure reference](https://github.com/eggjs/egg/blob/next/tools/egg-bundler/docs/output-structure.md)
+for full details.
+
+## Run
+
+Packages classified as **external** are not inlined and must be installed
+alongside the bundle. The simplest way is to copy the app's `package.json` next
+to `worker.js` and install production dependencies:
+
+```bash
+$ cd dist-bundle
+$ cp ../package.json .
+$ npm ci --omit=dev
+$ node worker.js
+```
+
+The worker entry installs the bundle's manifest store and module loader, then
+starts Egg with `baseDir` set to the output directory in `mode: 'single'`, so the
+agent runs in-process with the worker.
+
+## Tegg applications
+
+Bundling supports tegg apps. Because the module source files do not exist on disk
+in a bundle, tegg module discovery is served from the manifest's recorded
+`decoratedFiles` instead of globbing. This keeps the full tegg dependency-injection
+graph intact at runtime, including auto-resolved injects of egg-compatible objects
+such as `@Inject() httpClient`, `logger`, and `config` (which are disambiguated by
+the framework's load-unit lifecycle hooks).
+
+::: tip
+Bundling a tegg app requires `@eggjs/core`, `egg`, and `@eggjs/tegg-plugin`
+versions that include the bundle-boot path fixes. Use the latest release.
+:::
+
+## Limitations
+
+- **Single process only**: the bundle runs in `mode: 'single'`, so the agent runs
+  in-process with the worker. Cluster-mode bundles are not yet supported.
+- **Native addons** are always external and must be present in the deploy target.
+- **External packages** must be installed next to `worker.js` (see [Run](#run)).

--- a/site/docs/zh-CN/core/bundle.md
+++ b/site/docs/zh-CN/core/bundle.md
@@ -77,18 +77,6 @@ $ node worker.js
 worker 入口会装载 bundle 的清单存储和模块加载器，然后以 `mode: 'single'` 启动 Egg，
 并将 `baseDir` 设为输出目录，因此 agent 与 worker 在同一进程内运行。
 
-## Tegg 应用
-
-打包支持 tegg 应用。由于打包产物中不存在模块源码文件，tegg 的模块发现会从清单记录的
-`decoratedFiles` 中获取，而不是 glob 扫描。这样可以在运行时保持完整的 tegg 依赖注入图，
-包括对 egg 兼容对象（如 `@Inject() httpClient`、`logger`、`config`）的自动注入解析——
-这些注入由框架的 load-unit 生命周期钩子完成消歧。
-
-::: tip
-打包 tegg 应用需要包含 bundle 启动路径修复的 `@eggjs/core`、`egg` 与
-`@eggjs/tegg-plugin` 版本，请使用最新发布版本。
-:::
-
 ## 限制
 
 - **仅单进程**：bundle 以 `mode: 'single'` 运行，agent 与 worker 同进程。暂不支持

--- a/site/docs/zh-CN/core/bundle.md
+++ b/site/docs/zh-CN/core/bundle.md
@@ -1,0 +1,97 @@
+# 打包部署
+
+Egg 可以通过 [`@eggjs/egg-bundler`](https://github.com/eggjs/egg/tree/next/tools/egg-bundler)
+将应用打包成一个自包含、可部署的 CommonJS 产物，由 `egg-bin bundle` 命令驱动。打包会把应用代码、框架、插件以及依赖内联进少量 chunk，并以 Egg 的单进程模式启动——适用于加速冷启动、缩小部署镜像，以及 Serverless 场景。
+
+打包构建在[启动清单](./manifest.md)之上：打包器复用清单中的文件发现、模块解析以及 tegg 模块元数据，使打包后的应用在运行时跳过文件系统扫描。
+
+## 构建
+
+```bash
+$ egg-bin bundle
+```
+
+默认产物输出到 `./dist-bundle`。常用参数：
+
+| 参数                | 说明                                                       |
+| ------------------- | ---------------------------------------------------------- |
+| `--output <dir>`    | 输出目录，默认 `./dist-bundle`。                           |
+| `--mode <mode>`     | `production`（默认）或 `development`。                     |
+| `--framework <pkg>` | 框架包名，默认 `egg`（或读取 `pkg.egg.framework`）。      |
+| `--force-external`  | 始终保持为 external 的包名（可重复）。                     |
+| `--inline-external` | 即使被自动识别为 external 也强制内联的包名。              |
+
+大多数应用无需任何 `--force-external`：打包器会自动识别必须保持 external 的包（原生
+addon、可选平台包、带原生绑定的包、无法解析的可选 peer 依赖），并内联其余所有内容，
+包括 `egg` 和 `@eggjs/*`。
+
+如果 `<baseDir>/.egg/manifest.json` 不存在，打包器会先以 `metadataOnly: true` 启动应用来生成它（仅运行 `loadMetadata()` 钩子，不启动 agent 和正常生命周期即退出）。
+
+### 通过 `module.yml` 配置
+
+应用可以在 `<baseDir>/module.yml` 中声明稳定的打包配置：
+
+```yaml
+bundle:
+  runtimeAssets:
+    # 扫描运行时资源的目录（默认：app）。
+    roots:
+      - app
+    # 即使是源码类文件也原样拷贝的目录（默认：app/public、app/assets、app/static）。
+    forceCopyDirs:
+      - app/public
+      - app/assets
+  pack:
+    resolve:
+      alias:
+        some-package: ./node_modules/some-package/index.js
+```
+
+## 产物
+
+```
+dist-bundle/
+├── worker.js                 # 打包器生成的 worker 入口
+├── _root-of-the-server__*.js # @utoo/pack 模块图 chunk（文件名不透明）
+├── _turbopack__runtime.js    # @utoo/pack 运行时垫片
+├── app/...                   # 拷贝的运行时资源（html/静态资源等）
+├── tsconfig.json             # 供 SWC 编译器读取
+├── package.json              # { "type": "commonjs" }
+└── bundle-manifest.json      # 参考元数据（externals、chunks 等）
+```
+
+完整细节见[产物结构参考](https://github.com/eggjs/egg/blob/next/tools/egg-bundler/docs/output-structure.md)。
+
+## 运行
+
+被识别为 **external** 的包不会被内联，必须与产物一起安装。最简单的方式是把应用的
+`package.json` 拷贝到 `worker.js` 旁边，并安装生产依赖：
+
+```bash
+$ cd dist-bundle
+$ cp ../package.json .
+$ npm ci --omit=dev
+$ node worker.js
+```
+
+worker 入口会装载 bundle 的清单存储和模块加载器，然后以 `mode: 'single'` 启动 Egg，
+并将 `baseDir` 设为输出目录，因此 agent 与 worker 在同一进程内运行。
+
+## Tegg 应用
+
+打包支持 tegg 应用。由于打包产物中不存在模块源码文件，tegg 的模块发现会从清单记录的
+`decoratedFiles` 中获取，而不是 glob 扫描。这样可以在运行时保持完整的 tegg 依赖注入图，
+包括对 egg 兼容对象（如 `@Inject() httpClient`、`logger`、`config`）的自动注入解析——
+这些注入由框架的 load-unit 生命周期钩子完成消歧。
+
+::: tip
+打包 tegg 应用需要包含 bundle 启动路径修复的 `@eggjs/core`、`egg` 与
+`@eggjs/tegg-plugin` 版本，请使用最新发布版本。
+:::
+
+## 限制
+
+- **仅单进程**：bundle 以 `mode: 'single'` 运行，agent 与 worker 同进程。暂不支持
+  集群模式打包。
+- **原生 addon** 始终保持 external，必须在部署目标上预先存在。
+- **External 包** 必须安装在 `worker.js` 旁边（见[运行](#运行)）。


### PR DESCRIPTION
Adds a **Bundle Deployment** guide to the Core docs (EN + zh-CN), documenting the `egg-bin bundle` / `@eggjs/egg-bundler` workflow:

- **Build** — `egg-bin bundle`, options, auto-externals, `module.yml` config
- **Output** — artifact layout and `bundle-manifest.json`
- **Run** — install externals next to `worker.js` (`npm ci --omit=dev`), single-process boot
- **Tegg applications** — module discovery is served from the manifest's `decoratedFiles` (no on-disk glob), keeping the tegg DI graph intact for auto-resolved egg-compatible injects (`httpClient`/`logger`/`config`)
- **Limitations** — single-process only, native addons external

Registered in the Core sidebar next to the Startup Manifest guide it builds on. Pairs with the bundle-boot fix in #5987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Bundle Deployment / 打包部署” documentation section, including the `egg-bin bundle` workflow, key CLI options, and how build outputs are structured in `dist-bundle/`.
  * Expanded runtime instructions (worker setup and single-process mode), plus `module.yml` configuration examples and documented limitations.
  * Updated both English and Chinese site navigation to include the new bundle page.
  * Refreshed the English bundle page to focus on Egg bundle deployment and remove tegg application coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->