### PR TITLE
fix(mcp-proxy): declare _client so the base APIClientBase value survives

### DIFF
--- a/tegg/plugin/mcp-proxy/src/index.ts
+++ b/tegg/plugin/mcp-proxy/src/index.ts
@@ -220,7 +220,11 @@ export const MCPProxyHook: MCPControllerHook = {
 };
 
 export class MCPProxyApiClient extends APIClientBase {
-  private _client: any;
+  // `declare`: APIClientBase's constructor assigns `this._client`. Without
+  // `declare`, this field declaration emits `this._client = undefined` after
+  // super() under useDefineForClassFields (target ES2022), masking the base
+  // value, so registerClient()/getClient() hit `undefined`.
+  declare private _client: any;
   private logger: EggLogger;
   private proxyHandlerMap: { [P in ProxyAction]?: StreamableHTTPServerTransport['handleRequest'] } = {};
   private port: number;

--- a/tegg/plugin/mcp-proxy/test/client-field-shadow.test.ts
+++ b/tegg/plugin/mcp-proxy/test/client-field-shadow.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert';
+
+import { describe, it } from 'vitest';
+
+// Regression guard for the MCPProxyApiClient `_client` field shadowing fix.
+//
+// MCPProxyApiClient extends cluster-client's APIClientBase, whose constructor
+// assigns `this._client` (the data-client delegate). Declaring `_client` as a
+// real class field (without `declare`) re-initialises it to `undefined` AFTER
+// super() under useDefineForClassFields (target ES2022) — masking the base
+// value, so registerClient()/unregisterClient()/getClient() call into undefined.
+// The field must be `declare`d so it is a type-only annotation emitting no
+// runtime initializer.
+//
+// Constructing a real cluster-client in a unit test is heavy, so this pins the
+// exact language/build semantics the fix relies on, under the same toolchain the
+// published package is built with.
+describe('plugin/mcp-proxy/test/client-field-shadow.test.ts', () => {
+  class FakeAPIClientBase {
+    _client: unknown;
+    constructor() {
+      // Mirror APIClientBase: the base sets _client in its constructor.
+      this._client = {
+        registerClient() {
+          return true;
+        },
+      };
+    }
+  }
+
+  it('a bare subclass field re-initialises the base value to undefined (the bug)', () => {
+    class Shadowed extends FakeAPIClientBase {
+      _client: unknown;
+    }
+    assert.strictEqual(new Shadowed()._client, undefined);
+  });
+
+  it('`declare` keeps the base-class value across super() (the fix)', () => {
+    class Declared extends FakeAPIClientBase {
+      declare _client: unknown;
+    }
+    const client = new Declared()._client as { registerClient(): boolean } | undefined;
+    assert.ok(client, '_client must survive super(), not be shadowed to undefined');
+    assert.strictEqual(typeof client.registerClient, 'function');
+  });
+});

--- a/tegg/plugin/mcp-proxy/test/client-field-shadow.test.ts
+++ b/tegg/plugin/mcp-proxy/test/client-field-shadow.test.ts
@@ -14,13 +14,13 @@ import { describe, it } from 'vitest';
 //
 // Constructing a real cluster-client in a unit test is heavy, so this pins the
 // exact language/build semantics the fix relies on, under the same toolchain the
-// published package is built with.
+// published package is built with. The base assigns `_client` dynamically (no
+// typed field) so the subclasses below own the declaration — mirroring how
+// cluster-client's APIClientBase sets it without a TS field.
 describe('plugin/mcp-proxy/test/client-field-shadow.test.ts', () => {
   class FakeAPIClientBase {
-    _client: unknown;
     constructor() {
-      // Mirror APIClientBase: the base sets _client in its constructor.
-      this._client = {
+      (this as { _client?: unknown })._client = {
         registerClient() {
           return true;
         },
@@ -40,7 +40,9 @@ describe('plugin/mcp-proxy/test/client-field-shadow.test.ts', () => {
       declare _client: unknown;
     }
     const client = new Declared()._client as { registerClient(): boolean } | undefined;
-    assert.ok(client, '_client must survive super(), not be shadowed to undefined');
-    assert.strictEqual(typeof client.registerClient, 'function');
+    assert.ok(
+      client && typeof client.registerClient === 'function',
+      '_client must survive super() with a working registerClient, not be shadowed to undefined',
+    );
   });
 });


### PR DESCRIPTION
## What

`MCPProxyApiClient` declares `private _client: any` while extending cluster-client's `APIClientBase`, whose constructor assigns `this._client`. Under `target: ES2022` (`useDefineForClassFields: true`) the field declaration emits `this._client = undefined` **after** `super()`, masking the base value — so `registerClient()` / `unregisterClient()` / `getClient()` call into `undefined` and MCP proxy registration fails at runtime (observed as `Cannot read properties of undefined (reading 'registerClient')`).

## Fix

Mark the field `declare` so TypeScript treats it as a type-only annotation and emits no runtime initializer, letting the base-class assignment stand. One-line change in `tegg/plugin/mcp-proxy/src/index.ts`.

```ts
-  private _client: any;
+  declare private _client: any;
```

Verified the emit difference at `target: ES2022` (default `useDefineForClassFields: true`):

```
class WithField  extends Base { _client; }   // re-inits to undefined after super()
class WithDeclare extends Base { }            // no field emit — base value survives
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the MCP proxy client reference from being unintentionally reset during initialization, improving reliability for registering, retrieving, and unregistering clients.
* **Tests**
  * Added a regression test to cover the class-field shadowing scenario under modern class-field transpilation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->