### PR TITLE
fix(development): start reload watcher in didReady instead of serverDidReady

### DIFF
--- a/plugins/development/src/agent.ts
+++ b/plugins/development/src/agent.ts
@@ -27,7 +27,13 @@ export default class AgentBoot implements ILifecycleBoot {
     }
   }
 
-  async serverDidReady(): Promise<void> {
+  // Set up the reload file watcher in `didReady` (agent is ready) instead of
+  // `serverDidReady` (which waits for the app workers to be ready). The watcher
+  // only needs the agent itself; waiting for the app server means file changes
+  // that happen right after the workers start — but before `serverDidReady`
+  // fires — are not being watched yet and get missed (the reload never triggers).
+  // Starting the watch earlier closes that window without changing reload behavior.
+  async didReady(): Promise<void> {
     const agent = this.#agent;
     // single process mode don't watch and reload
     if (agent.options && Reflect.get(agent.options, 'mode') === 'single') {


### PR DESCRIPTION
## What's the problem

The dev reload file watcher in `@eggjs/development` is set up in
`AgentBoot.serverDidReady()`. This lifecycle hook fires **after the app workers
are ready**. Any source file that changes in the window between "workers ready"
and "`serverDidReady` fired" is therefore **not being watched yet**, so the
change is missed and the worker never reloads.

The watcher only needs the agent itself — it does not depend on the app server
being up. Waiting for `serverDidReady` just delays the start of watching and
opens this race window.

## How to reproduce

Start `egg-bin dev` and modify a watched source file the instant the worker
becomes ready (before `serverDidReady`). The file watcher hasn't been attached
yet, so no `reload worker because ...` is logged and the worker keeps the old
code.

This was surfaced by a downstream framework (chair-bin) whose hot-reload e2e
tests edit `app.js` the moment the worker prints its startup log. On egg 4 the
edit consistently landed before `serverDidReady`, so the reload never fired and
the tests hung until timeout. Moving the watch setup earlier makes all of them
pass again.

## The fix

Move the reload watcher setup from `serverDidReady()` to `didReady()` (agent is
ready, before the app workers boot). Watching starts earlier and no early change
is lost. **Reload behavior itself is unchanged** — it still only reloads when a
watched file actually changes, honoring `reloadOnDebug` / `reloadPattern` /
ignore dirs exactly as before.

Single-process mode is still skipped, same as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development reload reliability by starting file watching earlier, reducing the chance of missing file changes during startup.
  * Development updates should now trigger more consistently when files change right after the server begins launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->