### PR TITLE
fix(aop): register GlobalGraph build hooks before moduleHandler.ready()

### DIFF
--- a/tegg/plugin/aop/src/app.ts
+++ b/tegg/plugin/aop/src/app.ts
@@ -36,10 +36,15 @@ export default class AopAppHook implements ILifecycleBoot {
   }
 
   async didLoad(): Promise<void> {
+    // Register the GlobalGraph build hooks BEFORE moduleHandler.ready(). ready()
+    // triggers EggModuleLoader.load() -> globalGraph.build(), which is what runs
+    // the registered build hooks. Registering on GlobalGraph.instance *after*
+    // ready() is too late — the build has already run — so cross-loadUnit
+    // crosscut/pointcut advice weaving silently never happens.
+    this.app.moduleHandler.registerGlobalGraphBuildHook(crossCutGraphHook);
+    this.app.moduleHandler.registerGlobalGraphBuildHook(pointCutGraphHook);
     await this.app.moduleHandler.ready();
     assert(GlobalGraph.instance, 'GlobalGraph.instance is not set');
-    GlobalGraph.instance.registerBuildHook(crossCutGraphHook);
-    GlobalGraph.instance.registerBuildHook(pointCutGraphHook);
     this.aopContextHook = new AopContextHook(this.app.moduleHandler);
     this.app.eggContextLifecycleUtil.registerLifecycle(this.aopContextHook);
   }

--- a/tegg/plugin/aop/test/aop.test.ts
+++ b/tegg/plugin/aop/test/aop.test.ts
@@ -36,4 +36,12 @@ describe('plugin/aop/test/aop.test.ts', () => {
       msg: 'withContextPointAroundResult(hello withContextPointAroundParam(foo))',
     });
   });
+
+  it('cross-loadUnit module aop should work', async () => {
+    app.mockCsrf();
+    const res = await app.httpRequest().get('/crossModuleAop').expect(200);
+    expect(res.body).toEqual({
+      msg: 'withCrossModuleResult(helloCross withCrossModuleParam(foo))',
+    });
+  });
 });

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/app/controller/app.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/app/controller/app.ts
@@ -16,4 +16,11 @@ export default class App extends Controller {
     this.ctx.status = 200;
     this.ctx.body = { msg };
   }
+
+  async crossModuleAop(): Promise<void> {
+    const hello: Hello = await this.ctx.module.aopModule.hello;
+    const msg = await hello.helloCross('foo');
+    this.ctx.status = 200;
+    this.ctx.body = { msg };
+  }
 }

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/app/router.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/app/router.ts
@@ -3,4 +3,5 @@ import type { Application } from 'egg';
 export default (app: Application): void => {
   app.router.get('/aop', app.controller.app.aop);
   app.router.get('/singletonAop', app.controller.app.contextAdviceWithSingleton);
+  app.router.get('/crossModuleAop', app.controller.app.crossModuleAop);
 };

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/config/module.json
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/config/module.json
@@ -1,5 +1,8 @@
 [
   {
     "path": "../modules/aop-module"
+  },
+  {
+    "path": "../modules/aop-cross-module"
   }
 ]

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/CrossModuleAdvice.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/CrossModuleAdvice.ts
@@ -1,0 +1,20 @@
+import { Advice, type AdviceContext, Crosscut, type IAdvice, PointcutType } from '@eggjs/tegg/aop';
+
+import { Hello } from '../aop-module/Hello.js';
+
+// This advice lives in a different module (loadUnit) than its target `Hello`.
+// `Hello`'s loadUnit is built before this module's advice is registered, so it
+// exercises the cross-loadUnit crosscut weaving path (the GlobalGraph build hook).
+@Crosscut({
+  type: PointcutType.CLASS,
+  clazz: Hello,
+  methodName: 'helloCross',
+})
+@Advice()
+export class CrossModuleAdvice implements IAdvice<Hello> {
+  async around(ctx: AdviceContext<Hello>, block: () => Promise<any>): Promise<any> {
+    ctx.args[0] = `withCrossModuleParam(${ctx.args[0]})`;
+    const result = await block();
+    return `withCrossModuleResult(${result})`;
+  }
+}

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/package.json
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "aop-cross-module",
+  "type": "module",
+  "eggModule": {
+    "name": "aopCrossModule"
+  }
+}

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
@@ -28,6 +28,11 @@ export class Hello {
   async helloEggObjectAop(): Promise<void> {
     this.logger.info('foo');
   }
+
+  // Crosscut from another module (aop-cross-module) to exercise cross-loadUnit weaving.
+  async helloCross(name: string): Promise<string> {
+    return `helloCross ${name}`;
+  }
 }
 
 @Crosscut({

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
@@ -75,4 +75,10 @@ export class SingletonHello {
   async helloEggObjectAop(): Promise<void> {
     this.logger.info('foo');
   }
+
+  // Keep SingletonHello structurally compatible with Hello (the controller assigns
+  // singletonHello to a `Hello`-typed variable).
+  async helloCross(name: string): Promise<string> {
+    return `helloCross ${name}`;
+  }
 }


### PR DESCRIPTION
## Bug

`AopAppHook.didLoad()` registers the `crossCutGraphHook` / `pointCutGraphHook` GlobalGraph build hooks **after** `await this.app.moduleHandler.ready()`:

```ts
async didLoad() {
  await this.app.moduleHandler.ready();          // <- builds the graph here
  GlobalGraph.instance.registerBuildHook(crossCutGraphHook);   // <- too late
  GlobalGraph.instance.registerBuildHook(pointCutGraphHook);
}
```

But `moduleHandler.ready()` → `EggModuleLoader.load()` → `globalGraph.build()`, and `build()` is exactly what runs the registered build hooks. Registering on `GlobalGraph.instance` after `ready()` is too late — the build already ran — so **the build hooks never execute**.

The effect: **cross-loadUnit crosscut/pointcut advice weaving silently never happens.** A class crosscut by an `@Advice` `@Crosscut` from *another* loadUnit (e.g. an advice in plugin/module B targeting a class in plugin/module A) is never woven. Same-loadUnit AOP still works because `LoadUnitAopHook.postCreate` builds its `ASPECT_LIST` directly, so the bug is easy to miss.

## Fix

Register the hooks via `moduleHandler.registerGlobalGraphBuildHook()` **before** `ready()`, so they're queued (`pendingBuildHooks`) and registered onto the graph before `build()` runs:

```ts
async didLoad() {
  this.app.moduleHandler.registerGlobalGraphBuildHook(crossCutGraphHook);
  this.app.moduleHandler.registerGlobalGraphBuildHook(pointCutGraphHook);
  await this.app.moduleHandler.ready();
  ...
}
```

## Test

Adds a cross-loadUnit crosscut fixture: a new module `aop-cross-module` whose `@Crosscut` advice targets `aop-module`'s `Hello.helloCross` (the advice and the target live in different loadUnits, and the target's loadUnit is built first). The new `cross-loadUnit module aop should work` test **fails without this fix** (advice not woven, returns the bare result) and **passes with it**. Existing same-loadUnit AOP tests are unchanged.

Found while migrating a downstream tegg distribution where a tracer advice cross-cut a DAL plugin's `generateSql` to inject SQL comments — the advice silently never applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AOP advice weaving by registering global graph build hooks early, so cross-cut and point-cut advice is applied correctly during module initialization.
* **New Features**
  * Added cross-module AOP coverage, including a new cross-module advice scenario and supporting test app route.
* **Tests**
  * Added a new end-to-end test for the cross-module AOP case, with new fixture modules and advice to validate expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->