### PR TITLE
fix(controller): resolve MCP global middleware lazily on first request

### DIFF
--- a/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
+++ b/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
@@ -112,7 +112,7 @@ export class MCPControllerRegister implements ControllerRegister {
   > = new Map();
 
   static hooks: MCPControllerHook[] = [];
-  globalMiddlewares: compose.ComposedMiddleware<EggContext>;
+  globalMiddlewares?: compose.ComposedMiddleware<EggContext>;
 
   registerMap: Record<
     string,
@@ -165,9 +165,7 @@ export class MCPControllerRegister implements ControllerRegister {
     const postRouterFunc = this.router.post;
     const self = this;
     let mw = (self.app.middleware as any).teggCtxLifecycleMiddleware();
-    if (self.globalMiddlewares) {
-      mw = compose([mw, self.globalMiddlewares]);
-    }
+    mw = self.composeGlobalMiddleware(mw);
     const initHandler = async (ctx: Context) => {
       // Create fresh transport and server per request
       // MCP SDK >= 1.26 requires stateless transports to be single-use
@@ -249,9 +247,7 @@ export class MCPControllerRegister implements ControllerRegister {
     const allRouterFunc = this.router.all;
     const self = this;
     let mw = (self.app.middleware as any).teggCtxLifecycleMiddleware();
-    if (self.globalMiddlewares) {
-      mw = compose([mw, self.globalMiddlewares]);
-    }
+    mw = self.composeGlobalMiddleware(mw);
     const initHandler = async (ctx: Context) => {
       ctx.respond = false;
       if (MCPControllerRegister.hooks.length > 0) {
@@ -446,9 +442,7 @@ export class MCPControllerRegister implements ControllerRegister {
   sseCtxStorageRun(ctx: Context, transport: SSEServerTransport, name?: string): void {
     const self = this;
     let mw = (this.app.middleware as any).teggCtxLifecycleMiddleware();
-    if (self.globalMiddlewares) {
-      mw = compose([mw, self.globalMiddlewares]);
-    }
+    mw = self.composeGlobalMiddleware(mw);
     const closeFunc = transport.onclose;
     transport.onclose = () => {
       closeFunc?.();
@@ -511,9 +505,7 @@ export class MCPControllerRegister implements ControllerRegister {
     const self = this;
 
     let mw = (self.app.middleware as any).teggCtxLifecycleMiddleware();
-    if (self.globalMiddlewares) {
-      mw = compose([mw, self.globalMiddlewares]);
-    }
+    mw = self.composeGlobalMiddleware(mw);
     const messageHander = async (ctx: Context) => {
       const sessionId = ctx.query.sessionId as string;
 
@@ -569,6 +561,16 @@ export class MCPControllerRegister implements ControllerRegister {
   }
 
   getGlobalMiddleware(): void {
+    // Build once. The named middleware factories come from `app.middlewares`,
+    // which is only populated by `loadMiddleware`. Controller registration runs
+    // during the tegg load-unit init (postCreate), before `loadMiddleware`, so
+    // this is invoked lazily on the first request (see `composeGlobalMiddleware`)
+    // instead of at registration time — otherwise registering a controller whose
+    // `config.mcp.middleware` names a middleware throws `Middleware xxx not found`
+    // at boot.
+    if (this.globalMiddlewares) {
+      return;
+    }
     const middlewareNames = this.app.config.mcp.middleware || [];
     const middlewares: compose.Middleware<EggContext>[] = [];
     for (const name of middlewareNames) {
@@ -582,6 +584,18 @@ export class MCPControllerRegister implements ControllerRegister {
       middlewares.push(mw);
     }
     this.globalMiddlewares = compose(middlewares);
+  }
+
+  // Wrap a base middleware so the configured global middlewares are resolved and
+  // composed on the first request (when `app.middlewares` is ready), not at
+  // registration time. Safe to install during controller registration.
+  composeGlobalMiddleware(mw: compose.Middleware<EggContext>): compose.Middleware<EggContext> {
+    const self = this;
+    return async (ctx, next) => {
+      self.getGlobalMiddleware();
+      const composed = self.globalMiddlewares ? compose([mw, self.globalMiddlewares]) : mw;
+      return composed(ctx as any, next);
+    };
   }
 
   mcpServerPing(server: Server, sessionId: string, name?: string): void {
@@ -616,7 +630,6 @@ export class MCPControllerRegister implements ControllerRegister {
       }
       const metadata = proto.getMetaData(CONTROLLER_META_DATA) as MCPControllerMeta;
       if (!this.mcpServerHelperMap[metadata.name ?? 'default']) {
-        this.getGlobalMiddleware();
         this.mcpServerHelperMap[metadata.name ?? 'default'] = () => {
           return new MCPServerHelper({
             name: this.controllerMeta.name ?? `chair-mcp-${metadata.name ?? this.app.name}-server`,

--- a/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
+++ b/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
@@ -591,9 +591,19 @@ export class MCPControllerRegister implements ControllerRegister {
   // registration time. Safe to install during controller registration.
   composeGlobalMiddleware(mw: compose.Middleware<EggContext>): compose.Middleware<EggContext> {
     const self = this;
+    // Resolve + compose once on the first request, then reuse the composed chain
+    // (globalMiddlewares is static after it is built) to avoid re-composing per
+    // request.
+    let resolved = false;
+    let composed: compose.Middleware<EggContext> = mw;
     return async (ctx, next) => {
-      self.getGlobalMiddleware();
-      const composed = self.globalMiddlewares ? compose([mw, self.globalMiddlewares]) : mw;
+      if (!resolved) {
+        self.getGlobalMiddleware();
+        composed = (
+          self.globalMiddlewares ? compose([mw, self.globalMiddlewares]) : mw
+        ) as compose.Middleware<EggContext>;
+        resolved = true;
+      }
       return composed(ctx as any, next);
     };
   }

--- a/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
+++ b/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
@@ -92,6 +92,27 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
     assert.throws(() => register.getGlobalMiddleware(), /Middleware nope not found/);
   });
 
+  it('wires the lazy middleware into the MCP route setup without touching app.middlewares', () => {
+    // The route-setup methods run during registration (before loadMiddleware).
+    // They must install the lazy wrapper without resolving app.middlewares.
+    const app: any = {
+      eggContainerFactory: {},
+      router: { post() {}, get() {}, del() {}, all() {} },
+      middleware: {
+        teggCtxLifecycleMiddleware: () => async (_ctx: any, next: any) => next(),
+      },
+      config: { mcp: { middleware: ['trace'] } },
+      middlewares: {}, // 'trace' not loaded yet
+    };
+    const register = new (MCPControllerRegister as any)({}, {}, app);
+
+    assert.doesNotThrow(() => register.mcpStatelessStreamServerInit());
+    assert.doesNotThrow(() => register.mcpStreamServerInit());
+    assert.doesNotThrow(() => register.mcpServerRegister());
+    // Still not resolved — deferred to the first request.
+    assert.equal(register.globalMiddlewares, undefined);
+  });
+
   it('keeps koa-compose onion ordering for multiple global middlewares', async () => {
     const { register, app } = createRegister({ middleware: ['a', 'b'] }, {});
     const order: string[] = [];

--- a/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
+++ b/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
@@ -109,6 +109,8 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
     assert.doesNotThrow(() => register.mcpStatelessStreamServerInit());
     assert.doesNotThrow(() => register.mcpStreamServerInit());
     assert.doesNotThrow(() => register.mcpServerRegister());
+    // sseCtxStorageRun wires the same lazy wrapper per SSE connection.
+    assert.doesNotThrow(() => register.sseCtxStorageRun({} as any, {} as any, 'default'));
     // Still not resolved — deferred to the first request.
     assert.equal(register.globalMiddlewares, undefined);
   });

--- a/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
+++ b/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
@@ -24,7 +24,7 @@ function createRegister(mcp: any, middlewares: any) {
   return { register, app };
 }
 
-describe('test/lib/MCPGlobalMiddleware.test.ts', () => {
+describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
   it('does not read app.middlewares at registration time', () => {
     // app.middlewares is still empty here, mirroring registration time.
     const { register } = createRegister({ middleware: ['trace'] }, {});
@@ -57,6 +57,24 @@ describe('test/lib/MCPGlobalMiddleware.test.ts', () => {
 
     assert.deepEqual(order, ['base', 'trace', 'handler']);
     assert.ok(register.globalMiddlewares, 'built and cached after first request');
+  });
+
+  it('resolves and composes the global chain once across requests', async () => {
+    const { register, app } = createRegister({ middleware: ['m'] }, {});
+    let factoryCalls = 0;
+    app.middlewares.m = () => {
+      factoryCalls++;
+      return async (_ctx: any, next: any) => next();
+    };
+    const base: any = async (_ctx: any, next: any) => next();
+    const wrapped = register.composeGlobalMiddleware(base);
+
+    await wrapped({} as any, async () => {});
+    await wrapped({} as any, async () => {});
+
+    // The middleware factory is only invoked on the first request; the composed
+    // chain is cached and reused afterwards.
+    assert.equal(factoryCalls, 1);
   });
 
   it('getGlobalMiddleware is idempotent (builds once)', () => {

--- a/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
+++ b/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+
+import compose from 'koa-compose';
+import { describe, it } from 'vitest';
+
+import { MCPControllerRegister } from '../../src/lib/impl/mcp/MCPControllerRegister.ts';
+
+// Unit tests for the lazy MCP global-middleware resolution.
+//
+// MCPControllerRegister.register() runs during the tegg load-unit init
+// (postCreate), which happens before egg's `loadMiddleware` populates
+// `app.middlewares`. The middleware named in `config.mcp.middleware` must
+// therefore be resolved lazily — on the first request — rather than at
+// registration time, otherwise booting an app that configures `mcp.middleware`
+// throws `Middleware <name> not found`.
+function createRegister(mcp: any, middlewares: any) {
+  const app: any = {
+    eggContainerFactory: {},
+    router: {},
+    config: { mcp },
+    middlewares,
+  };
+  const register = new (MCPControllerRegister as any)({}, {}, app);
+  return { register, app };
+}
+
+describe('test/lib/MCPGlobalMiddleware.test.ts', () => {
+  it('does not read app.middlewares at registration time', () => {
+    // app.middlewares is still empty here, mirroring registration time.
+    const { register } = createRegister({ middleware: ['trace'] }, {});
+    const base: any = async (_ctx: any, next: any) => next();
+
+    // Wrapping the base middleware must not throw even though `trace` is not yet
+    // available; resolution is deferred to the first request.
+    assert.doesNotThrow(() => register.composeGlobalMiddleware(base));
+    assert.equal(register.globalMiddlewares, undefined);
+  });
+
+  it('resolves and runs the configured global middleware on first request', async () => {
+    const { register, app } = createRegister({ middleware: ['trace'] }, {});
+    const order: string[] = [];
+    const base: any = async (_ctx: any, next: any) => {
+      order.push('base');
+      return next();
+    };
+    const wrapped = register.composeGlobalMiddleware(base);
+
+    // app.middlewares is populated later by loadMiddleware.
+    app.middlewares.trace = () => async (_ctx: any, next: any) => {
+      order.push('trace');
+      return next();
+    };
+
+    await wrapped({} as any, async () => {
+      order.push('handler');
+    });
+
+    assert.deepEqual(order, ['base', 'trace', 'handler']);
+    assert.ok(register.globalMiddlewares, 'built and cached after first request');
+  });
+
+  it('getGlobalMiddleware is idempotent (builds once)', () => {
+    const { register } = createRegister({ middleware: [] }, {});
+    register.getGlobalMiddleware();
+    const first = register.globalMiddlewares;
+    register.getGlobalMiddleware();
+    assert.equal(register.globalMiddlewares, first);
+  });
+
+  it('still surfaces a genuinely missing middleware at resolution time', () => {
+    // The fix defers *when* middlewares are resolved; it must not hide a real
+    // misconfiguration — an unknown name still throws once resolved.
+    const { register } = createRegister({ middleware: ['nope'] }, {});
+    assert.throws(() => register.getGlobalMiddleware(), /Middleware nope not found/);
+  });
+
+  it('keeps koa-compose onion ordering for multiple global middlewares', async () => {
+    const { register, app } = createRegister({ middleware: ['a', 'b'] }, {});
+    const order: string[] = [];
+    const make = (name: string) => () => async (_ctx: any, next: any) => {
+      order.push(`${name}:before`);
+      await next();
+      order.push(`${name}:after`);
+    };
+    app.middlewares.a = make('a');
+    app.middlewares.b = make('b');
+    const base: any = async (_ctx: any, next: any) => {
+      order.push('base');
+      return next();
+    };
+    const wrapped = register.composeGlobalMiddleware(base);
+    await wrapped({} as any, async () => order.push('handler'));
+    assert.deepEqual(order, ['base', 'a:before', 'b:before', 'handler', 'b:after', 'a:after']);
+    assert.equal(typeof compose, 'function');
+  });
+});


### PR DESCRIPTION
## Problem

`MCPControllerRegister.register()` runs during the tegg load-unit init (postCreate), which is **before** egg's `loadMiddleware` populates `app.middlewares`. It eagerly called `getGlobalMiddleware()`, resolving the names in `config.mcp.middleware` against `app.middlewares`, so booting an app that configures `mcp.middleware` throws at startup:

```
TypeError: Middleware <name> not found
  at MCPControllerRegister.getGlobalMiddleware
  at MCPControllerRegister.register
  at AppLoadUnitControllerHook.postCreate
```

## Fix

Defer the resolution to the first request, when `app.middlewares` is ready:
- `composeGlobalMiddleware(mw)` wraps the base middleware and builds/composes the global chain on first invocation.
- `getGlobalMiddleware()` is now idempotent (builds once).
- The eager call in `register()` is removed.

The middleware applied at request time is unchanged; it just no longer requires `app.middlewares` to be populated during controller registration.

## Test

`tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts` (5 cases): registration does not read `app.middlewares`; the middleware resolves & runs on first request; `getGlobalMiddleware` is idempotent; a genuinely unknown middleware still throws at resolution; koa-compose onion ordering is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global controller middleware for MCP routes is now resolved lazily at request time (no longer during startup/registration).
  * The configured global middleware runs in the correct order around the base and handler, with missing middleware names still throwing clear errors when first needed.
  * Global middleware composition is cached after the first request to prevent repeated resolution.

* **Tests**
  * Added coverage for lazy loading, caching/idempotency, execution order, error handling, and correct MCP route wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->