### PR TITLE
perf(tegg): optimize graph traversal

### DIFF
--- a/tegg/core/common-util/src/Graph.ts
+++ b/tegg/core/common-util/src/Graph.ts
@@ -120,6 +120,9 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
     return undefined;
   }
 
+  /**
+   * @deprecated Use loopPath() instead. This method is kept for compatibility.
+   */
   appendVertexToPath(node: GraphNode<T, M>, accessPath: GraphPath<T, M>, meta?: M): boolean {
     if (!accessPath.pushVertex(node, meta)) {
       return false;
@@ -188,22 +191,33 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
     return;
   }
 
-  private accessNodeWithSet(node: GraphNode<T, M>, accessed: Set<GraphNode<T, M>>, res: Array<GraphNode<T, M>>): void {
+  private accessNodeWithSet(
+    node: GraphNode<T, M>,
+    accessed: Set<GraphNode<T, M>>,
+    visiting: Set<GraphNode<T, M>>,
+    res: Array<GraphNode<T, M>>,
+  ): void {
     if (accessed.has(node)) {
       return;
     }
-    if (!node.toNodeMap.size) {
-      accessed.add(node);
-      res.push(node);
-      return;
+    if (visiting.has(node)) {
+      throw new Error('graph has recursive deps: ' + node);
     }
-    for (const toNode of node.toNodeMap.values()) {
-      this.accessNodeWithSet(toNode.node, accessed, res);
+    visiting.add(node);
+    try {
+      for (const toNode of node.toNodeMap.values()) {
+        this.accessNodeWithSet(toNode.node, accessed, visiting, res);
+      }
+    } finally {
+      visiting.delete(node);
     }
     accessed.add(node);
     res.push(node);
   }
 
+  /**
+   * @deprecated Prefer sort(), which uses Set-based traversal directly.
+   */
   accessNode(
     node: GraphNode<T, M>,
     nodes: Array<GraphNode<T, M>>,
@@ -216,7 +230,7 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
         accessedSet.add(nodes[i]);
       }
     }
-    this.accessNodeWithSet(node, accessedSet, res);
+    this.accessNodeWithSet(node, accessedSet, new Set<GraphNode<T, M>>(), res);
     for (let i = 0; i < nodes.length; ++i) {
       accessed[i] = accessedSet.has(nodes[i]);
     }
@@ -234,8 +248,9 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
     const res: Array<GraphNode<T, M>> = [];
     const nodes = Array.from(this.nodes.values());
     const accessed = new Set<GraphNode<T, M>>();
+    const visiting = new Set<GraphNode<T, M>>();
     for (const node of nodes) {
-      this.accessNodeWithSet(node, accessed, res);
+      this.accessNodeWithSet(node, accessed, visiting, res);
     }
     return res;
   }

--- a/tegg/core/common-util/src/Graph.ts
+++ b/tegg/core/common-util/src/Graph.ts
@@ -133,15 +133,75 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
     return true;
   }
 
-  loopPath(): GraphPath<T, M> | undefined {
+  private buildLoopPath(
+    stack: Array<{ node: GraphNode<T, M>; meta?: M }>,
+    node: GraphNode<T, M>,
+    meta?: M,
+  ): GraphPath<T, M> {
     const accessPath = new GraphPath<T, M>();
+    for (const pathNode of stack) {
+      accessPath.pushVertex(pathNode.node, pathNode.meta);
+    }
+    accessPath.pushVertex(node, meta);
+    return accessPath;
+  }
+
+  private findLoopPath(
+    node: GraphNode<T, M>,
+    visiting: Set<string>,
+    visited: Set<string>,
+    stack: Array<{ node: GraphNode<T, M>; meta?: M }>,
+    meta?: M,
+  ): GraphPath<T, M> | undefined {
+    if (visited.has(node.id)) {
+      return;
+    }
+    if (visiting.has(node.id)) {
+      return this.buildLoopPath(stack, node, meta);
+    }
+
+    visiting.add(node.id);
+    stack.push({ node, meta });
+    for (const toNode of node.toNodeMap.values()) {
+      const loopPath = this.findLoopPath(toNode.node, visiting, visited, stack, toNode.meta);
+      if (loopPath) {
+        return loopPath;
+      }
+    }
+    stack.pop();
+    visiting.delete(node.id);
+    visited.add(node.id);
+    return;
+  }
+
+  loopPath(): GraphPath<T, M> | undefined {
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+    const stack: Array<{ node: GraphNode<T, M>; meta?: M }> = [];
     const nodes = Array.from(this.nodes.values());
     for (const node of nodes) {
-      if (!this.appendVertexToPath(node, accessPath)) {
-        return accessPath;
+      const loopPath = this.findLoopPath(node, visiting, visited, stack);
+      if (loopPath) {
+        return loopPath;
       }
     }
     return;
+  }
+
+  private accessNodeWithSet(node: GraphNode<T, M>, accessed: Set<GraphNode<T, M>>, res: Array<GraphNode<T, M>>): void {
+    if (accessed.has(node)) {
+      return;
+    }
+    if (!node.toNodeMap.size) {
+      accessed.add(node);
+      res.push(node);
+      return;
+    }
+    for (const toNode of node.toNodeMap.values()) {
+      this.accessNodeWithSet(toNode.node, accessed, res);
+    }
+    accessed.add(node);
+    res.push(node);
   }
 
   accessNode(
@@ -150,20 +210,16 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
     accessed: boolean[],
     res: Array<GraphNode<T, M>>,
   ): void {
-    const index = nodes.indexOf(node);
-    if (accessed[index]) {
-      return;
+    const accessedSet = new Set<GraphNode<T, M>>();
+    for (let i = 0; i < nodes.length; ++i) {
+      if (accessed[i]) {
+        accessedSet.add(nodes[i]);
+      }
     }
-    if (!node.toNodeMap.size) {
-      accessed[nodes.indexOf(node)] = true;
-      res.push(node);
-      return;
+    this.accessNodeWithSet(node, accessedSet, res);
+    for (let i = 0; i < nodes.length; ++i) {
+      accessed[i] = accessedSet.has(nodes[i]);
     }
-    for (const toNode of node.toNodeMap.values()) {
-      this.accessNode(toNode.node, nodes, accessed, res);
-    }
-    accessed[nodes.indexOf(node)] = true;
-    res.push(node);
   }
 
   // sort by direct
@@ -177,13 +233,9 @@ export class Graph<T extends GraphNodeObj, M extends EdgeMeta = EdgeMeta> {
   sort(): Array<GraphNode<T, M>> {
     const res: Array<GraphNode<T, M>> = [];
     const nodes = Array.from(this.nodes.values());
-    const accessed: boolean[] = [];
-    for (let i = 0; i < nodes.length; ++i) {
-      accessed.push(false);
-    }
-    for (let i = 0; i < nodes.length; ++i) {
-      const node = nodes[i];
-      this.accessNode(node, nodes, accessed, res);
+    const accessed = new Set<GraphNode<T, M>>();
+    for (const node of nodes) {
+      this.accessNodeWithSet(node, accessed, res);
     }
     return res;
   }

--- a/tegg/core/common-util/test/ProtoGraph.test.ts
+++ b/tegg/core/common-util/test/ProtoGraph.test.ts
@@ -82,6 +82,28 @@ describe('test/LoadUnit/Graph.test.ts', () => {
   });
 
   describe('sort', () => {
+    function buildLayeredGraph(layerSize: number, layerCount: number) {
+      const graph = new Graph<GraphNodeVal>();
+      const layers: GraphNode<GraphNodeVal>[][] = [];
+      for (let layerIndex = 0; layerIndex < layerCount; ++layerIndex) {
+        const layer: GraphNode<GraphNodeVal>[] = [];
+        for (let nodeIndex = 0; nodeIndex < layerSize; ++nodeIndex) {
+          const node = new GraphNode(new GraphNodeVal(`${layerIndex}-${nodeIndex}`));
+          graph.addVertex(node);
+          layer.push(node);
+        }
+        layers.push(layer);
+      }
+      for (let layerIndex = 0; layerIndex < layerCount - 1; ++layerIndex) {
+        for (const fromNode of layers[layerIndex]) {
+          for (const toNode of layers[layerIndex + 1]) {
+            graph.addEdge(fromNode, toNode);
+          }
+        }
+      }
+      return { graph, layers };
+    }
+
     it('can not access vertex should at first', () => {
       const graph = new Graph();
       const node1 = new GraphNode({ id: '1' });
@@ -115,27 +137,42 @@ describe('test/LoadUnit/Graph.test.ts', () => {
       assert.deepStrictEqual(sortRes, [node5, node2, node1, node4, node3]);
     });
 
-    it('should sort shared acyclic paths once', () => {
+    it('should fail fast when sorting circular dependencies', () => {
       const graph = new Graph();
-      const layers: GraphNode<GraphNodeVal>[][] = [];
+      const node1 = new GraphNode(new GraphNodeVal('1'));
+      const node2 = new GraphNode(new GraphNodeVal('2'));
+      graph.addVertex(node1);
+      graph.addVertex(node2);
+      graph.addEdge(node1, node2);
+      graph.addEdge(node2, node1);
+
+      assert.throws(() => graph.sort(), /graph has recursive deps: id:1/);
+    });
+
+    it('should keep legacy accessNode boolean array API', () => {
+      const graph = new Graph<GraphNodeVal>();
+      const node1 = new GraphNode(new GraphNodeVal('1'));
+      const node2 = new GraphNode(new GraphNodeVal('2'));
+      const node3 = new GraphNode(new GraphNodeVal('3'));
+      graph.addVertex(node1);
+      graph.addVertex(node2);
+      graph.addVertex(node3);
+      graph.addEdge(node1, node2);
+      graph.addEdge(node2, node3);
+      const nodes = [node1, node2, node3];
+      const accessed = [false, false, true];
+      const res: GraphNode<GraphNodeVal>[] = [node3];
+
+      graph.accessNode(node1, nodes, accessed, res);
+
+      assert.deepStrictEqual(res, [node3, node2, node1]);
+      assert.deepStrictEqual(accessed, [true, true, true]);
+    });
+
+    it('should sort shared acyclic paths once', () => {
       const layerSize = 8;
       const layerCount = 8;
-      for (let layerIndex = 0; layerIndex < layerCount; ++layerIndex) {
-        const layer: GraphNode<GraphNodeVal>[] = [];
-        for (let nodeIndex = 0; nodeIndex < layerSize; ++nodeIndex) {
-          const node = new GraphNode(new GraphNodeVal(`${layerIndex}-${nodeIndex}`));
-          graph.addVertex(node);
-          layer.push(node);
-        }
-        layers.push(layer);
-      }
-      for (let layerIndex = 0; layerIndex < layerCount - 1; ++layerIndex) {
-        for (const fromNode of layers[layerIndex]) {
-          for (const toNode of layers[layerIndex + 1]) {
-            graph.addEdge(fromNode, toNode);
-          }
-        }
-      }
+      const { graph, layers } = buildLayeredGraph(layerSize, layerCount);
 
       assert.equal(graph.loopPath(), undefined);
       const sortRes = graph.sort();
@@ -149,6 +186,27 @@ describe('test/LoadUnit/Graph.test.ts', () => {
           }
         }
       }
+    });
+
+    it('should not scan nodes with Array#indexOf when sorting shared paths', () => {
+      const { graph } = buildLayeredGraph(8, 8);
+      const originalIndexOf = Array.prototype.indexOf;
+      let indexOfCallCount = 0;
+      Array.prototype.indexOf = function indexOfSpy(
+        this: unknown[],
+        searchElement: unknown,
+        fromIndex?: number,
+      ): number {
+        indexOfCallCount++;
+        return originalIndexOf.call(this, searchElement, fromIndex);
+      };
+      try {
+        graph.sort();
+      } finally {
+        Array.prototype.indexOf = originalIndexOf;
+      }
+
+      assert.equal(indexOfCallCount, 0);
     });
   });
 });

--- a/tegg/core/common-util/test/ProtoGraph.test.ts
+++ b/tegg/core/common-util/test/ProtoGraph.test.ts
@@ -41,6 +41,23 @@ describe('test/LoadUnit/Graph.test.ts', () => {
       assert(loopPath!.toString() === 'id:2 -> id:3 -> id:1 -> id:2');
     });
 
+    it('should return the current access path when loop is reached', () => {
+      const graph = new Graph();
+      const node1 = new GraphNode(new GraphNodeVal('1'));
+      const node2 = new GraphNode(new GraphNodeVal('2'));
+      const node3 = new GraphNode(new GraphNodeVal('3'));
+      graph.addVertex(node1);
+      graph.addVertex(node2);
+      graph.addVertex(node3);
+
+      graph.addEdge(node1, node2);
+      graph.addEdge(node2, node3);
+      graph.addEdge(node3, node2);
+
+      const loopPath = graph.loopPath();
+      assert(loopPath!.toString() === 'id:1 -> id:2 -> id:3 -> id:2');
+    });
+
     it('if do not has loop, should return undefined', () => {
       const graph = new Graph();
       const node1 = new GraphNode({ id: '1' });
@@ -96,6 +113,42 @@ describe('test/LoadUnit/Graph.test.ts', () => {
       graph.addEdge(node4, node5);
       const sortRes = graph.sort();
       assert.deepStrictEqual(sortRes, [node5, node2, node1, node4, node3]);
+    });
+
+    it('should sort shared acyclic paths once', () => {
+      const graph = new Graph();
+      const layers: GraphNode<GraphNodeVal>[][] = [];
+      const layerSize = 8;
+      const layerCount = 8;
+      for (let layerIndex = 0; layerIndex < layerCount; ++layerIndex) {
+        const layer: GraphNode<GraphNodeVal>[] = [];
+        for (let nodeIndex = 0; nodeIndex < layerSize; ++nodeIndex) {
+          const node = new GraphNode(new GraphNodeVal(`${layerIndex}-${nodeIndex}`));
+          graph.addVertex(node);
+          layer.push(node);
+        }
+        layers.push(layer);
+      }
+      for (let layerIndex = 0; layerIndex < layerCount - 1; ++layerIndex) {
+        for (const fromNode of layers[layerIndex]) {
+          for (const toNode of layers[layerIndex + 1]) {
+            graph.addEdge(fromNode, toNode);
+          }
+        }
+      }
+
+      assert.equal(graph.loopPath(), undefined);
+      const sortRes = graph.sort();
+      const sortedIndexMap = new Map(sortRes.map((node, index) => [node.id, index]));
+      assert.equal(sortRes.length, layerSize * layerCount);
+      assert.equal(new Set(sortRes).size, sortRes.length);
+      for (let layerIndex = 0; layerIndex < layerCount - 1; ++layerIndex) {
+        for (const fromNode of layers[layerIndex]) {
+          for (const toNode of layers[layerIndex + 1]) {
+            assert(sortedIndexMap.get(toNode.id)! < sortedIndexMap.get(fromNode.id)!);
+          }
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Avoid repeatedly traversing shared acyclic subgraphs in `Graph.loopPath()` by tracking `visiting` and `visited` nodes.
- Avoid repeated `nodes.indexOf()` scans in `Graph.sort()` by using a `Set` for visited graph nodes.
- Add regression coverage for preserving loop access paths and sorting a shared DAG exactly once.

## Why

A downstream large Egg 4 / TEGG app exposed `@eggjs/tegg-common-util` graph traversal as the dominant boot-time cost during unit-test coverage startup. The app graph has 28 app refs and about 1512 protos in the measured load path.

The old implementation has two expensive paths on shared DAGs:

- `loopPath()` starts DFS from every node and does not memoize already-proven-acyclic subgraphs, so shared dependencies are traversed repeatedly.
- `sort()` calls `nodes.indexOf(node)` inside recursive traversal, adding repeated linear scans on top of DFS.

## Timing Data

Local before/after was measured in the downstream app by applying the equivalent patch to the installed package and running the same focused coverage boot command. The profiler only records entries >= 20ms, so the optimized `GlobalGraph.sort` disappearing from records means it was below 20ms.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall clock (`time real`) | 70.72s | 37.11s | -33.61s / -47.5% |
| Egg `application Start` | 53.61s | 19.59s | -34.02s / -63.5% |
| `ModuleHandler.init` | 44.68s | 11.32s | -33.36s / -74.7% |
| `EggModuleLoader.loadModule` | 36.34s | 3.72s | -32.62s / -89.8% |
| `GlobalGraph.sort` | 31.70s | <0.02s | >31.68s / >99.9% |

CI profiling before this optimization showed the same hot path dominating startup:

| CI sample | Egg `application Start` | TEGG didLoad | `EggModuleLoader.loadModule` | `GlobalGraph.sort` |
| --- | ---: | ---: | ---: | ---: |
| recommend module tests | 109.7s | 89.0s | 70.9s | 57.2s |
| gongdan module tests | 95.9s | 80.0s | 65.8s | 54.6s |
| open-platform module tests | 240.5s | 198.1s | 161.1s | 131.3s |

## Checks

- `utx vitest run tegg/core/common-util/test/ProtoGraph.test.ts --testTimeout 20000`
- `utx tsgo --noEmit -p tegg/core/common-util/tsconfig.json`
- `utx oxfmt --check tegg/core/common-util/src/Graph.ts tegg/core/common-util/test/ProtoGraph.test.ts`
- `utx oxlint --type-aware --type-check --quiet tegg/core/common-util/src/Graph.ts tegg/core/common-util/test/ProtoGraph.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cycle/loop detection so reported loop paths include the full traversal route (rather than stopping early).
  * Refined graph sorting to produce correct ordering for DAGs while preventing duplicate processing and faster cycle/recursion detection.
* **Tests**
  * Expanded coverage for loop-path reporting and `sort()` behavior on layered acyclic graphs.
  * Added checks for fast failure on circular dependencies and backward compatibility of the legacy `accessNode` boolean-array API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->