### PR TITLE
fix(controller): defer MCP base middleware to first request

### DIFF
--- a/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
+++ b/tegg/plugin/controller/src/lib/impl/mcp/MCPControllerRegister.ts
@@ -164,8 +164,7 @@ export class MCPControllerRegister implements ControllerRegister {
   mcpStatelessStreamServerInit(name?: string): void {
     const postRouterFunc = this.router.post;
     const self = this;
-    let mw = (self.app.middleware as any).teggCtxLifecycleMiddleware();
-    mw = self.composeGlobalMiddleware(mw);
+    const mw = self.composeGlobalMiddleware(() => (self.app.middleware as any).teggCtxLifecycleMiddleware());
     const initHandler = async (ctx: Context) => {
       // Create fresh transport and server per request
       // MCP SDK >= 1.26 requires stateless transports to be single-use
@@ -246,8 +245,7 @@ export class MCPControllerRegister implements ControllerRegister {
   mcpStreamServerInit(name?: string): void {
     const allRouterFunc = this.router.all;
     const self = this;
-    let mw = (self.app.middleware as any).teggCtxLifecycleMiddleware();
-    mw = self.composeGlobalMiddleware(mw);
+    const mw = self.composeGlobalMiddleware(() => (self.app.middleware as any).teggCtxLifecycleMiddleware());
     const initHandler = async (ctx: Context) => {
       ctx.respond = false;
       if (MCPControllerRegister.hooks.length > 0) {
@@ -441,8 +439,7 @@ export class MCPControllerRegister implements ControllerRegister {
 
   sseCtxStorageRun(ctx: Context, transport: SSEServerTransport, name?: string): void {
     const self = this;
-    let mw = (this.app.middleware as any).teggCtxLifecycleMiddleware();
-    mw = self.composeGlobalMiddleware(mw);
+    const mw = self.composeGlobalMiddleware(() => (this.app.middleware as any).teggCtxLifecycleMiddleware());
     const closeFunc = transport.onclose;
     transport.onclose = () => {
       closeFunc?.();
@@ -504,8 +501,7 @@ export class MCPControllerRegister implements ControllerRegister {
     const routerFunc = this.router.post;
     const self = this;
 
-    let mw = (self.app.middleware as any).teggCtxLifecycleMiddleware();
-    mw = self.composeGlobalMiddleware(mw);
+    const mw = self.composeGlobalMiddleware(() => (self.app.middleware as any).teggCtxLifecycleMiddleware());
     const messageHander = async (ctx: Context) => {
       const sessionId = ctx.query.sessionId as string;
 
@@ -586,18 +582,26 @@ export class MCPControllerRegister implements ControllerRegister {
     this.globalMiddlewares = compose(middlewares);
   }
 
-  // Wrap a base middleware so the configured global middlewares are resolved and
-  // composed on the first request (when `app.middlewares` is ready), not at
-  // registration time. Safe to install during controller registration.
-  composeGlobalMiddleware(mw: compose.Middleware<EggContext>): compose.Middleware<EggContext> {
+  // Wrap a base middleware so that both the base middleware itself and the
+  // configured global middlewares are resolved and composed on the first request
+  // (when `app.middleware`/`app.middlewares` are ready), not at registration time.
+  //
+  // The base middleware factory must be passed as a thunk rather than an already
+  // resolved middleware: `app.middleware.teggCtxLifecycleMiddleware` is loaded by
+  // egg's `loadMiddleware`, which runs *after* controller registration (the tegg
+  // load-unit init / postCreate). Calling it eagerly at registration time throws
+  // `teggCtxLifecycleMiddleware is not a function`. Deferring the call to the
+  // first request lets it bind once the middleware is loaded.
+  composeGlobalMiddleware(mwFactory: () => compose.Middleware<EggContext>): compose.Middleware<EggContext> {
     const self = this;
     // Resolve + compose once on the first request, then reuse the composed chain
     // (globalMiddlewares is static after it is built) to avoid re-composing per
     // request.
     let resolved = false;
-    let composed: compose.Middleware<EggContext> = mw;
+    let composed: compose.Middleware<EggContext>;
     return async (ctx, next) => {
       if (!resolved) {
+        const mw = mwFactory();
         self.getGlobalMiddleware();
         composed = (
           self.globalMiddlewares ? compose([mw, self.globalMiddlewares]) : mw

--- a/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
+++ b/tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts
@@ -32,7 +32,7 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
 
     // Wrapping the base middleware must not throw even though `trace` is not yet
     // available; resolution is deferred to the first request.
-    assert.doesNotThrow(() => register.composeGlobalMiddleware(base));
+    assert.doesNotThrow(() => register.composeGlobalMiddleware(() => base));
     assert.equal(register.globalMiddlewares, undefined);
   });
 
@@ -43,7 +43,7 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
       order.push('base');
       return next();
     };
-    const wrapped = register.composeGlobalMiddleware(base);
+    const wrapped = register.composeGlobalMiddleware(() => base);
 
     // app.middlewares is populated later by loadMiddleware.
     app.middlewares.trace = () => async (_ctx: any, next: any) => {
@@ -67,7 +67,7 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
       return async (_ctx: any, next: any) => next();
     };
     const base: any = async (_ctx: any, next: any) => next();
-    const wrapped = register.composeGlobalMiddleware(base);
+    const wrapped = register.composeGlobalMiddleware(() => base);
 
     await wrapped({} as any, async () => {});
     await wrapped({} as any, async () => {});
@@ -92,14 +92,44 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
     assert.throws(() => register.getGlobalMiddleware(), /Middleware nope not found/);
   });
 
+  it('defers the base middleware factory to the first request', async () => {
+    // `app.middleware.teggCtxLifecycleMiddleware` is loaded by egg's
+    // loadMiddleware, which runs *after* controller registration. The base
+    // middleware must therefore be acquired via a thunk on the first request,
+    // not eagerly — otherwise registration throws
+    // `teggCtxLifecycleMiddleware is not a function`.
+    const { register } = createRegister({ middleware: [] }, {});
+    let baseFactoryCalls = 0;
+    const base: any = async (_ctx: any, next: any) => next();
+    const wrapped = register.composeGlobalMiddleware(() => {
+      baseFactoryCalls++;
+      return base;
+    });
+
+    // Wrapping does not resolve the base middleware.
+    assert.equal(baseFactoryCalls, 0);
+
+    await wrapped({} as any, async () => {});
+    await wrapped({} as any, async () => {});
+
+    // Resolved exactly once, on the first request, then cached.
+    assert.equal(baseFactoryCalls, 1);
+  });
+
   it('wires the lazy middleware into the MCP route setup without touching app.middlewares', () => {
     // The route-setup methods run during registration (before loadMiddleware).
-    // They must install the lazy wrapper without resolving app.middlewares.
+    // They must install the lazy wrapper without resolving app.middlewares and
+    // without invoking the base teggCtxLifecycleMiddleware factory (which is not
+    // loaded onto app.middleware until after registration).
+    let baseMiddlewareCalls = 0;
     const app: any = {
       eggContainerFactory: {},
       router: { post() {}, get() {}, del() {}, all() {} },
       middleware: {
-        teggCtxLifecycleMiddleware: () => async (_ctx: any, next: any) => next(),
+        teggCtxLifecycleMiddleware: () => {
+          baseMiddlewareCalls++;
+          return async (_ctx: any, next: any) => next();
+        },
       },
       config: { mcp: { middleware: ['trace'] } },
       middlewares: {}, // 'trace' not loaded yet
@@ -111,8 +141,10 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
     assert.doesNotThrow(() => register.mcpServerRegister());
     // sseCtxStorageRun wires the same lazy wrapper per SSE connection.
     assert.doesNotThrow(() => register.sseCtxStorageRun({} as any, {} as any, 'default'));
-    // Still not resolved — deferred to the first request.
+    // Still not resolved — both the global middlewares and the base middleware
+    // are deferred to the first request.
     assert.equal(register.globalMiddlewares, undefined);
+    assert.equal(baseMiddlewareCalls, 0);
   });
 
   it('keeps koa-compose onion ordering for multiple global middlewares', async () => {
@@ -129,7 +161,7 @@ describe('plugin/controller/test/lib/MCPGlobalMiddleware.test.ts', () => {
       order.push('base');
       return next();
     };
-    const wrapped = register.composeGlobalMiddleware(base);
+    const wrapped = register.composeGlobalMiddleware(() => base);
     await wrapped({} as any, async () => order.push('handler'));
     assert.deepEqual(order, ['base', 'a:before', 'b:before', 'handler', 'b:after', 'a:after']);
     assert.equal(typeof compose, 'function');


### PR DESCRIPTION
Follow-up to #5994.

## Problem

The MCP route-setup methods acquire the **base** middleware eagerly during controller registration:

```ts
let mw = (app.middleware as any).teggCtxLifecycleMiddleware();
mw = self.composeGlobalMiddleware(mw);
```

`app.middleware.teggCtxLifecycleMiddleware` is loaded by egg’s `loadMiddleware`, which runs **after** controller registration (the tegg load-unit init / `postCreate`). Calling it at registration time throws:

```
TypeError: self.app.middleware.teggCtxLifecycleMiddleware is not a function
  at MCPControllerRegister.mcpStatelessStreamServerInit
  at MCPControllerRegister.register
  at AppLoadUnitControllerHook.postCreate
```

when booting an app that registers MCP controllers.

This is the **same class of bug as #5994** (eager middleware access at registration), one layer deeper: #5994 deferred the *configured global* middlewares; this defers the *base* middleware too.

## Fix

`composeGlobalMiddleware` now takes a **thunk** that resolves the base middleware on the first request, alongside the global middlewares. All four call sites (`mcpStatelessStreamServerInit`, `mcpStreamServerInit`, `sseCtxStorageRun`, `mcpServerRegister`) pass `() => app.middleware.teggCtxLifecycleMiddleware()` instead of the already-resolved middleware.

## Tests

`tegg/plugin/controller/test/lib/MCPGlobalMiddleware.test.ts` (8 tests, all green):
- new: **defers the base middleware factory to the first request** — asserts the base thunk is invoked exactly once, on the first request, not at wrap time.
- strengthened the route-setup wiring test to assert `teggCtxLifecycleMiddleware` is **not** invoked at registration.

Verified end-to-end by patching the published `@eggjs/controller-plugin@4.0.2-beta.14` dist into a downstream tegg app: the `teggCtxLifecycleMiddleware is not a function` boot error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling by delaying middleware setup until the first request, reducing unnecessary startup work.
  * Ensured middleware chains are built once and reused, keeping behavior consistent across repeated requests.
  * Preserved the expected order of global and base middleware during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->