### PR TITLE
fix(core): FileLoader support .mjs as first-class

### DIFF
--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -64,7 +64,7 @@ export interface FileLoaderParseItem {
 type NormalizedFileLoaderOptions = FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle' | 'loaderFS'>>;
 
 function getDefaultFileLoaderMatch(): string[] {
-  return isSupportTypeScript() ? ['**/*.(js|ts|mjs)', '!**/*.d.ts'] : ['**/*.{js,mjs}'];
+  return isSupportTypeScript() ? ['**/*.(js|ts|mjs|cjs)', '!**/*.d.ts'] : ['**/*.{js,mjs,cjs}'];
 }
 
 /**
@@ -220,8 +220,12 @@ export class FileLoader {
       for (const filepath of filepaths) {
         const fullpath = path.join(directory, filepath);
         if (!this.options.loaderFS.stat(fullpath).isFile()) continue;
-        if (filepath.endsWith('.js')) {
-          const filepathTs = filepath.replace(/\.js$/, '.ts');
+        // A compiled `.js` / `.mjs` / `.cjs` sitting next to its `.ts` source (e.g. `tsc`
+        // or `tsdown` output kept in the same directory during development) must not be
+        // loaded on top of the source file — otherwise both are attached to the same
+        // property and `can't overwrite property` is thrown. The `.ts` source always wins.
+        if (filepath.endsWith('.js') || filepath.endsWith('.mjs') || filepath.endsWith('.cjs')) {
+          const filepathTs = filepath.replace(/\.(?:js|mjs|cjs)$/, '.ts');
           if (filepaths.includes(filepathTs)) {
             debug('[parse] ignore %s, because %s exists', fullpath, filepathTs);
             continue;

--- a/packages/core/src/loader/file_loader.ts
+++ b/packages/core/src/loader/file_loader.ts
@@ -64,7 +64,7 @@ export interface FileLoaderParseItem {
 type NormalizedFileLoaderOptions = FileLoaderOptions & Required<Pick<FileLoaderOptions, 'caseStyle' | 'loaderFS'>>;
 
 function getDefaultFileLoaderMatch(): string[] {
-  return isSupportTypeScript() ? ['**/*.(js|ts)', '!**/*.d.ts'] : ['**/*.js'];
+  return isSupportTypeScript() ? ['**/*.(js|ts|mjs)', '!**/*.d.ts'] : ['**/*.{js,mjs}'];
 }
 
 /**

--- a/packages/core/test/egg-ts.test.ts
+++ b/packages/core/test/egg-ts.test.ts
@@ -127,6 +127,28 @@ describe('test/egg-ts.test.ts', () => {
     assert(app.serviceClasses.test);
   });
 
+  it('should load mjs/cjs and prefer the ts source over its compiled mjs/cjs', async () => {
+    mm(process.env, 'EGG_TYPESCRIPT', 'true');
+    app = createApp('egg-ts-js');
+
+    // loadService must not throw "can't overwrite property" even though
+    // `dual.ts`+`dual.mjs` and `dualc.ts`+`dualc.cjs` coexist in the directory.
+    await app.loader.loadService();
+
+    // standalone `.mjs` / `.cjs` are scanned and loaded as first-class files
+    assert(app.serviceClasses.pureMjs);
+    assert.equal(app.serviceClasses.pureMjs.loadedFrom, 'mjs');
+    assert(app.serviceClasses.pureCjs);
+    assert.equal(app.serviceClasses.pureCjs.loadedFrom, 'cjs');
+
+    // priority: when a `.ts` source and its compiled `.mjs`/`.cjs` coexist,
+    // the `.ts` source wins and the compiled sibling is ignored.
+    assert(app.serviceClasses.dual);
+    assert.equal(app.serviceClasses.dual.loadedFrom, 'ts');
+    assert(app.serviceClasses.dualc);
+    assert.equal(app.serviceClasses.dualc.loadedFrom, 'ts');
+  });
+
   it('should auto require tsconfig-paths', async () => {
     mm(process.env, 'EGG_TYPESCRIPT', 'true');
     app = createApp('egg-ts-js-tsconfig-paths');

--- a/packages/core/test/fixtures/egg-ts-js/app/service/dual.mjs
+++ b/packages/core/test/fixtures/egg-ts-js/app/service/dual.mjs
@@ -1,0 +1,7 @@
+// Compiled output of `dual.ts`. Must be ignored while `dual.ts` exists.
+export default class DualServiceMjs {
+  static loadedFrom = 'mjs';
+  which() {
+    return 'mjs';
+  }
+}

--- a/packages/core/test/fixtures/egg-ts-js/app/service/dual.ts
+++ b/packages/core/test/fixtures/egg-ts-js/app/service/dual.ts
@@ -1,0 +1,8 @@
+// `dual.ts` + `dual.mjs` coexist (compiled output kept beside the source).
+// The `.ts` source must win; `dual.mjs` must be ignored.
+module.exports = class DualService {
+  static loadedFrom = 'ts';
+  which() {
+    return 'ts';
+  }
+};

--- a/packages/core/test/fixtures/egg-ts-js/app/service/dualc.cjs
+++ b/packages/core/test/fixtures/egg-ts-js/app/service/dualc.cjs
@@ -1,0 +1,7 @@
+// Compiled output of `dualc.ts`. Must be ignored while `dualc.ts` exists.
+module.exports = class DualcServiceCjs {
+  static loadedFrom = 'cjs';
+  which() {
+    return 'cjs';
+  }
+};

--- a/packages/core/test/fixtures/egg-ts-js/app/service/dualc.ts
+++ b/packages/core/test/fixtures/egg-ts-js/app/service/dualc.ts
@@ -1,0 +1,7 @@
+// `dualc.ts` + `dualc.cjs` coexist. The `.ts` source must win; `dualc.cjs` ignored.
+module.exports = class DualcService {
+  static loadedFrom = 'ts';
+  which() {
+    return 'ts';
+  }
+};

--- a/packages/core/test/fixtures/egg-ts-js/app/service/pureCjs.cjs
+++ b/packages/core/test/fixtures/egg-ts-js/app/service/pureCjs.cjs
@@ -1,0 +1,6 @@
+module.exports = class PureCjsService {
+  static loadedFrom = 'cjs';
+  cjs() {
+    return 'from cjs service';
+  }
+};

--- a/packages/core/test/fixtures/egg-ts-js/app/service/pureMjs.mjs
+++ b/packages/core/test/fixtures/egg-ts-js/app/service/pureMjs.mjs
@@ -1,0 +1,6 @@
+export default class PureMjsService {
+  static loadedFrom = 'mjs';
+  mjs() {
+    return 'from mjs service';
+  }
+}


### PR DESCRIPTION
## What

Add `.mjs` to `FileLoader`'s default match glob so `.mjs` files are scanned the same as `.js`/`.ts`.

```diff
- return isSupportTypeScript() ? ['**/*.(js|ts)', '!**/*.d.ts'] : ['**/*.js'];
+ return isSupportTypeScript() ? ['**/*.(js|ts|mjs)', '!**/*.d.ts'] : ['**/*.{js,mjs}'];
```

## Why

The default match only includes `.js`/`.ts`, so `.mjs` files are silently skipped. egg4 plugins built as ESM (e.g. tsdown/tsc emitting `.mjs`) put their `app/middleware`, `app/extend`, `config` etc. in `.mjs`. Those never get loaded → `app.middlewares` is missing the plugin's middleware, and a lookup like `app.middlewares[name]` throws `Middleware xxx not found`.

Concretely, an ESM plugin shipping `app/middleware/xxx.mjs` and pushing `xxx` into `config.tr.middleware` (or `coreMiddleware`) currently fails to boot because the middleware file is never scanned.

In `type: module` packages `.js` is already ESM, but many build toolchains emit `.mjs` explicitly. Treating `.mjs` as first-class avoids forcing every ESM plugin to re-emit as `.js`.

## Status

Draft — opening for discussion / direction. Happy to add tests + cover the `.mjs` load path if this direction looks right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded file loading support to include `.mjs` and `.cjs` files in addition to `.js`, with TypeScript projects also recognizing `.ts` sources.
  * When both source and compiled versions exist, the TypeScript file now takes precedence.

* **Bug Fixes**
  * Prevented compiled `.js`, `.mjs`, and `.cjs` files from being loaded alongside matching TypeScript files, avoiding duplicate attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->