### PR TITLE
feat(utils): consume `__EGG_MODULE_IMPORTER__` in importModule

### DIFF
--- a/packages/utils/src/import.ts
+++ b/packages/utils/src/import.ts
@@ -501,6 +501,21 @@ export async function importModule(filepath: string, options?: ImportModuleOptio
     return obj;
   }
 
+  // Async module importer override (e.g. a Vitest runner that loads the module
+  // through its own module graph). Same `ModuleImporter` global the tegg loader
+  // uses, so app/boot files and tegg modules resolve via one realm under test.
+  const _moduleImporter = globalThis.__EGG_MODULE_IMPORTER__;
+  if (_moduleImporter) {
+    let obj = (await _moduleImporter(moduleFilePath)) as any;
+    if (obj && typeof obj === 'object' && obj.default?.__esModule === true && obj.default && 'default' in obj.default) {
+      obj = obj.default;
+    }
+    if (options?.importDefaultOnly && obj && typeof obj === 'object' && 'default' in obj) {
+      obj = obj.default;
+    }
+    return obj;
+  }
+
   let obj: any;
   if (isESM) {
     // esm

--- a/packages/utils/test/module-importer.test.ts
+++ b/packages/utils/test/module-importer.test.ts
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert';
+
+import type {} from '@eggjs/typings/global';
+import { afterEach, describe, it } from 'vitest';
+
+import { importModule } from '../src/import.ts';
+import { getFilepath } from './helper.ts';
+
+describe('test/module-importer.test.ts', () => {
+  afterEach(() => {
+    globalThis.__EGG_MODULE_IMPORTER__ = undefined;
+  });
+
+  it('returns the real module when no importer is registered', async () => {
+    const result = await importModule(getFilepath('esm'));
+    assert.ok(result);
+    assert.equal(typeof result, 'object');
+  });
+
+  it('intercepts importModule with the registered async importer', async () => {
+    const seen: string[] = [];
+    const fakeModule = { default: { hello: 'importer' }, other: 'stuff' };
+    globalThis.__EGG_MODULE_IMPORTER__ = async (p: string) => {
+      seen.push(p);
+      return fakeModule;
+    };
+
+    const result = await importModule(getFilepath('esm'));
+    assert.deepEqual(result, fakeModule);
+    assert.ok(seen.some((p) => /[\\/]fixtures[\\/]esm[\\/]index\.js$/.test(p)));
+  });
+
+  it('honors importDefaultOnly when the importer result has a default key', async () => {
+    globalThis.__EGG_MODULE_IMPORTER__ = async () => ({ default: { greet: 'hi' }, other: 'x' });
+
+    const result = await importModule(getFilepath('esm'), { importDefaultOnly: true });
+    assert.deepEqual(result, { greet: 'hi' });
+  });
+
+  it('unwraps the __esModule double-default shape', async () => {
+    globalThis.__EGG_MODULE_IMPORTER__ = async () => ({
+      default: { __esModule: true, default: { fn: 'imported' } },
+    });
+
+    const result = await importModule(getFilepath('esm'));
+    assert.equal(result.__esModule, true);
+    assert.deepEqual(result.default, { fn: 'imported' });
+  });
+
+  it('takes precedence over the native dynamic import', async () => {
+    globalThis.__EGG_MODULE_IMPORTER__ = async () => ({ fromImporter: true });
+
+    const result = await importModule(getFilepath('esm'));
+    assert.deepEqual(result, { fromImporter: true });
+  });
+});


### PR DESCRIPTION
Re-opened from a same-repo branch so CodeQL code scanning runs (the fork-based #5990 was permanently `BLOCKED` waiting on CodeQL results that never arrive for fork PRs). Supersedes #5990.

## What

Follow-up to #5989. That PR added the `ModuleImporter` type + `__EGG_MODULE_IMPORTER__` global and made `@eggjs/tegg-loader` consume it. This extends the same hook to egg-core's module/boot-file loading in `@eggjs/utils` `importModule()`:

```ts
const _moduleImporter = globalThis.__EGG_MODULE_IMPORTER__;
if (_moduleImporter) {
  let obj = await _moduleImporter(moduleFilePath);
  // …same default/__esModule unwrapping as the other loaders
  return obj;
}
// …existing native `await import(fileUrl)` fallback
```

## Why

`importModule()` loads plugin boot files (`app.ts`, `app/extend/*.ts`) and config. Under a bundler-based test runner (Vitest) the worker thread loads these via native `import()`, which can't transpile TS `enum`/decorators in boot files and puts them in a different module realm than the test. Routing `importModule` through the same `__EGG_MODULE_IMPORTER__` makes boot files, config, and tegg modules resolve through one module graph — which is what lets a downstream tegg distribution (externalized published packages) boot its app fixtures and run `ctx.getEggObject(ImportedClass)` against a single class instance.

- No behavior change when the hook is unset.
- Mirrors `__EGG_BUNDLE_MODULE_LOADER__` / `_snapshotModuleLoader` and the `@eggjs/tegg-loader` consumer from #5989.
- The `ModuleImporter` type + global are already on `next`.

## Test

Adds `packages/utils/test/module-importer.test.ts` (load through importer / importDefaultOnly / __esModule unwrap / precedence over native import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a global async module importer hook, allowing module loading to be intercepted before the standard import flow.
  * Module results are now normalized consistently, including default-only handling and nested default export shapes.

* **Tests**
  * Added coverage for standard loading, importer interception, default-only behavior, export normalization, and precedence over native import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->