### PR TITLE
fix(ci): publish release with npm instead of ut publish

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -137,31 +137,40 @@ for (const pkg of packages) {
   }
 }
 
-// Retry failed packages once
+// Retry failed packages once. A dry-run retry would just reproduce the same
+// result, so we skip the retry but still report the failures — otherwise a
+// dry-run would exit 0 even when every package failed to pack, defeating its
+// purpose as a pre-flight check.
 const finalFailed = [];
-if (toRetry.length > 0 && !isDryRun) {
-  console.log(`\n🔄 Retrying ${toRetry.length} failed package(s)...`);
-
-  for (const pkg of toRetry) {
-    const label = `${pkg.name}@${pkg.version}`;
-
-    if (isPublished(pkg.name, pkg.version)) {
-      console.log(`  ⏭️  ${label} now published`);
-      skipped.push(label);
-      continue;
+if (toRetry.length > 0) {
+  if (isDryRun) {
+    for (const pkg of toRetry) {
+      finalFailed.push(`${pkg.name}@${pkg.version}`);
     }
+  } else {
+    console.log(`\n🔄 Retrying ${toRetry.length} failed package(s)...`);
 
-    try {
-      publishOne(pkg);
-      console.log(`  ✅ ${label} (retry)`);
-      published.push(label);
-    } catch {
+    for (const pkg of toRetry) {
+      const label = `${pkg.name}@${pkg.version}`;
+
       if (isPublished(pkg.name, pkg.version)) {
-        console.log(`  ⏭️  ${label} now published (confirmed after retry error)`);
+        console.log(`  ⏭️  ${label} now published`);
         skipped.push(label);
-      } else {
-        console.error(`  ❌ ${label} retry failed`);
-        finalFailed.push(label);
+        continue;
+      }
+
+      try {
+        publishOne(pkg);
+        console.log(`  ✅ ${label} (retry)`);
+        published.push(label);
+      } catch {
+        if (isPublished(pkg.name, pkg.version)) {
+          console.log(`  ⏭️  ${label} now published (confirmed after retry error)`);
+          skipped.push(label);
+        } else {
+          console.error(`  ❌ ${label} retry failed`);
+          finalFailed.push(label);
+        }
       }
     }
   }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -3,7 +3,14 @@
 /**
  * Resilient per-package publish script.
  *
- * Unlike `ut -r publish`, this script:
+ * Publishes with npm so the release keeps npm trusted publishing / provenance
+ * via OIDC (`ut publish` supports neither `--access` nor `--provenance`).
+ * Because npm does not understand the pnpm/utoo `workspace:` and `catalog:`
+ * protocol specifiers, each package manifest is rewritten to concrete version
+ * ranges right before publishing and restored afterwards — the same rewrite
+ * `pnpm publish` performed for us before the utoo migration.
+ *
+ * On top of that, unlike a bulk publish this script:
  * - Skips packages that are already published on npm (safe for retries)
  * - Publishes each package individually so one failure doesn't block others
  * - Retries failed packages once
@@ -14,9 +21,16 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 
-import { getPublishablePackages } from './utils.js';
+import {
+  applyPublishConfigOverrides,
+  getCatalogs,
+  getPublishablePackages,
+  getWorkspaceVersionMap,
+  resolveWorkspaceProtocols,
+} from './utils.js';
 
 const args = process.argv.slice(2);
 const isDryRun = args.includes('--dry-run');
@@ -30,7 +44,9 @@ if (tagArg) {
 
 const baseDir = path.join(import.meta.dirname, '..');
 const packages = getPublishablePackages(baseDir);
-const utBin = process.platform === 'win32' ? 'ut.cmd' : 'ut';
+const versionMap = getWorkspaceVersionMap(baseDir);
+const catalogs = getCatalogs(baseDir);
+const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 console.log(
   `📦 Publishing ${packages.length} packages (tag: ${npmTag}${isDryRun ? ', dry-run' : ''}${useProvenance ? ', provenance' : ''})`,
@@ -41,7 +57,7 @@ console.log(
  */
 function isPublished(name, version) {
   try {
-    const result = execFileSync('npm', ['view', `${name}@${version}`, 'version'], {
+    const result = execFileSync(npmBin, ['view', `${name}@${version}`, 'version'], {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 15000,
@@ -55,23 +71,39 @@ function isPublished(name, version) {
 }
 
 /**
- * Publish a single package by running `ut publish` from the package
- * directory. utoo's publish only documents --tag/--dry-run/--otp, so we
- * keep the npm-standard --access/--provenance flags (forwarded to npm)
- * and configure npm to skip git checks because the release workflow builds
- * gitignored dist outputs before publishing.
+ * Publish a single package with npm from the package directory. The manifest is
+ * rewritten in place to resolve `workspace:` / `catalog:` protocol specifiers
+ * (npm understands neither) and to hoist `publishConfig` overrides such as
+ * `exports`, then restored in a `finally` block so a crash mid-publish can never
+ * leave the rewritten manifest on disk. `--access` and `--provenance` are
+ * npm-native flags.
  */
 function publishOne(pkg) {
   const publishArgs = ['publish', '--access', 'public', '--tag', npmTag];
   if (useProvenance) publishArgs.push('--provenance');
   if (isDryRun) publishArgs.push('--dry-run');
 
-  execFileSync(utBin, publishArgs, {
-    cwd: path.join(baseDir, pkg.directory, pkg.folder),
-    stdio: 'inherit',
-    env: { ...process.env, NPM_CONFIG_LOGLEVEL: 'verbose', NPM_CONFIG_GIT_CHECKS: 'false' },
-    timeout: 120000,
-  });
+  const packageDir = path.join(baseDir, pkg.directory, pkg.folder);
+  const manifestPath = path.join(packageDir, 'package.json');
+  const originalManifest = fs.readFileSync(manifestPath, 'utf8');
+
+  try {
+    const withVersions = resolveWorkspaceProtocols(JSON.parse(originalManifest), {
+      versionMap,
+      catalogs,
+    });
+    const resolved = applyPublishConfigOverrides(withVersions);
+    fs.writeFileSync(manifestPath, `${JSON.stringify(resolved, null, 2)}\n`);
+
+    execFileSync(npmBin, publishArgs, {
+      cwd: packageDir,
+      stdio: 'inherit',
+      env: { ...process.env, NPM_CONFIG_LOGLEVEL: 'verbose' },
+      timeout: 120000,
+    });
+  } finally {
+    fs.writeFileSync(manifestPath, originalManifest);
+  }
 }
 
 const published = [];

--- a/scripts/sync-cnpm.js
+++ b/scripts/sync-cnpm.js
@@ -7,7 +7,7 @@ import urllib from 'urllib';
 import { getPublishablePackages } from './utils.js';
 
 const baseDir = path.join(import.meta.dirname, '..');
-const packages = getPublishablePackages(baseDir).filter((pkg) => !pkg.private);
+const packages = getPublishablePackages(baseDir);
 
 console.log(`🚀 Syncing to https://npmmirror.com ...`);
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -3,19 +3,62 @@ import path from 'node:path';
 
 import yaml from 'js-yaml';
 
-// Get all publishable packages by reading pnpm-workspace.yaml
-// (utoo consumes the same workspace manifest).
+// Dependency fields whose `workspace:` / `catalog:` specifiers must be resolved
+// before publishing with npm.
+const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
 
-export function getPublishablePackages(baseDir) {
+// Manifest fields that pnpm/utoo hoist from `publishConfig` onto the published
+// package at publish time. npm leaves `publishConfig` untouched apart from its
+// own keys (registry/access/tag/provenance), so we replicate the hoist here.
+// (`access`/`tag` are intentionally absent — npm reads those from publishConfig
+// directly and they are also passed on the CLI.)
+const PUBLISH_CONFIG_OVERRIDE_FIELDS = [
+  'bin',
+  'main',
+  'module',
+  'exports',
+  'types',
+  'typings',
+  'browser',
+  'esnext',
+  'es2015',
+  'unpkg',
+  'umd:main',
+  'typesVersions',
+  'cpu',
+  'os',
+];
+
+function readWorkspaceConfig(baseDir) {
   const workspaceFile = path.join(baseDir, 'pnpm-workspace.yaml');
 
   if (!fs.existsSync(workspaceFile)) {
     throw new Error('pnpm-workspace.yaml not found');
   }
 
-  const workspaceConfig = yaml.load(fs.readFileSync(workspaceFile, 'utf8'));
-  const packages = workspaceConfig.packages || [];
-  const publishablePackages = [];
+  return yaml.load(fs.readFileSync(workspaceFile, 'utf8')) || {};
+}
+
+// Walk every workspace package declared in pnpm-workspace.yaml
+// (utoo consumes the same workspace manifest) and yield a lightweight record
+// for each one, regardless of whether it is private.
+function collectWorkspacePackages(baseDir) {
+  const { packages = [] } = readWorkspaceConfig(baseDir);
+  const collected = [];
+
+  const pushPackage = (directory, folder, packageJsonPath) => {
+    if (!fs.existsSync(packageJsonPath)) {
+      return;
+    }
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    collected.push({
+      folder,
+      directory,
+      name: packageJson.name,
+      private: packageJson.private,
+      version: packageJson.version,
+    });
+  };
 
   for (const packagePattern of packages) {
     // Handle glob patterns like 'packages/*', 'tools/*', etc.
@@ -29,39 +72,131 @@ export function getPublishablePackages(baseDir) {
           .filter((folder) => fs.statSync(path.join(fullDir, folder)).isDirectory());
 
         for (const folder of folders) {
-          const packageJsonPath = path.join(fullDir, folder, 'package.json');
-          if (fs.existsSync(packageJsonPath)) {
-            const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-            // Include packages that are not explicitly marked as private
-            if (!packageJson.private) {
-              publishablePackages.push({
-                folder,
-                directory: dirPath,
-                name: packageJson.name,
-                private: packageJson.private,
-                version: packageJson.version,
-              });
-            }
-          }
+          pushPackage(dirPath, folder, path.join(fullDir, folder, 'package.json'));
         }
       }
     } else {
       // Handle direct package paths like 'site'
-      const packageJsonPath = path.join(baseDir, packagePattern, 'package.json');
-      if (fs.existsSync(packageJsonPath)) {
-        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-        if (!packageJson.private) {
-          publishablePackages.push({
-            folder: path.basename(packagePattern),
-            directory: path.dirname(packagePattern) || '.',
-            name: packageJson.name,
-            private: packageJson.private,
-            version: packageJson.version,
-          });
-        }
-      }
+      pushPackage(
+        path.dirname(packagePattern) || '.',
+        path.basename(packagePattern),
+        path.join(baseDir, packagePattern, 'package.json'),
+      );
     }
   }
 
-  return publishablePackages;
+  return collected;
+}
+
+// Get all publishable packages (those not explicitly marked as private).
+export function getPublishablePackages(baseDir) {
+  return collectWorkspacePackages(baseDir).filter((pkg) => !pkg.private);
+}
+
+// Build a `name -> version` map for every workspace package (including private
+// ones) so `workspace:` protocol specifiers can be resolved to the concrete
+// versions currently on disk.
+export function getWorkspaceVersionMap(baseDir) {
+  const versions = {};
+  for (const pkg of collectWorkspacePackages(baseDir)) {
+    if (pkg.name) {
+      versions[pkg.name] = pkg.version;
+    }
+  }
+  return versions;
+}
+
+// Read the pnpm/utoo catalogs: the default `catalog` table and any named
+// `catalogs.<name>` tables.
+export function getCatalogs(baseDir) {
+  const config = readWorkspaceConfig(baseDir);
+  return {
+    default: config.catalog || {},
+    named: config.catalogs || {},
+  };
+}
+
+function resolveWorkspaceSpec(name, spec, versionMap) {
+  const version = versionMap[name];
+  if (!version) {
+    throw new Error(`Cannot resolve workspace dependency "${name}" (${spec}): no workspace package with that name`);
+  }
+  const range = spec.slice('workspace:'.length);
+  // pnpm semantics: `workspace:*` (and bare `workspace:`) pin the exact version,
+  // `workspace:^` / `workspace:~` add the matching prefix, and an explicit range
+  // such as `workspace:^1.2.3` is published with the `workspace:` prefix removed.
+  if (range === '' || range === '*') {
+    return version;
+  }
+  if (range === '^' || range === '~') {
+    return `${range}${version}`;
+  }
+  return range;
+}
+
+function resolveCatalogSpec(name, spec, catalogs) {
+  const catalogName = spec.slice('catalog:'.length);
+  const table = catalogName === '' ? catalogs.default : catalogs.named[catalogName];
+  if (!table || table[name] === undefined) {
+    const where = catalogName === '' ? 'default catalog' : `catalog "${catalogName}"`;
+    throw new Error(`Cannot resolve catalog dependency "${name}" (${spec}): missing from ${where}`);
+  }
+  return table[name];
+}
+
+// Replace pnpm/utoo `workspace:` and `catalog:` protocol specifiers in a package
+// manifest with concrete version ranges. npm understands neither protocol and
+// would otherwise publish the literal `workspace:*` / `catalog:` strings,
+// producing uninstallable packages. This mirrors what `pnpm publish` did for us
+// before the utoo migration. Returns a new manifest object; the input is not
+// mutated.
+export function resolveWorkspaceProtocols(manifest, { versionMap, catalogs }) {
+  const resolved = { ...manifest };
+
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = manifest[field];
+    if (!deps) {
+      continue;
+    }
+
+    const next = { ...deps };
+    for (const [name, spec] of Object.entries(deps)) {
+      if (typeof spec !== 'string') {
+        continue;
+      }
+      if (spec.startsWith('workspace:')) {
+        next[name] = resolveWorkspaceSpec(name, spec, versionMap);
+      } else if (spec.startsWith('catalog:')) {
+        next[name] = resolveCatalogSpec(name, spec, catalogs);
+      }
+    }
+    resolved[field] = next;
+  }
+
+  return resolved;
+}
+
+// Apply pnpm/utoo-style `publishConfig` overrides to a manifest: for the
+// publish-relevant fields (see PUBLISH_CONFIG_OVERRIDE_FIELDS), replace the
+// top-level value with the one declared under `publishConfig`. These egg
+// packages ship a dev-time root `exports` pointing at TypeScript source and a
+// `publishConfig.exports` pointing at the compiled `dist/` output; pnpm hoisted
+// the latter on publish. Plain `npm publish` does not, so without this the
+// published `exports` would point at `src/` files that are not even in the
+// tarball (`files: ["dist"]`), breaking every consumer. `publishConfig` itself
+// is left in place (npm still reads access/tag/registry from it). Returns a new
+// manifest object; the input is not mutated.
+export function applyPublishConfigOverrides(manifest) {
+  const { publishConfig } = manifest;
+  if (!publishConfig) {
+    return manifest;
+  }
+
+  const overridden = { ...manifest };
+  for (const field of PUBLISH_CONFIG_OVERRIDE_FIELDS) {
+    if (publishConfig[field] !== undefined) {
+      overridden[field] = publishConfig[field];
+    }
+  }
+  return overridden;
 }


### PR DESCRIPTION
## Motivation

The [Manual Release run](https://github.com/eggjs/egg/actions/runs/28323984300/job/83910742571) failed at the **Publish packages** step:

```
📦 Publishing 79 packages (tag: beta, provenance)
error: unexpected argument '--access' found
Usage: ut publish [OPTIONS]
```

`ut publish` does not accept npm-native flags (`--access`, `--provenance`), and more importantly it cannot do npm **trusted publishing / provenance via OIDC** — which is the whole reason the release workflow uses them. So this switches `scripts/publish.js` back to `npm publish`.

## The catch: npm doesn't replicate everything `pnpm publish` did

A naive `ut` → `npm` swap would publish **broken** packages, because npm understands neither of two things that `pnpm publish` handled for us before the utoo migration:

1. **`workspace:` / `catalog:` protocol specifiers.** 79 publishable packages ship `workspace:*`, `catalog:` and `catalog:path-to-regexp1` in their runtime `dependencies` (984 such specs). npm publishes them verbatim → uninstallable packages.
2. **`publishConfig` field hoisting.** 77/79 packages set a dev-time root `exports` pointing at `./src/*.ts` and a `publishConfig.exports` pointing at compiled `./dist/*.js`. pnpm hoists `publishConfig` on publish; **npm does not**. Since `files: ["dist"]`, the source isn't even in the tarball — every consumer's `import 'egg'` would resolve to a non-existent `./src/index.ts`. (npm exits 0 either way, so it fails silently.)

## Changes

`scripts/publish.js` now prepares each manifest right before `npm publish` and restores it in a `finally` (crash-safe), mirroring pnpm:

- resolve `workspace:*` → exact in-repo version, `workspace:^`/`~` → prefixed; `catalog:` / `catalog:<name>` → the spec from `pnpm-workspace.yaml`
- hoist `publishConfig` overrides (notably `exports`) onto the top-level manifest

`scripts/utils.js` gains `getWorkspaceVersionMap`, `getCatalogs`, `resolveWorkspaceProtocols`, and `applyPublishConfigOverrides` (and a `collectWorkspacePackages` refactor that keeps `getPublishablePackages` behavior identical). Also: `isPublished()` now uses the resolved `npm`/`npm.cmd` binary for Windows parity, and a redundant `.filter(!private)` in `sync-cnpm.js` is dropped.

## Tests / verification

- Across **all 79 publishable packages / 984 deps**: 0 leftover `workspace:`/`catalog:` specifiers after rewrite; every `workspace:*` → exact version, every `catalog:` → its table spec.
- **Ground-truth match** against the last pnpm-published manifests on npm: `@eggjs/router` (`path-to-regexp: ^1.9.0` via the named catalog), `@eggjs/security` (`@eggjs/ip: ^2.1.0`, `@eggjs/path-matching` exact), and `@eggjs/core` reproduce exactly.
- `publishConfig.exports` hoisted for all 77 packages that declare it; **0** resolved `exports` left pointing at `src/`.
- Real `npm pack` of `@eggjs/core` with the full rewrite produces `exports["."] = "./dist/index.js"`; the manifest is restored afterwards (git clean).
- `npm publish --dry-run` accepts `--access`/`--tag`/`--dry-run` (the flags `ut publish` rejected).
- `oxfmt --check` and `oxlint --type-aware` clean; pre-commit hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing now supports workspace-linked and catalog-based dependency/version resolution for each package.
  * Publish settings are applied automatically during publishing so released metadata stays consistent.

* **Bug Fixes**
  * Prevents leaving modified manifests behind by restoring package files after publish operations, even on failure.
  * Improved cross-platform publishing behavior (including Windows).

* **Behavior Changes**
  * Dry-run no longer retries after simulated failures; failures are reported accurately for visibility.
  * Still skips packages already available on the registry and retries failed publishes once (non-dry-run).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->