### PR TITLE
feat(tegg-loader): support async module importer override (`__EGG_MODULE_IMPORTER__`)

### DIFF
--- a/packages/typings/src/global.ts
+++ b/packages/typings/src/global.ts
@@ -1,8 +1,10 @@
-import type { BundleModuleLoader } from './index.ts';
+import type { BundleModuleLoader, ModuleImporter } from './index.ts';
 
 declare global {
   // eslint-disable-next-line no-var
   var __EGG_BUNDLE_MODULE_LOADER__: BundleModuleLoader | undefined;
+  // eslint-disable-next-line no-var
+  var __EGG_MODULE_IMPORTER__: ModuleImporter | undefined;
 }
 
 export {};

--- a/packages/typings/src/index.ts
+++ b/packages/typings/src/index.ts
@@ -4,3 +4,20 @@
  * standard import path.
  */
 export type BundleModuleLoader = (filepath: string) => unknown;
+
+/**
+ * Async module importer override for the tegg loader's file loading.
+ *
+ * When set, the loader delegates module loading to this importer instead of the
+ * built-in `await import(filePath)`. Its main use is testing with a bundler-based
+ * test runner (e.g. Vitest): when an app's egg modules are loaded by the loader
+ * via the native `import()` while the test file imports the same source through
+ * the runner's module graph, the two resolve to *different* module instances —
+ * so a class decorated as an egg proto by the loader is not the same class the
+ * test references, and `ctx.getEggObject(ClassRef)` fails with "can not get proto".
+ *
+ * A test runner can inject an importer that routes loading through its own module
+ * graph (e.g. `filePath => import(filePath)` evaluated inside the runner context),
+ * keeping a single module instance. Return value mirrors `await import()`.
+ */
+export type ModuleImporter = (filePath: string) => Promise<unknown>;

--- a/site/docs/zh-CN/core/bundle.md
+++ b/site/docs/zh-CN/core/bundle.md
@@ -13,13 +13,13 @@ $ egg-bin bundle
 
 默认产物输出到 `./dist-bundle`。常用参数：
 
-| 参数                | 说明                                                       |
-| ------------------- | ---------------------------------------------------------- |
-| `--output <dir>`    | 输出目录，默认 `./dist-bundle`。                           |
-| `--mode <mode>`     | `production`（默认）或 `development`。                     |
-| `--framework <pkg>` | 框架包名，默认 `egg`（或读取 `pkg.egg.framework`）。      |
-| `--force-external`  | 始终保持为 external 的包名（可重复）。                     |
-| `--inline-external` | 即使被自动识别为 external 也强制内联的包名。              |
+| 参数                | 说明                                                 |
+| ------------------- | ---------------------------------------------------- |
+| `--output <dir>`    | 输出目录，默认 `./dist-bundle`。                     |
+| `--mode <mode>`     | `production`（默认）或 `development`。               |
+| `--framework <pkg>` | 框架包名，默认 `egg`（或读取 `pkg.egg.framework`）。 |
+| `--force-external`  | 始终保持为 external 的包名（可重复）。               |
+| `--inline-external` | 即使被自动识别为 external 也强制内联的包名。         |
 
 大多数应用无需任何 `--force-external`：打包器会自动识别必须保持 external 的包（原生
 addon、可选平台包、带原生绑定的包、无法解析的可选 peer 依赖），并内联其余所有内容，

--- a/tegg/core/loader/src/LoaderUtil.ts
+++ b/tegg/core/loader/src/LoaderUtil.ts
@@ -99,7 +99,9 @@ export class LoaderUtil {
     // same instance the test file imports. See `ModuleImporter` in @eggjs/typings.
     if (exports == null && typeof globalThis.__EGG_MODULE_IMPORTER__ === 'function') {
       try {
-        exports = await globalThis.__EGG_MODULE_IMPORTER__(originalFilePath);
+        // Pass a POSIX-normalized path, mirroring __EGG_BUNDLE_MODULE_LOADER__,
+        // so importers behave consistently across platforms (e.g. on Windows).
+        exports = await globalThis.__EGG_MODULE_IMPORTER__(originalFilePath.split('\\').join('/'));
       } catch (e: unknown) {
         throw createLoadError(originalFilePath, e);
       }

--- a/tegg/core/loader/src/LoaderUtil.ts
+++ b/tegg/core/loader/src/LoaderUtil.ts
@@ -94,6 +94,16 @@ export class LoaderUtil {
     } catch (e: unknown) {
       throw createLoadError(originalFilePath, e);
     }
+    // Async module importer override (e.g. a Vitest runner that loads the module
+    // through its own module graph), so the proto class registered here is the
+    // same instance the test file imports. See `ModuleImporter` in @eggjs/typings.
+    if (exports == null && typeof globalThis.__EGG_MODULE_IMPORTER__ === 'function') {
+      try {
+        exports = await globalThis.__EGG_MODULE_IMPORTER__(originalFilePath);
+      } catch (e: unknown) {
+        throw createLoadError(originalFilePath, e);
+      }
+    }
     if (exports == null) {
       if (process.platform === 'win32') {
         // convert to file:// url

--- a/tegg/core/loader/test/Loader.test.ts
+++ b/tegg/core/loader/test/Loader.test.ts
@@ -11,6 +11,7 @@ import { LoaderFactory, LoaderUtil } from '../src/index.ts';
 describe('core/loader/test/Loader.test.ts', () => {
   afterEach(() => {
     globalThis.__EGG_BUNDLE_MODULE_LOADER__ = undefined;
+    globalThis.__EGG_MODULE_IMPORTER__ = undefined;
     LoaderUtil.setConfig({});
   });
 
@@ -88,6 +89,56 @@ describe('core/loader/test/Loader.test.ts', () => {
         (err: Error & { cause?: unknown }) => {
           assert.equal(err.message, '[tegg/loader] load /bundle/app/service.ts failed: bundle loader failed');
           assert.equal(err.cause, 'bundle loader failed');
+          return true;
+        },
+      );
+    });
+
+    it('should load through the async module importer when set', async () => {
+      class ImportedService {}
+      SingletonProto()(ImportedService);
+      const importedFile = '/imported/app/manager/ImportedService.ts';
+      let importerArg: string | undefined;
+      globalThis.__EGG_MODULE_IMPORTER__ = async (filePath: string) => {
+        importerArg = filePath;
+        return { ImportedService };
+      };
+
+      const prototypes = await LoaderUtil.loadFile(importedFile);
+
+      assert.equal(importerArg, importedFile);
+      assert.deepEqual(
+        prototypes.map((proto) => proto.name),
+        ['ImportedService'],
+      );
+      assert.equal(PrototypeUtil.getFilePath(ImportedService), importedFile);
+    });
+
+    it('should fall back to dynamic import when the module importer returns null', async () => {
+      const appRepoFile = path.join(__dirname, './fixtures/modules/module-for-loader/AppRepo.ts');
+      globalThis.__EGG_MODULE_IMPORTER__ = async () => null;
+
+      const prototypes = await LoaderUtil.loadFile(appRepoFile);
+
+      assert.deepEqual(
+        prototypes.map((proto) => proto.name),
+        ['AppRepo', 'AppRepo2'],
+      );
+    });
+
+    it('should wrap module importer errors', async () => {
+      const importedFile = '/imported/app/service.ts';
+      globalThis.__EGG_MODULE_IMPORTER__ = async () => {
+        throw 'importer failed';
+      };
+
+      await assert.rejects(
+        async () => {
+          await LoaderUtil.loadFile(importedFile);
+        },
+        (err: Error & { cause?: unknown }) => {
+          assert.equal(err.message, '[tegg/loader] load /imported/app/service.ts failed: importer failed');
+          assert.equal(err.cause, 'importer failed');
           return true;
         },
       );


### PR DESCRIPTION
## What

Add an optional `__EGG_MODULE_IMPORTER__` global hook to `LoaderUtil.loadFile`, mirroring the existing `__EGG_BUNDLE_MODULE_LOADER__` bundle hook. When set, the loader delegates module loading to it instead of the built-in `await import()`.

```ts
// tegg/core/loader/src/LoaderUtil.ts — loadFile()
if (exports == null && typeof globalThis.__EGG_MODULE_IMPORTER__ === 'function') {
  exports = await globalThis.__EGG_MODULE_IMPORTER__(originalFilePath);
}
// ...existing native fallback
if (exports == null) {
  exports = await import(filePath);
}
```

## Why

This is an extension point for **bundler-based test runners (e.g. Vitest)**.

When an egg app is tested with the tegg packages installed as **published packages** (so the loader is externalized and uses native `import()`), while the test file imports the same fixture source through the **runner's module graph** (Vite), the same file resolves to **two different module instances**. The proto registry keys by the class object (`Reflect.defineMetadata(CLAZZ_PROTO, proto, clazz)`), so the class the loader registered is not the class the test holds, and:

```
await ctx.getEggObject(HelloService) // → Error: can not get proto for clazz HelloService
```

eggjs's **own** tests don't hit this because the tegg packages resolve to **workspace source** (inlined by Vite), so the loader already imports through Vite and there is a single instance.

Downstream consumers (e.g. tegg distributed as published `@scope/*` packages) can route the loader's import through the runner by setting the hook in a **Vitest setupFile** (which is Vite-processed, so its `import` is the runner's):

```ts
// vitest setupFile
globalThis.__EGG_MODULE_IMPORTER__ = (filePath) => import(filePath);
```

This keeps one module instance → the loader-registered class === the test's class → `getEggObject(ClassRef)` works. (A follow-up can wire this provision into `@eggjs/tegg-vitest` / `@eggjs/mock`'s `setup_vitest` so it is out-of-box.)

## Notes

- No behavior change when the hook is unset (default path unchanged).
- Errors from the importer are wrapped the same way as the bundle loader and the native import.
- Type added as `ModuleImporter` in `@eggjs/typings` and declared on `globalThis`, mirroring `BundleModuleLoader`.

## Test

Added 3 cases to `tegg/core/loader/test/Loader.test.ts` mirroring the bundle-loader tests (load through importer / fall through on null / wrap errors). `vitest run tegg/core/loader/test/Loader.test.ts` → 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a custom async module importer via a new global hook, allowing an injected importer to override module resolution before the default loader fallback.
* **Tests**
  * Expanded loader tests to cover the new async importer behavior, including correct importer invocation, fallback when it returns `null`, and wrapped error reporting when it throws.
* **Documentation**
  * Updated the `egg-bin bundle` command parameter table formatting (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->