### PR TITLE
ci: single-leg coverage and cached utoo package store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,17 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Cache utoo package store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/utoo-store
+          key: pkgstore-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            pkgstore-${{ runner.os }}-
+
       - name: Install dependencies
+        env:
+          UTOO_CACHE_DIR: ${{ runner.temp }}/utoo-store
         run: ut install --from pnpm
 
       - name: Run lint
@@ -60,6 +70,18 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         node: ['22', '24']
+        coverage: [false]
+        # Replace (not duplicate) the ubuntu/24 leg with a coverage-enabled one.
+        # `include` cannot overwrite an existing matrix dimension, so the base
+        # coverage:false combo must be excluded first or ubuntu/24 would run twice.
+        exclude:
+          - os: 'ubuntu-latest'
+            node: '24'
+            coverage: false
+        include:
+          - os: 'ubuntu-latest'
+            node: '24'
+            coverage: true
 
     name: Test (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
@@ -159,17 +181,33 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache utoo package store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/utoo-store
+          key: pkgstore-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            pkgstore-${{ runner.os }}-
+
       - name: Install dependencies
+        env:
+          UTOO_CACHE_DIR: ${{ runner.temp }}/utoo-store
         run: ut install --from pnpm
 
-      - name: Run tests
+      - name: Run tests (with coverage)
+        if: ${{ matrix.coverage }}
         run: ut run ci
 
+      - name: Run tests
+        if: ${{ !matrix.coverage }}
+        run: ut run test
+
       # Summarize how parallel the full-isolate-off suite actually ran. The gating
-      # `ut run ci` run above emits Vitest JSON (vitest.config.ts, CI only); this step
-      # turns it into avg/peak concurrency + efficiency metrics in the job summary. It
-      # is informational only (always() so failures still surface metrics) and never
-      # changes the gate — `ut run ci` already set the job's pass/fail above.
+      # test run above (`ut run ci` on the coverage leg, `ut run test` on the rest)
+      # emits Vitest JSON (vitest.config.ts, CI only); this step turns it into
+      # avg/peak concurrency + efficiency metrics in the job summary. It is
+      # informational only (always() so failures still surface metrics) and never
+      # changes the gate — the test run above already set the job's pass/fail.
       - name: Report parallelism metrics
         if: always()
         # Call node directly: `ut run <script> -- ...` re-serializes forwarded args into
@@ -182,8 +220,7 @@ jobs:
           ut run example:test:all
 
       - name: Code Coverage
-        # skip on windows, it will hangup on codecov
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           use_oidc: true
@@ -194,6 +231,15 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
         node: ['24']
+        coverage: [false]
+        exclude:
+          - os: 'ubuntu-latest'
+            node: '24'
+            coverage: false
+        include:
+          - os: 'ubuntu-latest'
+            node: '24'
+            coverage: true
 
     name: Test bin (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
@@ -214,17 +260,33 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache utoo package store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/utoo-store
+          key: pkgstore-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            pkgstore-${{ runner.os }}-
+
       - name: Install dependencies
+        env:
+          UTOO_CACHE_DIR: ${{ runner.temp }}/utoo-store
         run: ut install --from pnpm
 
-      - name: Run tests
+      - name: Run tests (with coverage)
+        if: ${{ matrix.coverage }}
         run: |
           ut run build -- --workspace ./tools/egg-bin
           ut run ci --workspace @eggjs/bin
 
+      - name: Run tests
+        if: ${{ !matrix.coverage }}
+        run: |
+          ut run build -- --workspace ./tools/egg-bin
+          ut run test --workspace @eggjs/bin
+
       - name: Code Coverage
-        # skip on windows, it will hangup on codecov https://github.com/codecov/codecov-action/issues/1787
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           use_oidc: true
@@ -235,6 +297,15 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         node: ['22', '24']
+        coverage: [false]
+        exclude:
+          - os: 'ubuntu-latest'
+            node: '24'
+            coverage: false
+        include:
+          - os: 'ubuntu-latest'
+            node: '24'
+            coverage: true
 
     name: Test scripts (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
@@ -255,16 +326,33 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache utoo package store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/utoo-store
+          key: pkgstore-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            pkgstore-${{ runner.os }}-
+
       - name: Install dependencies
+        env:
+          UTOO_CACHE_DIR: ${{ runner.temp }}/utoo-store
         run: ut install --from pnpm
 
-      - name: Run tests
+      - name: Run tests (with coverage)
+        if: ${{ matrix.coverage }}
         run: |
           ut run build -- --workspace ./tools/scripts
           ut run ci --workspace tools/scripts
 
+      - name: Run tests
+        if: ${{ !matrix.coverage }}
+        run: |
+          ut run build -- --workspace ./tools/scripts
+          ut run test --workspace tools/scripts
+
       - name: Code Coverage
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.coverage }}
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           use_oidc: true


### PR DESCRIPTION
## Motivation

Cut CI wall time on the 3-OS × 2-Node `test` matrix **without adding matrix jobs** (sharding is intentionally out of scope — it multiplies jobs and queues the runner pool at this repo's PR volume). Two independent, low-risk levers.

## Task A — collect coverage on one matrix leg only

`ut run ci` (= `ut run test -- --coverage`) ran v8 coverage on all 6 legs, but codecov only needs one upload. Coverage adds ~10–30% per-leg overhead.

- Add a `coverage` matrix axis (default `false`), enabled on a single **ubuntu/node-24** leg.
- Split "Run tests" into two guarded steps — `ut run ci` (with `--coverage`) on the coverage leg, `ut run test` on the other 5. Both reach the same `pretest` prep (`clean-dist` + workspace pretest); only `--coverage` differs. (`ut run ci` only reaches `clean-dist` *via* its nested `ut run test`, so dropping `ci` for `test` keeps the prep identical.)
- Gate the codecov upload on `matrix.coverage` (was `matrix.os != 'windows-latest'`), so **exactly one leg** uploads. Applied to `test`, `test-egg-bin`, and `test-egg-scripts`.

> [!NOTE]
> **`exclude` is required, not just `include`.** GitHub's `include` cannot overwrite an existing matrix dimension. With `coverage: [false]` in the base, `include: { coverage: true }` would create a *separate* `ubuntu/24` leg → **7 legs, ubuntu/24 run twice**. The added `exclude` of the base `ubuntu/24/coverage:false` combo makes the coverage leg *replace* it. Leg counts stay **6 / 2 / 2**; the `done` gate is unaffected.

## Task B — cache the utoo package download store

Verified where `ut install --from pnpm` actually reads from before caching:

- It clones from a **content-addressable store at `$HOME/.cache/nm/<pkg>/<version>/`** (default), redirectable via the `UTOO_CACHE_DIR` env var (both confirmed empirically — a fresh uncached install populated exactly those dirs; warm installs report `cloned`, not `downloaded`). **Not a no-op.**
- Pin the store to `${{ runner.temp }}/utoo-store` (deterministic, identical expression in `env` and the cache `path`, outside the checkout) and wrap `ut install` with `actions/cache` in every installing job (`typecheck`, `test`, `test-egg-bin`, `test-egg-scripts`).

> [!NOTE]
> **Cache key deviates from a lockfile hash.** This repo commits **no lockfile** — dependency versions live in `pnpm-workspace.yaml`'s catalog + the `package.json` files (utoo generates an uncommitted `package-lock.json` at install time). `hashFiles('**/pnpm-lock.yaml')` would be empty → a constant key that never re-saves the growing store. The key hashes `pnpm-workspace.yaml` + `**/package.json` instead, with `restore-keys: pkgstore-<os>-` falling back to the latest per-OS store on a key miss.

Per repo convention, every action is pinned by commit SHA (`actions/cache@0057852…` = v4.3.0).

## Test evidence

- `actionlint` passes on the workflow.
- Matrix expansion simulated against GitHub's documented include/exclude algorithm: **6 / 2 / 2 legs (unchanged), exactly 1 coverage leg each (ubuntu/24)**.

### Before/after timings — to fill in from this PR's first runs
These require real CI runs and will be added once the workflow executes here:
- [ ] 5 non-coverage `test` legs: duration vs. `next` baseline (Task A).
- [ ] warm-cache `ut install` step duration vs. cold (Task B); cache hit-rate visible in the Actions cache UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by refining how dependencies are cached during validation runs.
  * Streamlined test execution with an explicit coverage vs. non-coverage flow, ensuring coverage runs only for the intended OS/node combinations.
  * Reduced redundant coverage reporting by uploading coverage results only when running in coverage-enabled mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->