### PR TITLE
perf(ci): persist V8 compile cache across test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,21 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache Node compile cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/node-compile-cache
+          key: node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-
+            node-compile-cache-${{ runner.os }}-
+
+      - name: Enable Node compile cache
+        # runner.* is not available in job-level env, so export NODE_COMPILE_CACHE
+        # here (bash on every OS) — every later step and forked child inherits it.
+        shell: bash
+        run: echo "NODE_COMPILE_CACHE=${{ runner.temp }}/node-compile-cache" >> "$GITHUB_ENV"
+
       - name: Cache utoo package store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -260,6 +275,21 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache Node compile cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/node-compile-cache
+          key: node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-
+            node-compile-cache-${{ runner.os }}-
+
+      - name: Enable Node compile cache
+        # runner.* is not available in job-level env, so export NODE_COMPILE_CACHE
+        # here (bash on every OS) — every later step and forked child inherits it.
+        shell: bash
+        run: echo "NODE_COMPILE_CACHE=${{ runner.temp }}/node-compile-cache" >> "$GITHUB_ENV"
+
       - name: Cache utoo package store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -325,6 +355,21 @@ jobs:
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Cache Node compile cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ runner.temp }}/node-compile-cache
+          key: node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}
+          restore-keys: |
+            node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-
+            node-compile-cache-${{ runner.os }}-
+
+      - name: Enable Node compile cache
+        # runner.* is not available in job-level env, so export NODE_COMPILE_CACHE
+        # here (bash on every OS) — every later step and forked child inherits it.
+        shell: bash
+        run: echo "NODE_COMPILE_CACHE=${{ runner.temp }}/node-compile-cache" >> "$GITHUB_ENV"
 
       - name: Cache utoo package store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/packages/core/test/loader/manifest.test.ts
+++ b/packages/core/test/loader/manifest.test.ts
@@ -751,6 +751,15 @@ describe('ManifestStore', () => {
     const savedPortable = process.env.NODE_COMPILE_CACHE_PORTABLE;
     const savedDisable = process.env.NODE_DISABLE_COMPILE_CACHE;
 
+    beforeEach(() => {
+      // enableCompileCache() respects an externally-set NODE_COMPILE_CACHE (CI
+      // may set one job-wide). Clear the ambient vars so these tests exercise
+      // the auto-set path from a clean slate; afterEach restores them.
+      delete process.env.NODE_COMPILE_CACHE;
+      delete process.env.NODE_COMPILE_CACHE_PORTABLE;
+      delete process.env.NODE_DISABLE_COMPILE_CACHE;
+    });
+
     afterEach(() => {
       for (const [key, saved] of [
         ['NODE_COMPILE_CACHE', savedCompileCache],

--- a/plugins/schedule/test/subscription.test.ts
+++ b/plugins/schedule/test/subscription.test.ts
@@ -15,7 +15,9 @@ describe('cluster - subscription', () => {
   afterAll(() => app.close());
 
   it('should support interval and cron', async () => {
-    await sleep(5000);
+    // interval is 4000ms; give the forked agent/worker boot + IPC + log flush
+    // enough slack on busy CI runners so the task fires at least once.
+    await sleep(process.env.CI ? 10000 : 5000);
 
     const log = getLogContent('subscription');
     // console.log(log);


### PR DESCRIPTION
## What

Enable Node's on-disk **V8 compile cache** (`NODE_COMPILE_CACHE`) for the three test jobs (`test`, `test-egg-bin`, `test-egg-scripts`) and persist it with `actions/cache`:

- Job-level `env.NODE_COMPILE_CACHE: ${{ runner.temp }}/node-compile-cache` so the value is inherited by vitest workers and any forked child processes, not just the top-level process.
- A `Cache Node compile cache` step (pinned `actions/cache@0057852…` # v4, the same pin already used for the utoo store) keyed `node-compile-cache-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-workspace.yaml', '**/package.json') }}` with graduated `restore-keys`, so the cache survives **within** a run (shared across processes) and **across** runs.

`typecheck` is intentionally excluded — it runs `tsgo`/`oxlint`/`tsdown` (Rust), not Node module execution, so there is nothing for the V8 compile cache to help.

Safety: Node validates each cache entry by source hash + Node version, so a stale restored entry is simply ignored (cache miss → recompile + rewrite). The change is low-risk and fully reversible.

## Honest measurement (please validate on CI before marking ready)

Opened as **draft** because the local benefit I could measure is ~0 and the CI/Windows benefit is unverified:

- On **macOS/arm64**, an A/B/C micro-benchmark of the egg-bin fork bootstrap (a full `egg-bin test` run, which populates **1346 cache files / 7.7 MB**) showed **no measurable speedup** — warm-cache runs landed inside the no-cache noise band (20.3–22.4s), and were marginally *slower* due to `flushCompileCache` write overhead on exit.
- Reason: per-fork wall time is dominated by the **oxc transform** and **module import** (`transform 1.51s` + `import 1.56s` of a 2.9s run), plus process spawn — and the compile cache only caches the **V8 compilation of already-transpiled JS**, not the transform itself.
- The case for keeping it rests on the **CI runners being much slower** at exactly the V8-compile + file-read work the cache removes (x64 ubuntu, and especially Windows) than an M-series Mac. That is plausible but **unmeasured here**. On Windows there is even a downside risk: a cache hit adds an extra file read per module (source + cache blob), and every file open is scanned by Defender, so it could be neutral or negative.

**How to validate:** compare the test-job step durations run-over-run (the existing `Report parallelism metrics` job already surfaces CI timing), and/or check cache hit-rate in the Actions cache UI. Keep if it helps a platform; drop the env+step if not.

## Scope note

This does **not** touch `tools/egg-bin/test/coffee.ts`, which forks the egg-bin CLI ~109× with a freshly-built `env` that does not pass `NODE_COMPILE_CACHE` through — so the compile cache does not currently reach those forks. That (and the Windows `test-egg-bin` slowdown generally) is being investigated separately on a Windows machine and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI build and test performance by enabling a Node.js compile-cache mechanism for relevant test jobs.
* **Tests**
  * Ensured compile-cache tests run with a clean environment by resetting related cache settings before each test.
  * Made the subscription interval/cron test more reliable in CI by increasing the wait time before log-based assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->