### PR TITLE
docs(snapshot): add V8 snapshot troubleshooting guide

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -292,6 +292,7 @@ function sidebarAdvanced(): DefaultTheme.SidebarItem[] {
         { text: 'Plugin Development', link: 'plugin' },
         { text: 'Framework Development', link: 'framework' },
         { text: 'V8 Startup Snapshot', link: 'snapshot' },
+        { text: 'Snapshot Troubleshooting', link: 'snapshot-troubleshooting' },
       ],
     },
   ];
@@ -406,6 +407,7 @@ function sidebarAdvancedZhCN(): DefaultTheme.SidebarItem[] {
         { text: '升级你的生命周期事件函数', link: 'loader-update' },
         { text: '对象生命周期', link: 'lifecycle' },
         { text: 'V8 启动快照', link: 'snapshot' },
+        { text: '快照故障排查', link: 'snapshot-troubleshooting' },
       ],
     },
   ];

--- a/site/docs/advanced/snapshot-troubleshooting.md
+++ b/site/docs/advanced/snapshot-troubleshooting.md
@@ -1,0 +1,386 @@
+---
+title: Snapshot Troubleshooting
+order: 8
+---
+
+# Snapshot Troubleshooting
+
+Building a [V8 startup snapshot](./snapshot.md) loads your entire module graph
+and serializes the heap. The hard constraint is **everything captured into that
+heap must be plain, serializable JavaScript**. A single dependency that opens a
+socket, starts a timer, or initializes a native binding at module-evaluation
+time can make the whole blob fail to build — or build successfully but crash on
+restore.
+
+This page explains how to find the module responsible and how to fix it.
+
+## The one rule: nothing live in the heap
+
+A snapshot freezes the heap at build time and thaws it on restore. Three classes
+of value cannot survive that round-trip:
+
+- **Native (C++-backed) bindings** — the llhttp `HTTPParser`, `nghttp2`,
+  TLS `SecureContext`, DNS `ChannelWrap`, native addons, etc.
+- **libuv handles** — open sockets, listening servers, timers, file handles,
+  watchers, and IPC channels.
+- **Node's lazy web-global getters** — `fetch`, `Headers`, `Request`,
+  `Response`, `FormData`, `WebSocket`, `EventSource`, `MessageEvent`,
+  `CloseEvent`, plus `Blob`/`File` (and `node:buffer`'s own `File`/`Blob`
+  getters) are accessor properties that initialize Node's built-in undici
+  (→ native http/http2) the first time they are touched. The accessor itself is
+  not serializable.
+
+A package is **snapshot-unsafe** when it creates any of these _at module-evaluation
+time_ or _before `configWillLoad`_ (the point where the build stops). The same
+package is usually fine if it defers that work into a function that only runs at
+request time.
+
+::: tip What Egg already handles for you
+The bundler keeps the Node network stack external and lazy by default
+(`http`, `https`, `http2`, `tls`, `dns`, `inspector`, plus their `node:` forms),
+and replaces the undici-backed web globals with build-time stubs. You only need
+this page when a **third-party dependency** or a **builtin not on that list**
+trips the constraint. See [How it works](./snapshot.md#how-it-works) for the
+mechanism.
+:::
+
+## Step 1 — Identify the failure surface
+
+A snapshot can fail at two distinct points. The error signature tells you which.
+
+### Build-time failure
+
+`egg-bin snapshot build` bundles the app, then wraps
+`node --snapshot-blob <blob> --build-snapshot worker.js`. When the V8 serializer
+reaches a non-serializable value it **aborts the process natively** — there is no
+catchable JS error. You will see one of:
+
+```text
+# the child was killed while serializing a native binding
+Error: <path>/node --snapshot-blob … --build-snapshot worker.js was killed by signal SIGSEGV
+
+# or it exited non-zero
+Error: <path>/node … exited with code 1
+
+# and, because no blob was produced:
+snapshot build finished but no blob was written at <output>/snapshot.blob
+```
+
+If instead the app threw a normal error while loading metadata (a bad config, a
+missing file), the worker prints it before exiting:
+
+```text
+[egg-bundler] failed to build snapshot: <message>
+```
+
+The first family means **a module captured something unserializable**. The second
+means an ordinary boot error — fix it the way you would fix a normal startup
+failure.
+
+A third, rarer family comes from the bundler itself, before `node` ever runs:
+
+```text
+snapshot prelude: an externalRequire helper was emitted but the lazy hook
+could not be injected (its signature did not match). …
+```
+
+This means `@utoo/pack`'s codegen for external requires changed shape (usually a
+version bump), so the lazy-external dispatch could not be injected. The bundler
+**fails closed on purpose** rather than emit a blob that loads the network stack
+at build time — it is not an app bug. Align the `@eggjs/egg-bundler` /
+`@utoo/pack` versions or file an issue.
+
+### Restore-time failure
+
+`egg-scripts start --snapshot-blob <blob>` (or `node --snapshot-blob`) restores
+the heap. Common signatures:
+
+| Symptom                                                                            | Meaning                                                                                                                                                                                                                                |
+| ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Native fatal `Check failed: current == end_slot_index` mid-deserialization         | Restoring on **Node.js < 24**. Always restore on Node.js >= 24. `egg-scripts` refuses to launch when it can determine the target is < 24; a custom `--node` whose version it cannot read falls through to the in-snapshot guard below. |
+| `[egg-bundler] V8 snapshot restore requires Node.js >= 24, but this process is vX` | The snapshot's own guard fired (you bypassed `egg-scripts`, or its version probe failed open).                                                                                                                                         |
+| `Error: Cannot find module '<pkg>'`                                                | An **external** dependency is missing. Externals are `require()`'d live on restore, resolved from `worker.js`'s own directory — keep `worker.js` next to a `node_modules` that contains them.                                          |
+| `Aop Advice(X) not found in loadUnits`                                             | A tegg decorated class kept the wrong source path in the bundle (see [tegg decorators](#tegg-aop-advice)).                                                                                                                             |
+| A `TypeError` deep inside a library that "worked before bundling"                  | The library mishandled a build-time member-proxy stub (see [lazy-external edge cases](#lazy-external-edge-cases)).                                                                                                                     |
+| `globalThis.fetch(...)` silently does nothing                                      | Web globals stay no-op stubs after restore (see [Known limitations](./snapshot.md#known-limitations)).                                                                                                                                 |
+| `[egg-bundler] failed to restore snapshot: <err>`                                  | Any other error thrown while finishing the deferred lifecycle (`snapshotDidDeserialize` → `didReady` → `listen`).                                                                                                                      |
+
+## Step 2 — Find the offending module (build failures)
+
+### Check the build environment first
+
+`egg-bin snapshot build` strips its _own_ TypeScript loader injection before
+spawning `node --build-snapshot`, but it inherits the rest of your shell
+environment. A `NODE_OPTIONS` that installs a custom loader or hook
+(`--require ts-node/register`, `--loader …`, `--import …`) rides into the
+snapshot-build child and can pull non-serializable state into the heap — the
+build then aborts natively with **no application-level cause**. Build from a
+clean environment first:
+
+```bash
+$ unset NODE_OPTIONS   # drop any inherited --require / --loader / --import
+$ egg-bin snapshot build
+```
+
+### Turn on debug logging
+
+Every stage of the bundler and launcher logs through `util.debuglog`. Enable the
+relevant namespaces with `NODE_DEBUG`:
+
+```bash
+# the bundler pipeline (manifest → entry → pack → prelude)
+$ NODE_DEBUG='egg/bundler/*,egg/bin/commands/snapshot' egg-bin snapshot build
+
+# the launcher (restore gate, spawn)
+$ NODE_DEBUG='egg/scripts/commands/start' egg-scripts start --snapshot-blob ./dist-bundle/snapshot.blob
+```
+
+Useful namespaces:
+
+| Namespace                      | What it traces                                                       |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `egg/bundler/bundler`          | bundle start, externals resolved, prelude/lazy-hook injection counts |
+| `egg/bundler/entry-generator`  | collected bundle entries, generated worker entry path                |
+| `egg/bundler/manifest-loader`  | what was discovered and externalized                                 |
+| `egg/bundler/snapshot-prelude` | externals whose export names could not be read                       |
+| `egg/bin/commands/snapshot`    | the exact `node --build-snapshot …` command spawned                  |
+
+### Read the native abort directly
+
+The build spawns the child with inherited stdio, so the V8 serializer's abort
+already prints to your terminal. To iterate faster, run the wrapped command by
+hand from the output directory — this is exactly what `egg-bin` runs:
+
+```bash
+$ cd ./dist-bundle
+$ EGG_BUNDLE_SNAPSHOT=build \
+    node --snapshot-blob ./snapshot.blob --build-snapshot ./worker.js
+```
+
+When the serializer aborts it usually names the object type it could not encode
+(for example a native handle), and the surrounding stack points into the module
+that created it. That is your prime suspect.
+
+To print that exact command (including any global exec args) **without** running
+it, use `egg-bin snapshot build --dry-run` — it bundles, then logs the precise
+`node --snapshot-blob … --build-snapshot worker.js` invocation instead of
+spawning it.
+
+### Bisect with `--skip-bundle`
+
+`--skip-bundle` re-runs **only** the snapshot step over an existing
+`worker.js`, skipping the (slow) bundling. Because the bundle is a single
+self-contained file, you can comment an `import`/`require` out of `worker.js` and
+re-run the snapshot step in seconds:
+
+```bash
+# 1. bundle once
+$ egg-bin snapshot build --output ./dist-bundle
+# 2. edit ./dist-bundle/worker.js — comment out a suspect module's evaluation
+# 3. re-run just the snapshot build
+$ egg-bin snapshot build --output ./dist-bundle --skip-bundle
+```
+
+If removing a module's evaluation makes the blob build, that module is the
+culprit.
+
+### Confirm with `--force-external`
+
+Pushing a suspect package **out** of the bundle is both a diagnostic and a fix.
+An external is never evaluated at build time — it is `require()`'d live on
+restore — so if `--force-external <pkg>` makes the build succeed, that package
+was capturing unserializable state at import:
+
+```bash
+$ egg-bin snapshot build --force-external some-native-client
+```
+
+## Step 3 — Fix it
+
+Pick the lightest fix that applies, roughly in this order.
+
+### 1. Keep the package external
+
+Best for a third-party package that opens connections, starts timers, or loads a
+native addon at import. It stays out of the snapshot and is required for real on
+restore:
+
+```bash
+$ egg-bin snapshot build \
+    --force-external undici \
+    --force-external some-native-driver
+```
+
+The package (and its own dependencies) must be **installed at the deploy
+target**, since it is loaded at runtime, not baked into the blob. The inverse
+flag, `--inline-external <pkg>`, forces a package the resolver auto-externalized
+back into the bundle.
+
+### 2. Add a builtin to `egg.snapshot.lazyModules`
+
+For a **builtin** (or builtin-like id) that initializes native state at import
+but is not in the default lazy list, add it in `package.json`. It is merged onto
+the defaults, stubbed at build, and loaded for real on restore:
+
+```json
+{
+  "egg": {
+    "snapshot": {
+      "lazyModules": ["node:zlib", "node:perf_hooks"]
+    }
+  }
+}
+```
+
+The built-in defaults already cover `http`, `https`, `http2`, `tls`, `dns`, and
+`inspector` (with their `node:` forms) — you do not need to list those.
+
+### 3. Implement the snapshot lifecycle hooks
+
+When _your own_ boot code owns a resource that cannot be serialized (a timer, a
+socket, a logger stream, a pooled connection), release it before serialization
+and recreate it after restore:
+
+```js
+class AppBootHook {
+  constructor(app) {
+    this.app = app;
+  }
+
+  async snapshotWillSerialize() {
+    // close/detach the non-serializable resource before the blob is written
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async snapshotDidDeserialize() {
+    // recreate it in the live, restored process
+    this.timer = setInterval(() => this.app.doWork(), 1000);
+  }
+}
+
+module.exports = AppBootHook;
+```
+
+See [Snapshot lifecycle hooks](./snapshot.md#snapshot-lifecycle-hooks) for the
+full contract. In single-process snapshot mode an `agent.js` boot class's hooks
+run too — the agent's `snapshotWillSerialize`/`snapshotDidDeserialize` fire
+**before** the app's — so resources owned by `agent.js` need the same treatment,
+and a `failed to restore snapshot` error can originate from an agent hook.
+
+### 4. Defer the work out of module scope
+
+Often the cleanest fix lives in your own code: move resource creation out of the
+top-level module body and into a function that runs at request time (or inside
+`didReady`/`snapshotDidDeserialize`). A module that only _defines_ classes and
+functions at evaluation time is always snapshot-safe; one that _connects_ or
+_starts a timer_ at evaluation time is not.
+
+```js
+// ✗ runs at module-eval → captured in the snapshot
+const client = new SomeClient({ keepAlive: true });
+
+// ✓ created on first use, in the live process
+let client;
+function getClient() {
+  return (client ??= new SomeClient({ keepAlive: true }));
+}
+```
+
+### 5. Avoid the web globals
+
+`globalThis.fetch` and the other undici-backed globals remain **no-op stubs**
+after restore (Node's lazy getter cannot be re-installed into a restored heap).
+Use a lazily-loaded HTTP client instead — `urllib` or `undici` kept external and
+required for real on restore:
+
+```js
+// ✗ no-op after restore
+await fetch(url);
+
+// ✓ real client, loaded live on restore
+const { request } = require('urllib');
+await request(url);
+```
+
+## Failure modes in detail
+
+### tegg decorators: "Aop Advice not found" {#tegg-aop-advice}
+
+tegg decorators (`@SingletonProto`, `@HTTPController`, `@Advice`, …) capture a
+class's source path from the call stack at module evaluation, using a hardcoded
+stack depth. In a bundle every user frame collapses onto `worker.js`, so a
+decorator that reads a _deeper_ frame than the norm (notably `@Advice`) captures
+`worker.js` instead of its own file, and tegg cannot match the proto to its load
+unit at restore.
+
+The bundler corrects this automatically: it re-stamps each decorated export's
+`filePath` from the manifest's tegg `decoratedFiles` before serialization. If you
+write a **custom decorator** that captures a stack frame at an unusual depth and
+hit this error, make sure the decorated file is part of a tegg module (so it
+appears in `decoratedFiles`), or file an issue with the decorator's stack depth.
+
+### Lazy-external edge cases {#lazy-external-edge-cases}
+
+External modules are represented at build time by a **member-proxy**: a stub that
+records the property/call/construct path taken against it (so
+`class X extends pkg.Base {}` and `DataTypes.INTEGER(11).UNSIGNED` keep working)
+and replays that path against the real module on restore.
+
+The proxy is faithful for the common patterns, but a library that does something
+unusual with a value it received at build time — for example coercing it to a
+string in an error template, or branching on an exotic `typeof` — can mishandle
+the stub and throw a confusing `TypeError`. If you see an error like
+`String.prototype.toString requires that 'this' be a String` originating inside a
+dependency during restore, the dependency received a member-proxy where it
+expected a concrete value. Keeping that dependency `--force-external` (so it is
+never proxied) is the reliable fix.
+
+### Missing files at request time (runtime assets) {#runtime-assets}
+
+A snapshot that restores cleanly can still `ENOENT` later when a handler reads a
+file. Only **non-source files under `app/`** (plus the force-copy dirs
+`app/public`, `app/assets`, `app/static`) are copied next to `worker.js`.
+Source-extension files (`.ts`/`.js`/`.json`/…), assets outside `app/`, and
+symlinked assets are **not** copied. And because the bundle rewrites `__dirname`
+and `import.meta.url` to the output directory, a module doing
+`fs.readFileSync(path.join(__dirname, 'tpl.html'))` or
+`new URL('./x', import.meta.url)` resolves against the bundle output dir — if the
+file was never copied there, it fails at request time, not at build or restore.
+
+Declare the extra assets in `module.yml` so they are copied into the bundle:
+
+```yaml
+bundle:
+  runtimeAssets:
+    roots: ['app', 'resources']
+    forceCopyDirs: ['app/public', 'resources/templates']
+```
+
+### Build succeeds, blob is missing
+
+`node --build-snapshot` can exit `0` without writing a blob — for instance if the
+entry threw after the `snapshotWillSerialize` hooks but before
+`setDeserializeMainFunction`. `egg-bin snapshot build` checks for the blob and
+fails loudly with `snapshot build finished but no blob was written at <path>`.
+Re-run with `NODE_DEBUG` and inspect the worker's own output for the underlying
+error.
+
+## Configuration reference
+
+| Mechanism                                              | Where                                      | Use it for                                                                                                                  |
+| ------------------------------------------------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `--force-external <pkg>`                               | `egg-bin snapshot build` flag (repeatable) | Keep a package out of the bundle; load it live on restore.                                                                  |
+| `--inline-external <pkg>`                              | `egg-bin snapshot build` flag (repeatable) | Force an auto-externalized package back into the bundle.                                                                    |
+| `egg.snapshot.lazyModules`                             | app `package.json`                         | Add a builtin/builtin-like id to the lazy-external set (merged onto the defaults).                                          |
+| `snapshotWillSerialize()` / `snapshotDidDeserialize()` | `app.js` / `agent.js` boot class           | Release & recreate resources your own code owns.                                                                            |
+| `--pack-alias <spec>=<target>`                         | `egg-bin snapshot build` flag (repeatable) | Redirect a module specifier during bundling.                                                                                |
+| `--skip-bundle`                                        | `egg-bin snapshot build` flag              | Re-run only the snapshot step over an existing `worker.js`.                                                                 |
+| `--dry-run`                                            | `egg-bin snapshot build` flag              | Print the `node --build-snapshot` command without spawning it.                                                              |
+| `bundle.runtimeAssets.roots` / `forceCopyDirs`         | app `module.yml`                           | Copy extra non-source files into the bundle so they exist at request time.                                                  |
+| `--no-sourcemap`                                       | `egg-scripts start` flag                   | Drop the auto-injected `--import source-map-support/register` from the restore launch (TypeScript apps) when it interferes. |
+| `NODE_OPTIONS`                                         | environment variable                       | Must be free of custom `--loader`/`--require`/`--import` before a build (they ride into the snapshot child).                |
+| `NODE_DEBUG=egg/bundler/*`                             | environment variable                       | Trace the bundler/launcher pipeline.                                                                                        |
+
+For the build/restore workflow and the supported surface, see the main
+[V8 Startup Snapshot](./snapshot.md) page.

--- a/site/docs/advanced/snapshot.md
+++ b/site/docs/advanced/snapshot.md
@@ -133,6 +133,25 @@ At restore time V8 deserializes the heap, then the snapshot main runs
 `snapshotDidDeserialize` hooks to recreate those runtime-only resources, finishes
 the deferred lifecycle through `didReady`, and starts listening.
 
+The set of modules kept external and lazy defaults to the Node network stack
+(`http`, `https`, `http2`, `tls`, `dns`, `inspector`, with their `node:` forms).
+If a builtin beyond that list initializes native state at import, extend the set
+via `egg.snapshot.lazyModules` in the app `package.json`:
+
+```json
+{
+  "egg": {
+    "snapshot": {
+      "lazyModules": ["node:zlib"]
+    }
+  }
+}
+```
+
+When a third-party dependency or builtin breaks the build or restore, see
+[Snapshot Troubleshooting](./snapshot-troubleshooting.md) for how to find the
+offending module and fix it.
+
 ## Snapshot lifecycle hooks
 
 If your `app.js` or `agent.js` boot class manages resources that cannot be
@@ -185,8 +204,9 @@ which is exactly the cost a snapshot front-loads into build time.
   so its state is released before serialization and rebuilt after restore. Not
   every package is snapshot-safe out of the box.
 - **Web globals are no-op stubs after restore**: at build the prelude replaces the
-  undici-backed globals (`fetch`/`Headers`/`Request`/`Response`/`FormData`/`WebSocket`,
-  plus `Blob`/`File`) with no-op stubs, because touching them at build time pulls in
+  undici-backed globals (`fetch`/`Headers`/`Request`/`Response`/`FormData`/`WebSocket`/
+  `EventSource`/`MessageEvent`/`CloseEvent`, plus `Blob`/`File`) with no-op stubs,
+  because touching them at build time pulls in
   Node's built-in undici and its native http/http2 bindings (which a snapshot cannot
   serialize). Node's native lazy getters are themselves not snapshot-serializable, so
   they cannot be reinstated on restore. **In the restored process those globals stay
@@ -195,3 +215,11 @@ which is exactly the cost a snapshot front-loads into build time.
 
 The supported surface is still evolving; the full list of known limitations and
 the design rationale are tracked in the project's V8 snapshot RFC.
+
+## Troubleshooting
+
+If a snapshot fails to build (a native abort during serialization) or fails to
+restore, see [Snapshot Troubleshooting](./snapshot-troubleshooting.md). It covers
+the build-time vs restore-time error signatures, how to find the module that
+captured non-serializable state, and the available fixes
+(`--force-external`, `egg.snapshot.lazyModules`, lifecycle hooks).

--- a/site/docs/zh-CN/advanced/snapshot-troubleshooting.md
+++ b/site/docs/zh-CN/advanced/snapshot-troubleshooting.md
@@ -1,0 +1,349 @@
+---
+title: 快照故障排查
+order: 9
+---
+
+# 快照故障排查
+
+构建 [V8 启动快照](./snapshot.md) 会加载整个模块图并序列化堆。硬性约束是
+**写入堆的所有内容都必须是可序列化的纯 JavaScript**。只要有一个依赖在模块求值阶段
+打开了 socket、启动了 timer，或初始化了原生绑定，就可能导致整个 blob 无法构建——
+或者构建成功，但在恢复时崩溃。
+
+本页说明如何定位罪魁祸首模块，以及如何修复。
+
+## 唯一的规则：堆里不能有「活的」资源
+
+快照在构建期冻结堆、在恢复期解冻。有三类值无法通过这个往返过程：
+
+- **原生（C++ 支撑的）绑定**——llhttp `HTTPParser`、`nghttp2`、TLS
+  `SecureContext`、DNS `ChannelWrap`、原生 addon 等。
+- **libuv 句柄**——打开的 socket、监听中的 server、timer、文件句柄、watcher、
+  以及 IPC channel。
+- **Node 的惰性 web 全局 getter**——`fetch`、`Headers`、`Request`、`Response`、
+  `FormData`、`WebSocket`、`EventSource`、`MessageEvent`、`CloseEvent`，以及
+  `Blob`/`File`（还有 `node:buffer` 自身的 `File`/`Blob` getter）都是访问器属性，
+  首次触碰时会初始化 Node 内建 undici（→ 原生 http/http2）。访问器本身不可序列化。
+
+当一个包在**模块求值阶段**、或在 `configWillLoad`（构建停止点）**之前**创建了上述
+任意一种资源，它就是**快照不安全**的。同一个包如果把这些工作推迟到只在请求期运行的
+函数里，通常就没问题。
+
+::: tip Egg 已经替你处理了什么
+bundler 默认把 Node 网络栈保持为 external 且惰性加载（`http`、`https`、`http2`、
+`tls`、`dns`、`inspector`，以及它们的 `node:` 形式），并把 undici 支撑的 web 全局
+对象替换为构建期桩。只有当某个**第三方依赖**或**不在该列表上的 builtin**触发了约束时，
+你才需要本页。机制细节见 [工作原理](./snapshot.md#工作原理)。
+:::
+
+## 第 1 步——确定失败发生面
+
+快照可能在两个不同的点失败，错误特征会告诉你是哪一个。
+
+### 构建期失败
+
+`egg-bin snapshot build` 先打包应用，然后包裹执行
+`node --snapshot-blob <blob> --build-snapshot worker.js`。当 V8 序列化器遇到不可
+序列化的值时，会**以原生方式中止进程**——没有可捕获的 JS 错误。你会看到下列之一：
+
+```text
+# 子进程在序列化某个原生绑定时被杀
+Error: <path>/node --snapshot-blob … --build-snapshot worker.js was killed by signal SIGSEGV
+
+# 或非零退出
+Error: <path>/node … exited with code 1
+
+# 并且因为没有产出 blob：
+snapshot build finished but no blob was written at <output>/snapshot.blob
+```
+
+如果是应用在加载元数据时抛出了普通错误（错误的配置、缺失的文件），worker 会在退出前
+打印出来：
+
+```text
+[egg-bundler] failed to build snapshot: <message>
+```
+
+第一类意味着**某个模块捕获了不可序列化的东西**；第二类是普通的启动错误——按修复普通
+启动失败的方式处理即可。
+
+还有第三类、更少见的错误来自 bundler 自身，在 `node` 运行之前就发生：
+
+```text
+snapshot prelude: an externalRequire helper was emitted but the lazy hook
+could not be injected (its signature did not match). …
+```
+
+这意味着 `@utoo/pack` 为 external require 生成的代码形态变了（通常是版本升级），导致
+惰性 external 派发无法注入。bundler **故意 fail closed**，而不是产出一个会在构建期加载
+网络栈的 blob——这不是应用 bug。请对齐 `@eggjs/egg-bundler` / `@utoo/pack` 的版本，
+或提个 issue。
+
+### 恢复期失败
+
+`egg-scripts start --snapshot-blob <blob>`（或 `node --snapshot-blob`）会恢复堆。
+常见特征：
+
+| 现象                                                                               | 含义                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 反序列化中途原生 fatal `Check failed: current == end_slot_index`                   | 在 **Node.js < 24** 上恢复。请始终在 Node.js >= 24 上恢复。`egg-scripts` 在能判定目标 < 24 时会拒绝启动；若自定义 `--node` 的版本无法读取，则会落到下面的快照内守卫。    |
+| `[egg-bundler] V8 snapshot restore requires Node.js >= 24, but this process is vX` | 快照自带的守卫触发了（你绕过了 `egg-scripts`，或它的版本探测 fail-open 了）。                                                                                            |
+| `Error: Cannot find module '<pkg>'`                                                | 某个 **external** 依赖缺失。external 在恢复时会被 `require()` 真实加载，且解析根锚定在 `worker.js` 所在目录——请让 `worker.js` 与包含这些依赖的 `node_modules` 放在一起。 |
+| `Aop Advice(X) not found in loadUnits`                                             | 某个 tegg 装饰类在 bundle 里保留了错误的源码路径（见 [tegg 装饰器](#tegg-aop-advice)）。                                                                                 |
+| 某个「打包前还好好的」库内部深处抛 `TypeError`                                     | 该库错误地处理了构建期的成员代理桩（见 [惰性 external 边界情况](#lazy-external-edge-cases)）。                                                                           |
+| `globalThis.fetch(...)` 静默无反应                                                 | 恢复后 web 全局对象仍是空操作桩（见 [已知限制](./snapshot.md#已知限制)）。                                                                                               |
+| `[egg-bundler] failed to restore snapshot: <err>`                                  | 在完成延后生命周期（`snapshotDidDeserialize` → `didReady` → `listen`）时抛出的任何其他错误。                                                                             |
+
+## 第 2 步——定位罪魁祸首模块（构建失败）
+
+### 先检查构建环境
+
+`egg-bin snapshot build` 在 spawn `node --build-snapshot` 前会剥离它**自己**注入的
+TypeScript loader，但会继承你 shell 环境的其余部分。如果 `NODE_OPTIONS` 装入了自定义
+loader 或 hook（`--require ts-node/register`、`--loader …`、`--import …`），它会随快照
+构建子进程一起进入，并可能把不可序列化状态拉进堆——此时构建会以原生方式中止，
+**且没有任何应用层面的原因**。请先在干净环境里构建：
+
+```bash
+$ unset NODE_OPTIONS   # 去掉任何继承来的 --require / --loader / --import
+$ egg-bin snapshot build
+```
+
+### 打开调试日志
+
+bundler 和启动器的每个阶段都通过 `util.debuglog` 打日志。用 `NODE_DEBUG` 打开相关
+命名空间：
+
+```bash
+# bundler 流水线（manifest → entry → pack → prelude）
+$ NODE_DEBUG='egg/bundler/*,egg/bin/commands/snapshot' egg-bin snapshot build
+
+# 启动器（恢复守卫、spawn）
+$ NODE_DEBUG='egg/scripts/commands/start' egg-scripts start --snapshot-blob ./dist-bundle/snapshot.blob
+```
+
+常用命名空间：
+
+| 命名空间                       | 追踪内容                                                 |
+| ------------------------------ | -------------------------------------------------------- |
+| `egg/bundler/bundler`          | 打包开始、externals 解析结果、prelude/惰性 hook 注入计数 |
+| `egg/bundler/entry-generator`  | 收集到的 bundle 入口、生成的 worker 入口路径             |
+| `egg/bundler/manifest-loader`  | 发现并 externalize 了哪些内容                            |
+| `egg/bundler/snapshot-prelude` | 哪些 external 的导出名无法读取                           |
+| `egg/bin/commands/snapshot`    | 实际 spawn 的 `node --build-snapshot …` 命令             |
+
+### 直接读原生中止信息
+
+构建会以继承 stdio 的方式 spawn 子进程，因此 V8 序列化器的中止信息已经打印到你的
+终端。为了更快迭代，可以从输出目录手动执行被包裹的命令——这正是 `egg-bin` 所运行的：
+
+```bash
+$ cd ./dist-bundle
+$ EGG_BUNDLE_SNAPSHOT=build \
+    node --snapshot-blob ./snapshot.blob --build-snapshot ./worker.js
+```
+
+序列化器中止时通常会指出它无法编码的对象类型（例如某个原生句柄），其周边栈会指向
+创建该对象的模块。那就是你的首要嫌疑。
+
+如果只想**打印**这条命令（含全局 exec 参数）而不运行它，用
+`egg-bin snapshot build --dry-run`——它会先打包，然后把精确的
+`node --snapshot-blob … --build-snapshot worker.js` 命令打印出来，而不 spawn。
+
+### 用 `--skip-bundle` 二分
+
+`--skip-bundle` 只对已有的 `worker.js` **重跑快照步骤**，跳过（缓慢的）打包。由于
+bundle 是单一自包含文件，你可以在 `worker.js` 里注释掉某个 `import`/`require`，
+几秒钟内重跑快照步骤：
+
+```bash
+# 1. 打包一次
+$ egg-bin snapshot build --output ./dist-bundle
+# 2. 编辑 ./dist-bundle/worker.js——注释掉某个嫌疑模块的求值
+# 3. 只重跑快照构建
+$ egg-bin snapshot build --output ./dist-bundle --skip-bundle
+```
+
+如果去掉某个模块的求值后 blob 能构建成功，那这个模块就是元凶。
+
+### 用 `--force-external` 确认
+
+把嫌疑包推**出** bundle 既是诊断手段也是修复手段。external 永远不会在构建期被求值
+——它在恢复时被真实 `require()`——所以如果 `--force-external <pkg>` 让构建成功了，
+说明该包在 import 时捕获了不可序列化状态：
+
+```bash
+$ egg-bin snapshot build --force-external some-native-client
+```
+
+## 第 3 步——修复
+
+按下面的大致顺序，选用最轻量的可行修复。
+
+### 1. 让包保持 external
+
+最适合在 import 时打开连接、启动 timer 或加载原生 addon 的第三方包。它会留在快照
+之外，并在恢复时被真实 require：
+
+```bash
+$ egg-bin snapshot build \
+    --force-external undici \
+    --force-external some-native-driver
+```
+
+该包（及其自身依赖）必须**安装在部署目标上**，因为它是在运行期加载的，并没有被烤进
+blob。反向标志 `--inline-external <pkg>` 会把解析器自动 externalize 的包强制塞回
+bundle。
+
+### 2. 把 builtin 加入 `egg.snapshot.lazyModules`
+
+对于在 import 时初始化原生状态、但不在默认惰性列表里的 **builtin**（或类 builtin 的
+id），在 `package.json` 里添加。它会被合并到默认值之上，在构建期被打桩，在恢复时被
+真实加载：
+
+```json
+{
+  "egg": {
+    "snapshot": {
+      "lazyModules": ["node:zlib", "node:perf_hooks"]
+    }
+  }
+}
+```
+
+内建默认值已经覆盖了 `http`、`https`、`http2`、`tls`、`dns` 和 `inspector`（含它们的
+`node:` 形式）——这些无需自行列出。
+
+### 3. 实现快照生命周期钩子
+
+当**你自己的** Boot 代码持有不可序列化的资源（timer、socket、logger 流、连接池），
+在序列化前释放、在恢复后重建：
+
+```js
+class AppBootHook {
+  constructor(app) {
+    this.app = app;
+  }
+
+  async snapshotWillSerialize() {
+    // 在写入 blob 前关闭/解绑不可序列化资源
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+
+  async snapshotDidDeserialize() {
+    // 在恢复后的真实进程里重建
+    this.timer = setInterval(() => this.app.doWork(), 1000);
+  }
+}
+
+module.exports = AppBootHook;
+```
+
+完整约定见 [快照生命周期钩子](./snapshot.md#快照生命周期钩子)。在单进程快照模式下，
+`agent.js` Boot 类的钩子也会运行——agent 的 `snapshotWillSerialize`/
+`snapshotDidDeserialize` 在 app 的**之前**触发——因此 `agent.js` 持有的资源需要同样的
+处理，且 `failed to restore snapshot` 错误也可能来自 agent 钩子。
+
+### 4. 把工作移出模块作用域
+
+最干净的修复往往就在你自己的代码里：把资源创建从顶层模块体移到一个在请求期运行的
+函数中（或放进 `didReady`/`snapshotDidDeserialize`）。一个在求值期只**定义**类和函数的
+模块永远是快照安全的；而一个在求值期就**建立连接**或**启动 timer** 的模块则不是。
+
+```js
+// ✗ 在模块求值期运行 → 被写入快照
+const client = new SomeClient({ keepAlive: true });
+
+// ✓ 首次使用时、在真实进程里创建
+let client;
+function getClient() {
+  return (client ??= new SomeClient({ keepAlive: true }));
+}
+```
+
+### 5. 避开 web 全局对象
+
+`globalThis.fetch` 和其他 undici 支撑的全局对象在恢复后仍是**空操作桩**（Node 的
+惰性 getter 无法被重新装回恢复后的堆）。请改用按需懒加载的 HTTP 客户端——把 `urllib`
+或 `undici` 保持 external，在恢复时真实 require：
+
+```js
+// ✗ 恢复后空操作
+await fetch(url);
+
+// ✓ 真实客户端，恢复时真实加载
+const { request } = require('urllib');
+await request(url);
+```
+
+## 失败模式详解
+
+### tegg 装饰器：「Aop Advice not found」 {#tegg-aop-advice}
+
+tegg 装饰器（`@SingletonProto`、`@HTTPController`、`@Advice` 等）会在模块求值时
+从调用栈用硬编码的栈深度捕获类的源码路径。在 bundle 里所有用户栈帧都坍缩到
+`worker.js` 上，因此一个读取比常规**更深**栈帧的装饰器（典型是 `@Advice`）会捕获到
+`worker.js` 而非自己的文件，于是 tegg 在恢复时无法把 proto 匹配到对应的 load unit。
+
+bundler 会自动纠正这一点：它在序列化前根据 manifest 里 tegg 的 `decoratedFiles`
+为每个装饰导出重新打上 `filePath`。如果你写了**自定义装饰器**、在非常规深度捕获栈帧
+并撞上这个错误，请确认该装饰文件属于某个 tegg module（这样它才会出现在 `decoratedFiles`
+里），或带上装饰器的栈深度提个 issue。
+
+### 惰性 external 边界情况 {#lazy-external-edge-cases}
+
+external 模块在构建期由一个**成员代理**表示：一个会记录对它执行的属性/调用/构造路径的
+桩（这样 `class X extends pkg.Base {}` 和 `DataTypes.INTEGER(11).UNSIGNED` 仍能工作），
+并在恢复时把该路径重放到真实模块上。
+
+代理对常见模式是忠实的，但如果某个库对它在构建期拿到的值做了不寻常的处理——例如在错误
+模板里把它强转成字符串，或基于某种奇特的 `typeof` 分支——就可能错误处理这个桩并抛出
+令人困惑的 `TypeError`。如果你看到类似 `String.prototype.toString requires that 'this'
+be a String` 的错误、源头在某个依赖内部且发生在恢复期，说明该依赖在期望具体值的地方
+收到了成员代理。把该依赖保持 `--force-external`（这样它永远不会被代理）是可靠的修复。
+
+### 请求期文件缺失（运行期资源） {#runtime-assets}
+
+一个能干净恢复的快照，仍可能在某个处理器读取文件时 `ENOENT`。只有 **`app/` 下的
+非源码文件**（加上强制拷贝目录 `app/public`、`app/assets`、`app/static`）会被拷贝到
+`worker.js` 旁边。源码扩展名文件（`.ts`/`.js`/`.json`/…）、`app/` 之外的资源、以及
+符号链接资源**都不会**被拷贝。而且由于 bundle 把 `__dirname` 和 `import.meta.url`
+重写成了输出目录，一个执行 `fs.readFileSync(path.join(__dirname, 'tpl.html'))` 或
+`new URL('./x', import.meta.url)` 的模块会相对 bundle 输出目录解析——如果该文件从未
+被拷贝过去，就会在请求期（而非构建或恢复期）失败。
+
+在 `module.yml` 里声明这些额外资源，它们就会被拷贝进 bundle：
+
+```yaml
+bundle:
+  runtimeAssets:
+    roots: ['app', 'resources']
+    forceCopyDirs: ['app/public', 'resources/templates']
+```
+
+### 构建成功，但 blob 缺失
+
+`node --build-snapshot` 可能在没写出 blob 的情况下以 `0` 退出——例如入口在
+`snapshotWillSerialize` 钩子之后、`setDeserializeMainFunction` 之前抛了错。
+`egg-bin snapshot build` 会检查 blob 是否存在，并以
+`snapshot build finished but no blob was written at <path>` 显式失败。请带上
+`NODE_DEBUG` 重跑，并检查 worker 自己的输出找到底层错误。
+
+## 配置参考
+
+| 机制                                                   | 位置                                    | 用途                                                                                            |
+| ------------------------------------------------------ | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `--force-external <pkg>`                               | `egg-bin snapshot build` 标志（可重复） | 把包留在 bundle 外，恢复时真实加载。                                                            |
+| `--inline-external <pkg>`                              | `egg-bin snapshot build` 标志（可重复） | 把被自动 externalize 的包强制塞回 bundle。                                                      |
+| `egg.snapshot.lazyModules`                             | 应用 `package.json`                     | 向惰性 external 集合添加 builtin/类 builtin 的 id（合并到默认值之上）。                         |
+| `snapshotWillSerialize()` / `snapshotDidDeserialize()` | `app.js` / `agent.js` Boot 类           | 释放并重建你自己代码持有的资源。                                                                |
+| `--pack-alias <spec>=<target>`                         | `egg-bin snapshot build` 标志（可重复） | 打包期重定向某个模块说明符。                                                                    |
+| `--skip-bundle`                                        | `egg-bin snapshot build` 标志           | 只对已有 `worker.js` 重跑快照步骤。                                                             |
+| `--dry-run`                                            | `egg-bin snapshot build` 标志           | 打印 `node --build-snapshot` 命令但不 spawn。                                                   |
+| `bundle.runtimeAssets.roots` / `forceCopyDirs`         | 应用 `module.yml`                       | 把额外的非源码文件拷进 bundle，使其在请求期存在。                                               |
+| `--no-sourcemap`                                       | `egg-scripts start` 标志                | 当自动注入的 `--import source-map-support/register` 干扰恢复启动时（TypeScript 应用）将其去掉。 |
+| `NODE_OPTIONS`                                         | 环境变量                                | 构建前必须不含自定义 `--loader`/`--require`/`--import`（它们会随快照子进程一起进入）。          |
+| `NODE_DEBUG=egg/bundler/*`                             | 环境变量                                | 追踪 bundler/启动器流水线。                                                                     |
+
+构建/恢复流程与支持范围见主页 [V8 启动快照](./snapshot.md)。

--- a/site/docs/zh-CN/advanced/snapshot.md
+++ b/site/docs/zh-CN/advanced/snapshot.md
@@ -117,6 +117,24 @@ await app.listen(7001);
 恢复阶段，V8 先反序列化堆，随后快照主函数运行 `snapshotDidDeserialize` 钩子重建这些
 运行期资源，跑完延后的生命周期直到 `didReady`，然后开始监听。
 
+保持 external 且惰性加载的模块集合默认是 Node 网络栈（`http`、`https`、`http2`、`tls`、
+`dns`、`inspector`，含它们的 `node:` 形式）。如果该列表之外的某个 builtin 在 import 时
+初始化了原生状态，可以通过应用 `package.json` 里的 `egg.snapshot.lazyModules` 扩展这个
+集合：
+
+```json
+{
+  "egg": {
+    "snapshot": {
+      "lazyModules": ["node:zlib"]
+    }
+  }
+}
+```
+
+当某个第三方依赖或 builtin 破坏了构建或恢复时，参见
+[快照故障排查](./snapshot-troubleshooting.md)，了解如何定位罪魁祸首模块并修复。
+
 ## 快照生命周期钩子
 
 如果你的 `app.js` 或 `agent.js` Boot 类管理了不能直接写入 V8 快照的资源，可以实现下面
@@ -166,10 +184,18 @@ module.exports = AppBootHook;
   （`--force-external`），要么实现快照生命周期钩子，在序列化前释放、在恢复后重建。并不是
   每个包都开箱即可被快照化。
 - **Web 全局对象在恢复后是惰性桩**：构建期 prelude 会把 undici 支撑的全局对象
-  （`fetch`/`Headers`/`Request`/`Response`/`FormData`/`WebSocket`、以及 `Blob`/`File`）替换为
-  空操作的桩，否则在构建期触碰它们会拉起 Node 内建 undici 的原生 http/http2 绑定（无法被快照
+  （`fetch`/`Headers`/`Request`/`Response`/`FormData`/`WebSocket`/`EventSource`/`MessageEvent`/
+  `CloseEvent`、以及 `Blob`/`File`）替换为空操作的桩，否则在构建期触碰它们会拉起 Node 内建
+  undici 的原生 http/http2 绑定（无法被快照
   序列化）。Node 的原生惰性 getter 本身不可被快照序列化，因此恢复后无法把它们还原。**恢复后的
   进程里这些全局对象仍是桩**——快照化的应用应使用按需懒加载的 HTTP 客户端（如 `urllib`/`undici`，
   通过 external 在恢复期加载真实模块），而不要直接依赖 `globalThis.fetch`。
 
 支持范围仍在演进中；完整的已知限制与设计取舍记录在项目的 V8 快照 RFC 中。
+
+## 故障排查
+
+如果快照无法构建（序列化期间原生中止）或无法恢复，参见
+[快照故障排查](./snapshot-troubleshooting.md)。其中涵盖了构建期与恢复期的错误特征、
+如何定位捕获了不可序列化状态的模块，以及可用的修复手段
+（`--force-external`、`egg.snapshot.lazyModules`、生命周期钩子）。


### PR DESCRIPTION
## Motivation

Building a V8 startup snapshot serializes the whole heap, so any dependency that
opens a socket, starts a timer, or initializes a native binding at
module-evaluation time can make the blob fail to build — or build and then crash
on restore. There was no guide for finding which module is responsible or how to
fix it.

## What

New dedicated page `advanced/snapshot-troubleshooting.md` (EN + zh-CN):

- **The serializability rule** — what cannot survive the round-trip (native
  bindings / libuv handles / lazy web-global getters) and when a dependency
  trips it.
- **Failure surfaces** — build-time vs restore-time, with the exact error
  strings each emits (`killed by signal SIGSEGV`, `no blob was written`,
  `Check failed: current == end_slot_index`, `Aop Advice not found`,
  `Cannot find module`, …).
- **Find the offending module** — `NODE_DEBUG` namespaces, a clean
  `NODE_OPTIONS`, `--dry-run`, `--skip-bundle` bisecting, `--force-external`
  confirmation.
- **Fixes** — `--force-external`, `egg.snapshot.lazyModules`, the snapshot
  lifecycle hooks, deferring work out of module scope, avoiding the web globals.
- **Failure modes in detail** (tegg `@Advice` filePath, the lazy-external member
  proxy, runtime-asset `ENOENT`) and a configuration reference table.

Also documents the previously-undocumented `egg.snapshot.lazyModules` config in
`advanced/snapshot.md`, cross-links the new page from it, and wires the page into
the English and Chinese advanced sidebars.

Docs-only; no runtime code change. Builds on the snapshot feature already on
`next` (#5998 / #5999 / #6001 / #6003).

## Test evidence

- `vitepress build site` passes clean — VitePress's dead-link/anchor check is
  green, so both new pages render and every cross-file and in-page anchor
  resolves (the two detail headings use explicit ASCII `{#…}` ids because the
  VitePress slugifier retains CJK + fullwidth `「」`).
- Every technical claim was adversarially verified against the
  `egg-bundler` / `egg-bin` / `egg-scripts` source — exact error strings, flag
  names, debug namespaces, and the default lazy-module set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Snapshot Troubleshooting guide in English and Chinese, covering common build and restore failure symptoms, how to diagnose them, and recommended fixes.
  * Expanded the Snapshot guide with guidance on configuring additional lazy-loaded modules, plus clearer troubleshooting links.
  * Updated the sidebar navigation to include the new troubleshooting page in both languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->