### PR TITLE
test: fix flaky CI tests (multipart tmpdir teardown + egg-scripts start readiness)

### DIFF
--- a/plugins/multipart/test/dynamic-option.test.ts
+++ b/plugins/multipart/test/dynamic-option.test.ts
@@ -21,7 +21,7 @@ describe('test/dynamic-option.test.ts', () => {
   });
 
   afterAll(async () => {
-    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
   });
   afterAll(() => app.close());
   afterAll(() => server.close());

--- a/plugins/multipart/test/enable-pathToRegexpModule.test.ts
+++ b/plugins/multipart/test/enable-pathToRegexpModule.test.ts
@@ -23,7 +23,7 @@ describe.skip('test/enable-pathToRegexpModule.test.ts', () => {
     host = 'http://127.0.0.1:' + server.address().port;
   });
   afterAll(async () => {
-    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
   });
   afterAll(() => app.close());
   afterAll(() => server.close());

--- a/plugins/multipart/test/file-mode-limit-filesize-per-request.test.ts
+++ b/plugins/multipart/test/file-mode-limit-filesize-per-request.test.ts
@@ -22,7 +22,7 @@ describe('test/file-mode-limit-filesize-per-request.test.ts', () => {
     host = 'http://127.0.0.1:' + server.address().port;
   });
   afterAll(async () => {
-    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
   });
   afterAll(() => app.close());
   afterAll(() => server.close());

--- a/plugins/multipart/test/file-mode.test.ts
+++ b/plugins/multipart/test/file-mode.test.ts
@@ -28,7 +28,7 @@ describe('test/file-mode.test.ts', () => {
     host = 'http://127.0.0.1:' + server.address().port;
   });
   afterAll(async () => {
-    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+    await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
   });
   afterAll(() => app.close());
   afterAll(() => server.close());

--- a/plugins/multipart/test/stream-mode-with-filematch-glob.test.ts
+++ b/plugins/multipart/test/stream-mode-with-filematch-glob.test.ts
@@ -26,7 +26,7 @@ describe('test/stream-mode-with-filematch-glob.test.ts', () => {
   });
   afterAll(async () => {
     try {
-      await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+      await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
     } catch (err) {
       console.error(err);
     }

--- a/plugins/multipart/test/stream-mode-with-filematch.test.ts
+++ b/plugins/multipart/test/stream-mode-with-filematch.test.ts
@@ -26,7 +26,7 @@ describe('test/stream-mode-with-filematch.test.ts', () => {
   });
   afterAll(async () => {
     try {
-      await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+      await fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
     } catch (err) {
       console.error(err);
     }

--- a/plugins/multipart/test/ts.test.ts
+++ b/plugins/multipart/test/ts.test.ts
@@ -25,7 +25,7 @@ describe('test/ts.test.ts', () => {
     host = 'http://127.0.0.1:' + server.address().port;
   });
   afterAll(() => {
-    return fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true });
+    return fs.rm(app.config.multipart.tmpdir, { force: true, recursive: true, maxRetries: 3 });
   });
   afterAll(() => app.close());
   afterAll(() => server.close());

--- a/tools/scripts/test/stop.test.ts
+++ b/tools/scripts/test/stop.test.ts
@@ -8,7 +8,7 @@ import { mm, restore } from 'mm';
 import { describe, it, beforeAll, afterAll, beforeEach, afterEach, expect } from 'vitest';
 
 import { isWindows } from '../src/helper.ts';
-import { cleanup, replaceWeakRefMessage, type Coffee } from './utils.ts';
+import { cleanup, replaceWeakRefMessage, waitFor, type Coffee } from './utils.ts';
 
 const __dirname = import.meta.dirname;
 
@@ -45,7 +45,9 @@ describe('test/stop.test.ts', () => {
       ]) as Coffee;
       app.debug();
       app.expect('code', 0);
-      await scheduler.wait(waitTime);
+      // Poll until the app reports it has started instead of a fixed delay: a 2-worker
+      // egg app can take well over a second to boot on a loaded CI runner.
+      await waitFor(() => app.stdout, /custom-framework started on http:\/\/127\.0\.0\.1:\d+/);
 
       expect(replaceWeakRefMessage(app.stderr)).toBe('');
       expect(app.stdout).toMatch(/custom-framework started on http:\/\/127\.0\.0\.1:\d+/);
@@ -155,7 +157,8 @@ describe('test/stop.test.ts', () => {
       ]) as Coffee;
       // app.debug();
       app.expect('code', 0);
-      await scheduler.wait(waitTime);
+      // Poll until the app reports it has started (see note above).
+      await waitFor(() => app.stdout, /custom-framework started on http:\/\/127\.0\.0\.1:\d+/);
 
       expect(replaceWeakRefMessage(app.stderr)).toBe('');
       expect(app.stdout).toMatch(/custom-framework started on http:\/\/127\.0\.0\.1:\d+/);
@@ -314,7 +317,8 @@ describe('test/stop.test.ts', () => {
       app.debug();
       app.expect('code', 0);
 
-      await scheduler.wait(waitTime);
+      // Poll until the app reports it has started (see note above).
+      await waitFor(() => app.stdout, /http:\/\/127\.0\.0\.1:\d+/);
 
       // assert.equal(replaceWeakRefMessage(app.stderr), '');
       expect(app.stdout).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
@@ -332,7 +336,13 @@ describe('test/stop.test.ts', () => {
       killer.debug();
       killer.expect('code', 0);
       await killer.end();
-      await scheduler.wait(waitTime);
+      // Poll until the app logs its shutdown instead of a fixed delay. On Windows the
+      // SIGTERM signal is not handled (no shutdown log), so keep a fixed settle there.
+      if (isWindows) {
+        await scheduler.wait(waitTime);
+      } else {
+        await waitFor(() => app.stdout, /\[master] master is killed by signal SIGTERM, closing/);
+      }
 
       // make sure is kill not auto exist
       expect(app.stdout).not.toMatch(/exist by env/);
@@ -356,7 +366,13 @@ describe('test/stop.test.ts', () => {
       killer.expect('code', 0);
 
       // await killer.end();
-      await scheduler.wait(waitTime);
+      // Poll until the app has fully exited (master exits last, after workers/agent),
+      // instead of a fixed delay. On Windows the signal is not handled, so settle fixed.
+      if (isWindows) {
+        await scheduler.wait(waitTime);
+      } else {
+        await waitFor(() => app.stdout, /\[master] exit with code:0/);
+      }
 
       // make sure is kill not auto exist
       expect(app.stdout).not.toMatch(/exist by env/);

--- a/tools/scripts/test/utils.ts
+++ b/tools/scripts/test/utils.ts
@@ -55,3 +55,19 @@ export function replaceWeakRefMessage(stderr: string) {
   }
   return stderr;
 }
+
+/**
+ * Poll until `getText()` matches `pattern`, up to `timeout` ms (default 10s),
+ * checking every 100ms. Returns as soon as it matches, and resolves anyway on
+ * timeout so the caller's own `expect(...).toMatch(...)` still produces a useful
+ * diff. Use this instead of a fixed `scheduler.wait(n)` before asserting on a
+ * forked process's stdout: a loaded CI runner may not have finished booting (or
+ * shutting down) within `n`, which is the classic source of these flaky timeouts.
+ */
+export async function waitFor(getText: () => string, pattern: RegExp, timeout = 10000): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (!pattern.test(getText())) {
+    if (Date.now() >= deadline) return;
+    await scheduler.wait(100);
+  }
+}


### PR DESCRIPTION
Two unrelated **flaky test** fixes surfaced while stabilizing CI for the snapshot work (#6011). Test-only; no `src` changes.

## 1. `@eggjs/multipart` — `ENOTEMPTY` teardown race

`file-mode.test.ts` flaked on macOS Node 24 (passing on every other matrix job):

```
Error: ENOTEMPTY: directory not empty, rmdir '.../egg-multipart-tmp/multipart-file-mode-demo/2026/06/28/05'
```

`fs.rm(tmpdir, { force: true, recursive: true })` defaults to `maxRetries: 0`, so a transient `ENOTEMPTY` (a file in a date-bucket dir mid recursive-removal — async per-request cleanup draining / APFS latency) throws and fails the suite. The production `clean_tmpdir` schedule already swallows these; only the 7 test teardowns are fragile. **Fix:** add `maxRetries: 3` to all 7.

## 2. `@eggjs/scripts` — flaky `stop.test.ts` start readiness

`Test scripts (ubuntu-22)` failed in `stop.test.ts`:

```
AssertionError: expected 'Starting custom-framework application…' to match /custom-framework started on http:\/\/…/
```

`stop.test.ts` waited a fixed **1s** for a 2-worker egg app to boot before asserting its `started on http://…` log — while every sibling `start-without-demon-*.test.ts` waits **10s**. On a loaded runner 1s isn't enough. **Fix:** replace the fixed `scheduler.wait(waitTime)` before each startup/shutdown assertion with a `waitFor(getText, pattern, timeout)` poll (`test/utils.ts`) that returns as soon as the expected output appears (up to 10s) — race-free and faster than a fixed delay. Windows keeps the fixed settle for the signal-driven shutdown checks (SIGTERM isn't handled there).

## Verification
- multipart: the 7 teardowns now retry; affected tests pass locally.
- scripts: `stop.test.ts` passes locally after build (8 passed, 1 skipped).

Re Gemini's review on the multipart hunks: it claimed Vitest runs `afterAll` in registration order — that's incorrect (default `sequence.hooks: 'stack'` → reverse; verified empirically on v4.1.9), so the current teardown already removes the tmpdir **last** (after `server.close()`/`app.close()`); the suggested reorder would move `fs.rm` first and reintroduce the race. Replied inline on each thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cleanup reliability across multipart-related test suites by adding additional retry behavior when removing temporary directories during teardown.
  * Updated process lifecycle checks in test runs to wait for specific startup/shutdown output instead of relying on fixed timing, reducing flaky boot/shutdown timing.
  * Introduced a reusable polling helper to detect expected log output within a timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->