### PR TITLE
fix(aop): register GlobalGraph build hooks before moduleHandler.ready()

### DIFF
--- a/tegg/plugin/aop/src/app.ts
+++ b/tegg/plugin/aop/src/app.ts
@@ -36,10 +36,15 @@ export default class AopAppHook implements ILifecycleBoot {
   }
 
   async didLoad(): Promise<void> {
+    // Register the GlobalGraph build hooks BEFORE moduleHandler.ready(). ready()
+    // triggers EggModuleLoader.load() -> globalGraph.build(), which is what runs
+    // the registered build hooks. Registering on GlobalGraph.instance *after*
+    // ready() is too late — the build has already run — so cross-loadUnit
+    // crosscut/pointcut advice weaving silently never happens.
+    this.app.moduleHandler.registerGlobalGraphBuildHook(crossCutGraphHook);
+    this.app.moduleHandler.registerGlobalGraphBuildHook(pointCutGraphHook);
     await this.app.moduleHandler.ready();
     assert(GlobalGraph.instance, 'GlobalGraph.instance is not set');
-    GlobalGraph.instance.registerBuildHook(crossCutGraphHook);
-    GlobalGraph.instance.registerBuildHook(pointCutGraphHook);
     this.aopContextHook = new AopContextHook(this.app.moduleHandler);
     this.app.eggContextLifecycleUtil.registerLifecycle(this.aopContextHook);
   }

--- a/tegg/plugin/aop/test/aop.test.ts
+++ b/tegg/plugin/aop/test/aop.test.ts
@@ -36,4 +36,12 @@ describe('plugin/aop/test/aop.test.ts', () => {
       msg: 'withContextPointAroundResult(hello withContextPointAroundParam(foo))',
     });
   });
+
+  it('cross-loadUnit module aop should work', async () => {
+    app.mockCsrf();
+    const res = await app.httpRequest().get('/crossModuleAop').expect(200);
+    expect(res.body).toEqual({
+      msg: 'withCrossModuleResult(helloCross withCrossModuleParam(foo))',
+    });
+  });
 });

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/app/controller/app.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/app/controller/app.ts
@@ -16,4 +16,11 @@ export default class App extends Controller {
     this.ctx.status = 200;
     this.ctx.body = { msg };
   }
+
+  async crossModuleAop(): Promise<void> {
+    const hello: Hello = await this.ctx.module.aopModule.hello;
+    const msg = await hello.helloCross('foo');
+    this.ctx.status = 200;
+    this.ctx.body = { msg };
+  }
 }

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/app/router.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/app/router.ts
@@ -3,4 +3,5 @@ import type { Application } from 'egg';
 export default (app: Application): void => {
   app.router.get('/aop', app.controller.app.aop);
   app.router.get('/singletonAop', app.controller.app.contextAdviceWithSingleton);
+  app.router.get('/crossModuleAop', app.controller.app.crossModuleAop);
 };

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/config/module.json
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/config/module.json
@@ -1,5 +1,8 @@
 [
   {
     "path": "../modules/aop-module"
+  },
+  {
+    "path": "../modules/aop-cross-module"
   }
 ]

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/CrossModuleAdvice.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/CrossModuleAdvice.ts
@@ -1,0 +1,20 @@
+import { Advice, type AdviceContext, Crosscut, type IAdvice, PointcutType } from '@eggjs/tegg/aop';
+
+import { Hello } from '../aop-module/Hello.js';
+
+// This advice lives in a different module (loadUnit) than its target `Hello`.
+// `Hello`'s loadUnit is built before this module's advice is registered, so it
+// exercises the cross-loadUnit crosscut weaving path (the GlobalGraph build hook).
+@Crosscut({
+  type: PointcutType.CLASS,
+  clazz: Hello,
+  methodName: 'helloCross',
+})
+@Advice()
+export class CrossModuleAdvice implements IAdvice<Hello> {
+  async around(ctx: AdviceContext<Hello>, block: () => Promise<any>): Promise<any> {
+    ctx.args[0] = `withCrossModuleParam(${ctx.args[0]})`;
+    const result = await block();
+    return `withCrossModuleResult(${result})`;
+  }
+}

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/package.json
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-cross-module/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "aop-cross-module",
+  "type": "module",
+  "eggModule": {
+    "name": "aopCrossModule"
+  }
+}

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
@@ -28,6 +28,11 @@ export class Hello {
   async helloEggObjectAop(): Promise<void> {
     this.logger.info('foo');
   }
+
+  // Crosscut from another module (aop-cross-module) to exercise cross-loadUnit weaving.
+  async helloCross(name: string): Promise<string> {
+    return `helloCross ${name}`;
+  }
 }
 
 @Crosscut({

--- a/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
+++ b/tegg/plugin/aop/test/fixtures/apps/aop-app/modules/aop-module/Hello.ts
@@ -75,4 +75,10 @@ export class SingletonHello {
   async helloEggObjectAop(): Promise<void> {
     this.logger.info('foo');
   }
+
+  // Keep SingletonHello structurally compatible with Hello (the controller assigns
+  // singletonHello to a `Hello`-typed variable).
+  async helloCross(name: string): Promise<string> {
+    return `helloCross ${name}`;
+  }
 }


### PR DESCRIPTION
Re-opened from a same-repo branch so CodeQL code scanning runs (the fork-based #5991 was permanently `BLOCKED` waiting on CodeQL results that never arrive for fork PRs). Supersedes #5991.

## Bug

`AopAppHook.didLoad()` registers the `crossCutGraphHook` / `pointCutGraphHook` GlobalGraph build hooks **after** `await this.app.moduleHandler.ready()`. But `ready()` → `EggModuleLoader.load()` → `globalGraph.build()`, and `build()` is what runs the registered build hooks. Registering on `GlobalGraph.instance` after `ready()` is too late — the build already ran — so **the build hooks never execute** and cross-loadUnit crosscut/pointcut advice weaving silently never happens (same-loadUnit AOP still works via `LoadUnitAopHook.postCreate`, so it's easy to miss).

## Fix

Register via `moduleHandler.registerGlobalGraphBuildHook()` **before** `ready()`, so the hooks are queued (`pendingBuildHooks`) and registered onto the graph before `build()` runs.

## Test

Adds a cross-loadUnit crosscut fixture: a new module `aop-cross-module` whose `@Crosscut` advice targets `aop-module`'s `Hello.helloCross` (advice and target in different loadUnits, target built first). The new `cross-loadUnit module aop should work` test fails without the fix and passes with it.

Found while migrating a downstream tegg distribution where a tracer advice cross-cut a DAL plugin's `generateSql` to inject SQL comments — the advice silently never applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cross-module AOP weaving so advice can now apply across module boundaries.
  * Introduced a new endpoint that returns a wrapped response demonstrating cross-module interception.

* **Bug Fixes**
  * Fixed hook registration timing so advice is set up early enough to take effect during app startup.

* **Tests**
  * Added coverage for cross-module AOP behavior to verify the new endpoint responds as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->