### PR TITLE
fix(ci): skip oclif shell probe in egg-bin

### DIFF
--- a/tools/egg-bin/bin/run.js
+++ b/tools/egg-bin/bin/run.js
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
-import { execute } from '@oclif/core';
+function presetWindowsShell() {
+  if (process.platform !== 'win32' || process.env.SHELL) return;
+
+  const comspec = process.env.ComSpec ?? process.env.COMSPEC;
+  process.env.SHELL = comspec?.split(/[\\/]/).at(-1) || 'cmd.exe';
+}
+
+presetWindowsShell();
+const { execute } = await import('@oclif/core');
 
 await execute({ dir: import.meta.dirname });

--- a/tools/egg-bin/test/fixtures/my-egg-bin/bin/run.js
+++ b/tools/egg-bin/test/fixtures/my-egg-bin/bin/run.js
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
-import { execute } from '@oclif/core';
+function presetWindowsShell() {
+  if (process.platform !== 'win32' || process.env.SHELL) return;
+
+  const comspec = process.env.ComSpec ?? process.env.COMSPEC;
+  process.env.SHELL = comspec?.split(/[\\/]/).at(-1) || 'cmd.exe';
+}
+
+presetWindowsShell();
+const { execute } = await import('@oclif/core');
 
 await execute({ dir: import.meta.url });

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -13,6 +13,7 @@ Read this file before exploring raw sources.
 
 - [CI parallel test metrics](./workflows/ci-parallel-test-metrics.md) - How the CI test gate surfaces avg/peak concurrency + parallel-efficiency metrics for the isolate:false suite, and how to read or reproduce them.
 - [Docs and API Updates](./workflows/docs-and-api-updates.md) - How to handle changes that affect user-facing docs or durable project understanding.
+- [Egg-bin Windows shell probe hotspot](./workflows/egg-bin-windows-shell-probe.md) - How PR #6014 diagnosed hosted-Windows egg-bin startup slowness and why the final fix only presets SHELL.
 
 ## Decisions
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-06-28] workflow | record egg-bin Windows shell probe hotspot
+
+- sources touched: `tools/egg-bin/bin/run.js`, `tools/egg-bin/test/fixtures/my-egg-bin/bin/run.js`, PR #6014 CI logs
+- pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/workflows/egg-bin-windows-shell-probe.md`
+- note: Recorded the PR #6014 investigation that found hosted-Windows `test-egg-bin` slowness was oclif's synchronous shell probe when spawned children lacked `SHELL`. The final code keeps only the Windows `SHELL` preset before dynamically importing `@oclif/core`; temporary timing and runner-diagnostic code was removed from the PR. Latest single Windows bin job passed in about 3m06s with `test/commands/test.test.ts` around 48.8s and `test/my-egg-bin.test.ts` around 8.5s.
+
 ## [2026-06-28] package | snapshot bundler lazy-externalizes undici + urllib by default (PR #6011)
 
 - sources touched: `tools/egg-bundler/src/lib/prelude.ts`, `tools/egg-bundler/test/snapshot-lazy-external.test.ts`, `tools/egg-bundler/test/snapshot-lazy.realbuild.test.ts`

--- a/wiki/workflows/egg-bin-windows-shell-probe.md
+++ b/wiki/workflows/egg-bin-windows-shell-probe.md
@@ -1,0 +1,60 @@
+---
+title: Egg-bin Windows shell probe hotspot
+type: workflow
+summary: How PR #6014 diagnosed hosted-Windows egg-bin startup slowness and why the final fix only presets SHELL.
+source_files:
+  - tools/egg-bin/bin/run.js
+  - tools/egg-bin/test/fixtures/my-egg-bin/bin/run.js
+  - https://github.com/eggjs/egg/pull/6014
+  - https://github.com/eggjs/egg/actions/runs/28316987317
+  - https://github.com/eggjs/egg/actions/runs/28317525249
+updated_at: 2026-06-28
+status: active
+---
+
+## Finding
+
+The Windows `test-egg-bin` hotspot in PR #6014 was repeated child-process CLI
+startup, not Vitest sharding, globby, or `egg-bin test` config construction.
+Hosted Windows runners started spawned `egg-bin` children without `SHELL`, which
+made oclif synchronously probe the parent process shell through PowerShell/CIM.
+Files such as `tools/egg-bin/test/commands/test.test.ts` amplify that cost
+because they spawn many child `egg-bin` processes.
+
+Inference: the hosted-runner slowdown looked like a long test file, but the
+dominant repeated cost happened before the command's own test work. Temporary
+CI-only timing showed normal `test` command globby/config work was tiny, while
+pre-command oclif startup dominated.
+
+## Final Fix
+
+The final code fix is deliberately small:
+
+- in `tools/egg-bin/bin/run.js`, preset `process.env.SHELL` on Windows when it is
+  missing, deriving the shell name from `COMSPEC`/`ComSpec` or falling back to
+  `cmd.exe`
+- do the same in `tools/egg-bin/test/fixtures/my-egg-bin/bin/run.js`, because the
+  custom CLI fixture has its own oclif entrypoint
+- dynamically import `@oclif/core` after the preset, so oclif observes `SHELL`
+  before it initializes
+
+The diagnostic instrumentation used during the investigation was removed from
+the final PR. The CI workflow stays as one Windows `test-egg-bin` leg; sharding
+is not needed after the shell-probe fix.
+
+## Evidence
+
+Observed on CI while diagnosing PR #6014:
+
+- Before the fix, `test/commands/test.test.ts` on Windows took about 1,077s.
+- After the main entrypoint preset, `test/commands/test.test.ts` dropped to about
+  42-48s.
+- After applying the same preset to the custom CLI fixture, `test/my-egg-bin.test.ts`
+  dropped from about 299s to about 7.6s.
+- After removing the diagnostic code and keeping the minimal fix, the single
+  Windows `test-egg-bin` job passed in about 3m06s; file-level timings included
+  `test/commands/test.test.ts` at 48.8s, `test/my-egg-bin.test.ts` at 8.5s, and
+  `test/commands/cov.test.ts` at 30.0s.
+
+Remaining slow cases are real test/app startup work, mainly TypeScript fixture
+cases around 9-10s, not repeated oclif shell probing.


### PR DESCRIPTION
## Summary

- preset `SHELL` before loading oclif in the main `egg-bin` entrypoint when Windows children start without it
- apply the same preset to the custom `my-egg-bin` fixture entrypoint
- move the investigation details into the wiki and keep temporary diagnostic code out of the final PR

## Root Cause

On GitHub-hosted Windows runners, spawned `egg-bin` children can start without `SHELL`. oclif then synchronously probes the parent process shell through PowerShell/CIM during startup. `tools/egg-bin/test/commands/test.test.ts` starts many child CLI processes, so that startup probe dominated the file runtime.

## Validation

- `git diff --check origin/next...HEAD`
- `node --check tools/egg-bin/bin/run.js`
- `node --check tools/egg-bin/test/fixtures/my-egg-bin/bin/run.js`
- local egg-bin smoke after build, with `CI=1` and `SHELL` unset:
  - `test/commands/test.test.ts -t "should only test files specified by TESTS argv"`
  - `test/my-egg-bin.test.ts -t "should my-egg-bin nsp success"`
- CI `Test bin (windows-latest, 24)` passed in about 3m06s after diagnostic code was removed

## Evidence

The diagnostic code used to isolate the hotspot was removed from this PR. The durable notes and CI evidence are recorded in `wiki/workflows/egg-bin-windows-shell-probe.md`.

- before fix: `test/commands/test.test.ts` on Windows took about 1,077s
- after main entrypoint fix: `test/commands/test.test.ts` dropped to about 42-49s
- after fixture entrypoint fix: `test/my-egg-bin.test.ts` dropped from about 299s to about 8.5s
- latest final-code Windows bin run: `test/commands/test.test.ts` 48.8s, `test/my-egg-bin.test.ts` 8.5s, `test/commands/cov.test.ts` 30.0s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows startup behavior for the CLI by ensuring a shell is available when one isn’t already set.
  * Reduced unnecessary startup overhead in Windows environments, making related commands and tests run faster and more reliably.

* **Documentation**
  * Added and updated wiki entries explaining the Windows startup investigation, timing impact, and final resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->