### PR TITLE
feat(utils): consume `__EGG_MODULE_IMPORTER__` in importModule

### DIFF
--- a/packages/utils/src/import.ts
+++ b/packages/utils/src/import.ts
@@ -501,6 +501,21 @@ export async function importModule(filepath: string, options?: ImportModuleOptio
     return obj;
   }
 
+  // Async module importer override (e.g. a Vitest runner that loads the module
+  // through its own module graph). Same `ModuleImporter` global the tegg loader
+  // uses, so app/boot files and tegg modules resolve via one realm under test.
+  const _moduleImporter = globalThis.__EGG_MODULE_IMPORTER__;
+  if (_moduleImporter) {
+    let obj = (await _moduleImporter(moduleFilePath)) as any;
+    if (obj && typeof obj === 'object' && obj.default?.__esModule === true && obj.default && 'default' in obj.default) {
+      obj = obj.default;
+    }
+    if (options?.importDefaultOnly && obj && typeof obj === 'object' && 'default' in obj) {
+      obj = obj.default;
+    }
+    return obj;
+  }
+
   let obj: any;
   if (isESM) {
     // esm

--- a/packages/utils/test/module-importer.test.ts
+++ b/packages/utils/test/module-importer.test.ts
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert';
+
+import type {} from '@eggjs/typings/global';
+import { afterEach, describe, it } from 'vitest';
+
+import { importModule } from '../src/import.ts';
+import { getFilepath } from './helper.ts';
+
+describe('test/module-importer.test.ts', () => {
+  afterEach(() => {
+    globalThis.__EGG_MODULE_IMPORTER__ = undefined;
+  });
+
+  it('returns the real module when no importer is registered', async () => {
+    const result = await importModule(getFilepath('esm'));
+    assert.ok(result);
+    assert.equal(typeof result, 'object');
+  });
+
+  it('intercepts importModule with the registered async importer', async () => {
+    const seen: string[] = [];
+    const fakeModule = { default: { hello: 'importer' }, other: 'stuff' };
+    globalThis.__EGG_MODULE_IMPORTER__ = async (p: string) => {
+      seen.push(p);
+      return fakeModule;
+    };
+
+    const result = await importModule(getFilepath('esm'));
+    assert.deepEqual(result, fakeModule);
+    assert.ok(seen.some((p) => /[\\/]fixtures[\\/]esm[\\/]index\.js$/.test(p)));
+  });
+
+  it('honors importDefaultOnly when the importer result has a default key', async () => {
+    globalThis.__EGG_MODULE_IMPORTER__ = async () => ({ default: { greet: 'hi' }, other: 'x' });
+
+    const result = await importModule(getFilepath('esm'), { importDefaultOnly: true });
+    assert.deepEqual(result, { greet: 'hi' });
+  });
+
+  it('unwraps the __esModule double-default shape', async () => {
+    globalThis.__EGG_MODULE_IMPORTER__ = async () => ({
+      default: { __esModule: true, default: { fn: 'imported' } },
+    });
+
+    const result = await importModule(getFilepath('esm'));
+    assert.equal(result.__esModule, true);
+    assert.deepEqual(result.default, { fn: 'imported' });
+  });
+
+  it('takes precedence over the native dynamic import', async () => {
+    globalThis.__EGG_MODULE_IMPORTER__ = async () => ({ fromImporter: true });
+
+    const result = await importModule(getFilepath('esm'));
+    assert.deepEqual(result, { fromImporter: true });
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #5989. That PR added the `ModuleImporter` type + `__EGG_MODULE_IMPORTER__` global declaration and made **`@eggjs/tegg-loader`** consume it. This PR extends the same hook to **egg-core's module/boot-file loading** in `@eggjs/utils` `importModule()`:

```ts
const _moduleImporter = globalThis.__EGG_MODULE_IMPORTER__;
if (_moduleImporter) {
  let obj = await _moduleImporter(moduleFilePath);
  // …same default/__esModule unwrapping as the other loaders
  return obj;
}
// …existing native `await import(fileUrl)` fallback
```

## Why

`importModule()` is what egg-core uses to load plugin boot files (`app.ts`, `app/extend/*.ts`) and config. Under a bundler-based test runner (Vitest) the worker thread loads these via native `import()`, which (a) can't transpile TS `enum`/decorators in boot files (`"enum is not supported in strip-only mode"`), and (b) puts them in a different module realm than the test file — so the tegg-loader hook alone (which covers tegg *modules*) isn't enough; the app's boot graph still loads natively.

Routing `importModule` through the same `__EGG_MODULE_IMPORTER__` (e.g. `filePath => import(filePath)` evaluated in the runner context) makes the whole app — boot files, config, and tegg modules — resolve through one module graph. This is what lets a downstream tegg distribution (published `@scope/*` packages, externalized by the runner) boot its app fixtures and run `ctx.getEggObject(ImportedClass)` against a single class instance.

## Notes

- No behavior change when the hook is unset (default native path unchanged).
- Mirrors the existing `__EGG_BUNDLE_MODULE_LOADER__` / `_snapshotModuleLoader` overrides and the `@eggjs/tegg-loader` consumer from #5989, including the default/`__esModule` unwrapping.
- The `ModuleImporter` type + global are already on `next` (from #5989).

## Test

Added `packages/utils/test/module-importer.test.ts` (load through importer / importDefaultOnly / __esModule unwrap / precedence over native import). `vitest run packages/utils/test/module-importer.test.ts` → green; existing bundle/snapshot import tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced customizable module loading framework supporting external resolution strategies and flexible export handling, enabling advanced import configurations and third-party system integration
* **Tests**
  * Added comprehensive test coverage for module interception capabilities, validating export behavior, selective export modes, and custom resolution precedence over standard imports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->