### PR TITLE
fix(egg): reopen logger streams on snapshot restore

### DIFF
--- a/packages/egg/src/lib/egg.ts
+++ b/packages/egg/src/lib/egg.ts
@@ -524,32 +524,69 @@ export class EggApplicationCore extends EggCore {
 
   /**
    * Clean up non-serializable resources before V8 heap serialization.
-   * Closes messenger (IPC listeners), loggers (file descriptors),
-   * and removes the process-level unhandledRejection listener.
+   * Closes messenger (IPC listeners), logger streams and flush timers
+   * (file descriptors), and removes the process-level unhandledRejection
+   * listener.
+   *
+   * The `EggLoggers` instance is intentionally kept (not discarded): plugins
+   * such as `@eggjs/schedule` capture individual logger references during the
+   * load phase, before serialization. Replacing them with a fresh `EggLoggers`
+   * on restore would leave those captured references pointing at closed
+   * streams (`... log stream had been closed`). Instead, `snapshotDidDeserialize`
+   * reopens these same logger objects in place.
    */
   protected snapshotWillSerialize(): void {
     this.messenger.close();
     if (this.#loggers) {
       for (const logger of this.#loggers.values()) {
+        // close() releases the file descriptor and, for buffered transports,
+        // clears the flush interval. The objects themselves stay reachable.
         logger.close();
       }
-      this.#loggers = undefined;
     }
     process.removeListener('unhandledRejection', this._unhandledRejectionHandler);
   }
 
   /**
    * Restore non-serializable resources after V8 heap deserialization.
-   * Recreates messenger, re-registers the egg-ready listener,
-   * and re-attaches the process-level unhandledRejection listener.
-   * Loggers are lazily re-created via the `loggers` getter.
+   * Recreates messenger, re-registers the egg-ready listener, reopens the
+   * logger streams closed during serialize, and re-attaches the process-level
+   * unhandledRejection listener.
    */
   protected snapshotDidDeserialize(): void {
     (this as { messenger: IMessenger }).messenger = createMessenger(this);
     this.messenger.once('egg-ready', () => {
       this.lifecycle.triggerServerDidReady();
     });
+    this.#reopenLoggers();
     process.on('unhandledRejection', this._unhandledRejectionHandler);
+  }
+
+  /**
+   * Reopen logger resources that `snapshotWillSerialize` released.
+   *
+   * `transport.reload()` reopens each `FileTransport` stream on the existing
+   * logger objects (so references captured before the snapshot keep working).
+   * `FileBufferTransport`, however, clears its flush interval in `close()` and
+   * does not restart it in `reload()`, so buffered logs would never flush after
+   * restore. Restart that interval explicitly to keep the willSerialize /
+   * didDeserialize resource pairing complete.
+   */
+  #reopenLoggers(): void {
+    if (!this.#loggers) return;
+    for (const logger of this.#loggers.values()) {
+      for (const transport of logger.values()) {
+        // No-op for ConsoleTransport; reopens the stream for file transports.
+        transport.reload();
+        const bufferTransport = transport as unknown as {
+          _timer?: NodeJS.Timeout | null;
+          _createInterval?: () => NodeJS.Timeout;
+        };
+        if (typeof bufferTransport._createInterval === 'function' && !bufferTransport._timer) {
+          bufferTransport._timer = bufferTransport._createInterval();
+        }
+      }
+    }
   }
 
   /**

--- a/packages/egg/test/snapshot.test.ts
+++ b/packages/egg/test/snapshot.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { describe, it, afterEach } from 'vitest';
@@ -119,7 +120,7 @@ describe('test/snapshot.test.ts', () => {
       assert.ok(app.messenger.listenerCount('egg-ready') >= 1, 'new messenger should have egg-ready listener');
     });
 
-    it('should clean up loggers on snapshotWillSerialize', async () => {
+    it('should keep the same EggLoggers instance across serialize/deserialize', async () => {
       app = new Application({
         baseDir: demoApp,
         mode: 'single',
@@ -128,20 +129,89 @@ describe('test/snapshot.test.ts', () => {
       await app.ready();
 
       // Access loggers to force lazy creation
-      const _loggers = app.loggers;
-      assert.ok(_loggers, 'loggers should exist');
+      const loggersBefore = app.loggers;
+      assert.ok(loggersBefore, 'loggers should exist');
 
       await app.triggerSnapshotWillSerialize();
 
-      // After serialize, loggers are cleared (set to undefined internally).
-      // Accessing loggers again would re-create them lazily.
-      // We can't directly check the private #loggers field, but we can verify
-      // that new loggers are created after deserialize.
+      // The EggLoggers instance is intentionally NOT discarded on serialize:
+      // plugins capture individual logger references during load, so replacing
+      // them with a fresh instance would orphan those captured references.
       await app.triggerSnapshotDidDeserialize();
       await new Promise<void>((resolve) => process.nextTick(resolve));
 
-      // After deserialize, loggers should be lazily re-created on access
-      assert.ok(app.loggers, 'loggers should be lazily re-created');
+      // Same instance is reused (reopened in place), not lazily re-created.
+      assert.strictEqual(app.loggers, loggersBefore, 'loggers instance should be preserved');
+    });
+
+    it('should reopen logger streams so captured references keep writing after deserialize', async () => {
+      app = new Application({
+        baseDir: demoApp,
+        mode: 'single',
+        snapshot: true,
+      });
+      await app.ready();
+      await app.loadFinished;
+
+      // Plugins such as @eggjs/schedule grab a logger reference during the load
+      // phase (in their boot hook constructor) and keep using it afterwards.
+      // Emulate that: capture the logger up-front, then drive serialize/restore.
+      const capturedLogger = app.getLogger('logger');
+      assert.ok(capturedLogger, 'logger should exist');
+
+      // Collect the file-backed transports of the captured logger.
+      const fileTransports: any[] = [...capturedLogger.values()].filter(
+        (t: any) => t.options && typeof t.options.file === 'string',
+      );
+      assert.ok(fileTransports.length > 0, 'logger should have a file transport');
+      for (const t of fileTransports) {
+        assert.equal(t.writable, true, 'file transport should be writable before serialize');
+      }
+
+      // Serialize: streams are closed and buffer flush timers cleared.
+      await app.triggerSnapshotWillSerialize();
+      for (const t of fileTransports) {
+        assert.ok(!t.writable, 'file transport should be closed after serialize');
+      }
+
+      // Deserialize: the SAME transports must be reopened (not replaced).
+      await app.triggerSnapshotDidDeserialize();
+      await new Promise<void>((resolve) => process.nextTick(resolve));
+
+      // Identity is preserved — the captured reference is still the live logger.
+      assert.strictEqual(app.getLogger('logger'), capturedLogger, 'captured logger reference should stay live');
+      for (const t of fileTransports) {
+        assert.equal(t.writable, true, 'file transport should be reopened after deserialize');
+        // Buffered transports clear their flush interval on close(); it must be
+        // restarted so buffered logs flush again.
+        if (typeof t._createInterval === 'function') {
+          assert.ok(t._timer, 'buffer flush timer should be restarted after deserialize');
+        }
+      }
+
+      // End-to-end: writing through the captured reference lands on disk
+      // instead of hitting the "log stream had been closed" path.
+      // Unique per execution so the assertion can't match a stale line left in
+      // the demo app's (append-only) log file by an earlier test run.
+      const marker = `snapshot-restore-marker-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      capturedLogger.info(marker);
+      for (const t of fileTransports) {
+        // flush buffered transports immediately so we don't wait for the interval
+        if (typeof t.flush === 'function') t.flush();
+      }
+      const appLog = fileTransports.find((t) => t.options.file.endsWith('-web.log'));
+      assert.ok(appLog, 'app web log transport should exist');
+      // flush() issues an async WriteStream.write(); poll until it reaches disk
+      // so the assertion does not race the libuv threadpool write on slow CI.
+      let landed = false;
+      for (let i = 0; i < 100 && !landed; i++) {
+        if (readFileSync(appLog.options.file, 'utf8').includes(marker)) {
+          landed = true;
+          break;
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      }
+      assert.ok(landed, 'log written after restore should reach the file');
     });
 
     it('should remove unhandledRejection handler on serialize and restore on deserialize', async () => {


### PR DESCRIPTION
## Motivation

After a V8 startup snapshot is restored, writing logs raised `... log stream had been closed` (e.g. `egg-schedule.log` when the schedule plugin's `didReady` starts).

Root cause: `EggApplicationCore.snapshotWillSerialize` closed every logger **and** discarded the `EggLoggers` instance (`#loggers = undefined`), relying on the lazy `loggers` getter to rebuild a *fresh* `EggLoggers` on restore. But plugins such as `@eggjs/schedule` capture an individual logger reference in their boot-hook **constructor** during the load phase (before serialize). The fresh `EggLoggers` left those captured references pointing at the original **closed** `FileTransport`, so writing through them after restore threw.

## Scope

`packages/egg` snapshot lifecycle resource rebuild only (no bundler changes). Preserve logger **identity** across the snapshot instead of rebuilding:

- `snapshotWillSerialize`: still `logger.close()` each logger (releases the fd and clears the `FileBufferTransport` flush interval) but **keeps** the `EggLoggers` instance.
- `snapshotDidDeserialize`: new `#reopenLoggers()` reopens the *same* logger objects in place — `transport.reload()` reopens each `FileTransport` stream, and the `FileBufferTransport` flush interval is restarted (which `close()` clears but `reload()` does not restore). This keeps the `willSerialize` / `didDeserialize` resource pairing complete and also fixes the parallel `onelogger` global-registry staleness.

Messenger (recreated) and the `unhandledRejection` listener (re-attached) were already paired; the agent keepalive timer is recreated by the lifecycle resume — no changes needed there.

## Test evidence

`packages/egg/test/snapshot.test.ts`:
- New regression test emulates a plugin capturing a logger before the snapshot, then asserts the file transport goes writable → closed → writable across serialize/deserialize, that logger **identity is preserved**, that the buffer flush timer is restarted, and that a log written through the captured reference after restore actually reaches the `-web.log` file (poll-read to avoid racing the async stream flush).
- Updated the previous "clean up loggers" test to assert instance preservation.

`pnpm --filter=egg run test test/snapshot.test.ts` → 11/11 pass. `tsgo --noEmit` clean. (Pre-existing unrelated failures in `test/lib/core/logger.test.ts` are present on `next` without this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot restore behavior so logger output continues working after a snapshot is serialized and reloaded.
  * Preserved existing logger instances across restore to avoid missed or interrupted log writes.
  * Ensured buffered log transports resume flushing correctly after restore, including continued writing to disk.
* **Tests**
  * Updated snapshot lifecycle tests to verify logger preservation and transport reopening/flush behavior after restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->