### PR TITLE
fix(controller): register middlewareGraphHook before global graph build

### DIFF
--- a/tegg/plugin/controller/src/app.ts
+++ b/tegg/plugin/controller/src/app.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 
 import { ControllerMetaBuilderFactory, ControllerType } from '@eggjs/controller-decorator';
-import { GlobalGraph, type LoadUnitLifecycleContext } from '@eggjs/metadata';
+import type { LoadUnitLifecycleContext } from '@eggjs/metadata';
 import { type LoadUnitInstanceLifecycleContext, ModuleLoadUnitInstance } from '@eggjs/tegg-runtime';
 import { AGENT_CONTROLLER_PROTO_IMPL_TYPE, TeggScope } from '@eggjs/tegg-types';
 import type { Application, ILifecycleBoot } from 'egg';
@@ -164,8 +164,14 @@ export default class ControllerAppBootHook implements ILifecycleBoot {
   }
 
   configDidLoad(): void {
-    // Pin to this app's graph (set later during didLoad) — no run wrap needed.
-    GlobalGraph.instanceFor(this.app._teggScopeBag)?.registerBuildHook(middlewareGraphHook);
+    // The per-app GlobalGraph does not exist yet (it is created inside
+    // moduleHandler.init() during didLoad), so registering on the graph here
+    // would be a silent no-op and cross-module controller middleware inject
+    // edges would never be woven. Buffer the hook on moduleHandler instead —
+    // it is flushed onto the graph right after creation, before build() runs.
+    // moduleHandler is created in the tegg plugin's configDidLoad, which runs
+    // before ours (teggController declares a dependency on tegg).
+    this.app.moduleHandler.registerGlobalGraphBuildHook(middlewareGraphHook);
   }
 
   mcpEnable(): boolean {

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/app/controller/README.md
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/app/controller/README.md
@@ -1,0 +1,1 @@
+// keep the app/controller dir for the controller loader

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/config/config.default.ts
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/config/config.default.ts
@@ -1,0 +1,11 @@
+export default () => {
+  const config = {
+    keys: 'test key',
+    security: {
+      csrf: {
+        ignoreJSON: false,
+      },
+    },
+  };
+  return config;
+};

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/config/module.json
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/config/module.json
@@ -1,0 +1,8 @@
+[
+  {
+    "path": "../../controller-app/modules/multi-module-common"
+  },
+  {
+    "path": "../../controller-app/modules/multi-module-controller"
+  }
+]

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/config/plugin.ts
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/config/plugin.ts
@@ -1,0 +1,22 @@
+export default {
+  tracer: {
+    package: '@eggjs/tracer',
+    enable: true,
+  },
+  tegg: {
+    package: '@eggjs/tegg-plugin',
+    enable: true,
+  },
+  teggConfig: {
+    package: '@eggjs/tegg-config',
+    enable: true,
+  },
+  teggAop: {
+    package: '@eggjs/aop-plugin',
+    enable: true,
+  },
+  teggController: {
+    package: '@eggjs/controller-plugin',
+    enable: true,
+  },
+};

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/package.json
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-b/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "controller-app-multi-b",
+  "type": "module"
+}

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/app/controller/README.md
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/app/controller/README.md
@@ -1,0 +1,1 @@
+// keep the app/controller dir for the controller loader

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/config/config.default.ts
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/config/config.default.ts
@@ -1,0 +1,11 @@
+export default () => {
+  const config = {
+    keys: 'test key',
+    security: {
+      csrf: {
+        ignoreJSON: false,
+      },
+    },
+  };
+  return config;
+};

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/config/module.json
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/config/module.json
@@ -1,0 +1,8 @@
+[
+  {
+    "path": "../../controller-app/modules/multi-module-common"
+  },
+  {
+    "path": "../../controller-app/modules/multi-module-controller"
+  }
+]

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/config/plugin.ts
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/config/plugin.ts
@@ -1,0 +1,22 @@
+export default {
+  tracer: {
+    package: '@eggjs/tracer',
+    enable: true,
+  },
+  tegg: {
+    package: '@eggjs/tegg-plugin',
+    enable: true,
+  },
+  teggConfig: {
+    package: '@eggjs/tegg-config',
+    enable: true,
+  },
+  teggAop: {
+    package: '@eggjs/aop-plugin',
+    enable: true,
+  },
+  teggController: {
+    package: '@eggjs/controller-plugin',
+    enable: true,
+  },
+};

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/package.json
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app-multi-c/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "controller-app-multi-c",
+  "type": "module"
+}

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app/config/module.json
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app/config/module.json
@@ -7,5 +7,8 @@
   },
   {
     "path": "../modules/multi-module-service"
+  },
+  {
+    "path": "../modules/multi-module-controller"
   }
 ]

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app/modules/multi-module-controller/CrossModuleMiddlewareController.ts
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app/modules/multi-module-controller/CrossModuleMiddlewareController.ts
@@ -1,0 +1,33 @@
+import { HTTPController, HTTPMethod, HTTPMethodEnum, Middleware } from '@eggjs/tegg';
+
+import { CountAdvice } from '../multi-module-common/advice/CountAdvice.js';
+import { FooMethodAdvice } from '../multi-module-common/advice/FooMethodAdvice.js';
+
+@HTTPController({
+  path: '/module/aop/middleware',
+})
+@Middleware(CountAdvice)
+export class CrossModuleMiddlewareController {
+  @HTTPMethod({
+    method: HTTPMethodEnum.GET,
+    path: '/global',
+  })
+  // CountAdvice
+  async global() {
+    return {
+      method: 'moduleGlobal',
+    };
+  }
+
+  @HTTPMethod({
+    method: HTTPMethodEnum.GET,
+    path: '/method',
+  })
+  @Middleware(FooMethodAdvice)
+  // FooMethodAdvice, CountAdvice
+  async method() {
+    return {
+      method: 'moduleMethod',
+    };
+  }
+}

--- a/tegg/plugin/controller/test/fixtures/apps/controller-app/modules/multi-module-controller/package.json
+++ b/tegg/plugin/controller/test/fixtures/apps/controller-app/modules/multi-module-controller/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "multi-module-controller",
+  "type": "module",
+  "eggModule": {
+    "name": "multi-module-controller"
+  }
+}

--- a/tegg/plugin/controller/test/http/middleware-graph-multi-app.test.ts
+++ b/tegg/plugin/controller/test/http/middleware-graph-multi-app.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+
+import { GlobalGraph } from '@eggjs/metadata';
+import { mm } from '@eggjs/mock';
+import type { InjectObjectDescriptor, ProtoDescriptor } from '@eggjs/tegg-types';
+import { afterEach, describe, it } from 'vitest';
+
+import { getFixtures } from '../utils.ts';
+
+function findControllerProto(globalGraph: GlobalGraph): ProtoDescriptor | undefined {
+  return globalGraph.moduleProtoDescriptorMap
+    .get('multi-module-controller')
+    ?.find((proto) => proto.name === 'crossModuleMiddlewareController');
+}
+
+function findCountAdviceInject(globalGraph: GlobalGraph, controllerProto: ProtoDescriptor) {
+  return globalGraph.findInjectProto(controllerProto, {
+    objName: 'countAdvice',
+  } as InjectObjectDescriptor);
+}
+
+describe('plugin/controller/test/http/middleware-graph-multi-app.test.ts', () => {
+  afterEach(() => {
+    return mm.restore();
+  });
+
+  it('should scope buffered middlewareGraphHook per app under concurrent boot', async () => {
+    // Both apps load the SAME cross-module middleware fixture modules. The
+    // buffered hook registration must land on each app's OWN graph: distinct
+    // graph instances, each with its own woven middleware inject edges.
+    const app1 = mm.app({ baseDir: getFixtures('apps/controller-app-multi-b') });
+    const app2 = mm.app({ baseDir: getFixtures('apps/controller-app-multi-c') });
+    await Promise.all([app1.ready(), app2.ready()]);
+    try {
+      const graph1 = GlobalGraph.instanceFor((app1 as any)._teggScopeBag);
+      const graph2 = GlobalGraph.instanceFor((app2 as any)._teggScopeBag);
+      assert(graph1);
+      assert(graph2);
+      assert.notStrictEqual(graph1, graph2, 'each app must have its own GlobalGraph');
+
+      for (const graph of [graph1!, graph2!]) {
+        const controllerProto = findControllerProto(graph);
+        assert(controllerProto, 'controller proto should exist in each app graph');
+        const countAdviceProto = findCountAdviceInject(graph, controllerProto!);
+        assert(countAdviceProto, 'middleware inject edge should be woven in each app graph');
+        assert.equal(countAdviceProto!.instanceModuleName, 'multi-module-common');
+      }
+
+      // The protos behind the edges are per-app instances, not shared.
+      const proto1 = findCountAdviceInject(graph1!, findControllerProto(graph1!)!);
+      const proto2 = findCountAdviceInject(graph2!, findControllerProto(graph2!)!);
+      assert.notStrictEqual(proto1, proto2, 'advice protos must not be shared across apps');
+    } finally {
+      await Promise.all([app1.close(), app2.close()]);
+    }
+  });
+});

--- a/tegg/plugin/controller/test/http/middleware-graph.test.ts
+++ b/tegg/plugin/controller/test/http/middleware-graph.test.ts
@@ -1,0 +1,70 @@
+import { GlobalGraph } from '@eggjs/metadata';
+import { mm, type MockApplication } from '@eggjs/mock';
+import type { InjectObjectDescriptor } from '@eggjs/tegg-types';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { getFixtures } from '../utils.ts';
+
+describe('plugin/controller/test/http/middleware-graph.test.ts', () => {
+  let app: MockApplication;
+
+  afterEach(() => {
+    return mm.restore();
+  });
+
+  beforeAll(async () => {
+    app = mm.app({
+      baseDir: getFixtures('apps/controller-app'),
+    });
+    await app.ready();
+  });
+
+  afterAll(() => {
+    return app.close();
+  });
+
+  it('middlewareGraphHook should weave cross-module middleware inject edges during graph build', () => {
+    const globalGraph = GlobalGraph.instanceFor((app as any)._teggScopeBag);
+    expect(globalGraph).toBeTruthy();
+
+    const controllerProtos = globalGraph!.moduleProtoDescriptorMap.get('multi-module-controller');
+    const controllerProto = controllerProtos?.find((proto) => proto.name === 'crossModuleMiddlewareController');
+    expect(controllerProto).toBeTruthy();
+
+    // middlewareGraphHook runs inside globalGraph.build() and adds an inject
+    // edge from the controller proto to every cross-module middleware advice
+    // proto. If the hook is registered after build() has already run (or never
+    // registered at all), these edges are silently missing.
+    const countAdviceProto = globalGraph!.findInjectProto(controllerProto!, {
+      objName: 'countAdvice',
+    } as InjectObjectDescriptor);
+    expect(countAdviceProto).toBeTruthy();
+    expect(countAdviceProto!.instanceModuleName).toBe('multi-module-common');
+
+    const fooMethodAdviceProto = globalGraph!.findInjectProto(controllerProto!, {
+      objName: 'fooMethodAdvice',
+    } as InjectObjectDescriptor);
+    expect(fooMethodAdviceProto).toBeTruthy();
+    expect(fooMethodAdviceProto!.instanceModuleName).toBe('multi-module-common');
+  });
+
+  it('cross-module controller middleware should work', async () => {
+    app.mockCsrf();
+    const res = await app.httpRequest().get('/module/aop/middleware/global').expect(200);
+    expect(res.body).toEqual({
+      method: 'moduleGlobal',
+      count: 0,
+      aopList: ['CountAdvice'],
+    });
+  });
+
+  it('cross-module method middleware should work', async () => {
+    app.mockCsrf();
+    const res = await app.httpRequest().get('/module/aop/middleware/method').expect(200);
+    expect(res.body).toEqual({
+      method: 'moduleMethod',
+      count: 0,
+      aopList: ['CountAdvice', 'FooMethodAdvice'],
+    });
+  });
+});


### PR DESCRIPTION
## Motivation

`middlewareGraphHook` was registered in the controller plugin's `configDidLoad` via `GlobalGraph.instanceFor(bag)?.registerBuildHook(...)`. But the per-app `GlobalGraph` is only created inside `moduleHandler.init()` during `didLoad`, so at that point `instanceFor` returns `undefined` and the optional chain silently no-ops — **cross-module controller middleware inject edges were never woven into the graph**.

This is a migration regression: in the standalone tegg repo the graph was created synchronously in the `EggModuleLoader` constructor (tegg plugin `configDidLoad`, which runs before the controller plugin's), so registering on `GlobalGraph.instance!` there worked. The migration moved graph creation into the async `load()` path and changed the non-null assertion into an optional chain, which masked the breakage.

## Change

Route the registration through `moduleHandler.registerGlobalGraphBuildHook()` — hooks buffered there are flushed onto the graph right after creation, before `build()` runs. This is the same pattern the aop plugin uses for its crosscut/pointcut graph hooks (`plugin/aop/src/app.ts`).

## Tests

- New fixture module `multi-module-controller` with a controller using cross-module `@Middleware` advices (`CountAdvice` / `FooMethodAdvice` from `multi-module-common`).
- New regression test `test/http/middleware-graph.test.ts` asserts the inject edges exist in the built graph (fails before the fix — the request-level behavior tests pass either way because middleware resolution is lazy at request time, which is exactly why this regression was silent).
- `@eggjs/controller-plugin` + `@eggjs/aop-plugin` suites: 16 files / 71 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller middleware setup so cross-module middleware is applied reliably after the app finishes loading.
  * Fixed cases where middleware could be missed during startup, helping controller endpoints return the expected middleware behavior.
* **Tests**
  * Added coverage for cross-module middleware behavior, including both global and method-level middleware responses.
  * Added a concurrent multi-app test to verify the middleware graph hook is correctly buffered and scoped per app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->