### PR TITLE
perf(ci): persist V8 compile cache across test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
     name: Test (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
 
+    env:
+      # Persisted V8 compile cache (restored/saved by the "Cache Node compile
+      # cache" step). Set at job level so vitest workers and any forked child
+      # processes inherit NODE_COMPILE_CACHE.
+      NODE_COMPILE_CACHE: ${{ runner.temp }}/node-compile-cache
+
     concurrency:
       group: test-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }})
       cancel-in-progress: true
@@ -181,6 +187,15 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache Node compile cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/node-compile-cache
+          key: node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-
+            node-compile-cache-${{ runner.os }}-
+
       - name: Cache utoo package store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -244,6 +259,12 @@ jobs:
     name: Test bin (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
 
+    env:
+      # Persisted V8 compile cache (restored/saved by the "Cache Node compile
+      # cache" step). Set at job level so vitest workers and any forked child
+      # processes inherit NODE_COMPILE_CACHE.
+      NODE_COMPILE_CACHE: ${{ runner.temp }}/node-compile-cache
+
     concurrency:
       group: test-egg-bin-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }})
       cancel-in-progress: true
@@ -259,6 +280,15 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Cache Node compile cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/node-compile-cache
+          key: node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-
+            node-compile-cache-${{ runner.os }}-
 
       - name: Cache utoo package store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
@@ -310,6 +340,12 @@ jobs:
     name: Test scripts (${{ matrix.os }}, ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
 
+    env:
+      # Persisted V8 compile cache (restored/saved by the "Cache Node compile
+      # cache" step). Set at job level so vitest workers and any forked child
+      # processes inherit NODE_COMPILE_CACHE.
+      NODE_COMPILE_CACHE: ${{ runner.temp }}/node-compile-cache
+
     concurrency:
       group: test-egg-scripts-${{ github.workflow }}-#${{ github.event.pull_request.number || github.head_ref || github.ref }}-(${{ matrix.os }}, ${{ matrix.node }})
       cancel-in-progress: true
@@ -325,6 +361,15 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Cache Node compile cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/node-compile-cache
+          key: node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-
+            node-compile-cache-${{ runner.os }}-
 
       - name: Cache utoo package store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
## What

Enable Node's on-disk **V8 compile cache** (`NODE_COMPILE_CACHE`) for the three test jobs (`test`, `test-egg-bin`, `test-egg-scripts`) and persist it with `actions/cache`:

- Job-level `env.NODE_COMPILE_CACHE: ${{ runner.temp }}/node-compile-cache` so the value is inherited by vitest workers and any forked child processes, not just the top-level process.
- A `Cache Node compile cache` step (pinned `actions/cache@0057852…` # v4, the same pin already used for the utoo store) keyed `node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}` with graduated `restore-keys`, so the cache survives **within** a run (shared across processes) and **across** runs.

`typecheck` is intentionally excluded — it runs `tsgo`/`oxlint`/`tsdown` (Rust), not Node module execution, so there is nothing for the V8 compile cache to help.

Safety: Node validates each cache entry by source hash + Node version, so a stale restored entry is simply ignored (cache miss → recompile + rewrite). The change is low-risk and fully reversible.

## Honest measurement (please validate on CI before marking ready)

Opened as **draft** because the local benefit I could measure is ~0 and the CI/Windows benefit is unverified:

- On **macOS/arm64**, an A/B/C micro-benchmark of the egg-bin fork bootstrap (a full `egg-bin test` run, which populates **1346 cache files / 7.7 MB**) showed **no measurable speedup** — warm-cache runs landed inside the no-cache noise band (20.3–22.4s), and were marginally *slower* due to `flushCompileCache` write overhead on exit.
- Reason: per-fork wall time is dominated by the **oxc transform** and **module import** (`transform 1.51s` + `import 1.56s` of a 2.9s run), plus process spawn — and the compile cache only caches the **V8 compilation of already-transpiled JS**, not the transform itself.
- The case for keeping it rests on the **CI runners being much slower** at exactly the V8-compile + file-read work the cache removes (x64 ubuntu, and especially Windows) than an M-series Mac. That is plausible but **unmeasured here**. On Windows there is even a downside risk: a cache hit adds an extra file read per module (source + cache blob), and every file open is scanned by Defender, so it could be neutral or negative.

**How to validate:** compare the test-job step durations run-over-run (the existing `Report parallelism metrics` job already surfaces CI timing), and/or check cache hit-rate in the Actions cache UI. Keep if it helps a platform; drop the env+step if not.

## Scope note

This does **not** touch `tools/egg-bin/test/coffee.ts`, which forks the egg-bin CLI ~109× with a freshly-built `env` that does not pass `NODE_COMPILE_CACHE` through — so the compile cache does not currently reach those forks. That (and the Windows `test-egg-bin` slowdown generally) is being investigated separately on a Windows machine and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the test pipeline’s caching so repeated runs can reuse compiled artifacts more effectively.
  * This should help speed up automated checks and make CI runs more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->