### PR TITLE
perf(metadata): index proto nodes by name

### DIFF
--- a/tegg/core/metadata/src/model/graph/GlobalGraph.ts
+++ b/tegg/core/metadata/src/model/graph/GlobalGraph.ts
@@ -69,6 +69,7 @@ export class GlobalGraph {
   moduleProtoDescriptorMap: Map<string, ProtoDescriptor[]>;
   strict: boolean;
   private buildHooks: GlobalGraphBuildHook[];
+  private protoNameNodeMap: Map<PropertyKey, GraphNode<ProtoNode, ProtoDependencyMeta>[]>;
 
   /**
    * The per-app graph instance used in ModuleLoadUnit, backed by TeggScope: the
@@ -98,6 +99,7 @@ export class GlobalGraph {
     this.strict = options?.strict ?? false;
     this.moduleProtoDescriptorMap = new Map();
     this.buildHooks = [];
+    this.protoNameNodeMap = new Map();
   }
 
   registerBuildHook(hook: GlobalGraphBuildHook): void {
@@ -112,6 +114,12 @@ export class GlobalGraph {
       if (!this.protoGraph.addVertex(protoNode)) {
         throw new Error(`duplicate proto: ${protoNode.val}`);
       }
+      let nodes = this.protoNameNodeMap.get(protoNode.val.proto.name);
+      if (!nodes) {
+        nodes = [];
+        this.protoNameNodeMap.set(protoNode.val.proto.name, nodes);
+      }
+      nodes.push(protoNode);
     }
   }
 
@@ -185,9 +193,8 @@ export class GlobalGraph {
     injectObject: InjectObjectDescriptor,
     qualifiers: QualifierInfo[],
   ): GraphNode<ProtoNode, ProtoDependencyMeta>[] {
-    // TODO perf O(n(proto count)*m(inject count)*n)
     const result: GraphNode<ProtoNode, ProtoDependencyMeta>[] = [];
-    for (const node of this.protoGraph.nodes.values()) {
+    for (const node of this.protoNameNodeMap.get(injectObject.objName) ?? []) {
       if (
         node.val.selectProto({
           name: injectObject.objName,

--- a/tegg/core/metadata/test/GlobalGraph.test.ts
+++ b/tegg/core/metadata/test/GlobalGraph.test.ts
@@ -1,9 +1,16 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 
+import {
+  AccessLevel,
+  ObjectInitType,
+  type InjectObjectDescriptor,
+  type ProtoDescriptor,
+  type QualifierInfo,
+} from '@eggjs/tegg-types';
 import { describe, it } from 'vitest';
 
-import { GlobalGraph } from '../src/index.js';
+import { GlobalGraph, GlobalModuleNode } from '../src/index.js';
 import { buildModuleNode } from './fixtures/LoaderUtil.js';
 import { RootProto } from './fixtures/modules/app-graph-modules/root/Root.js';
 import { UnusedProto } from './fixtures/modules/app-graph-modules/unused/Unused.js';
@@ -13,6 +20,35 @@ import { App2 } from './fixtures/modules/app-multi-inject-multi/app/modules/app2
 import { BizManager } from './fixtures/modules/app-multi-inject-multi/app/modules/bar/BizManager.js';
 import { Secret } from './fixtures/modules/app-multi-inject-multi/app/modules/foo/Secret.js';
 import { TestLoader } from './fixtures/TestLoader.js';
+
+function createProtoDescriptor(options: {
+  name: string;
+  moduleName?: string;
+  qualifiers?: QualifierInfo[];
+  injectObjects?: InjectObjectDescriptor[];
+}): ProtoDescriptor {
+  const moduleName = options.moduleName ?? 'app';
+  return {
+    name: options.name,
+    accessLevel: AccessLevel.PUBLIC,
+    initType: ObjectInitType.SINGLETON,
+    qualifiers: options.qualifiers ?? [],
+    injectObjects: options.injectObjects ?? [],
+    protoImplType: 'class',
+    properQualifiers: {},
+    defineModuleName: moduleName,
+    defineUnitPath: `/fixtures/${moduleName}`,
+    instanceModuleName: moduleName,
+    instanceDefineUnitPath: `/fixtures/${moduleName}`,
+    equal(protoDescriptor) {
+      return (
+        this.name === protoDescriptor.name &&
+        this.instanceModuleName === protoDescriptor.instanceModuleName &&
+        this.initType === protoDescriptor.initType
+      );
+    },
+  };
+}
 
 describe('test/LoadUnit/GlobalGraph.test.ts', () => {
   it('optional module dep should work', () => {
@@ -82,6 +118,40 @@ describe('test/LoadUnit/GlobalGraph.test.ts', () => {
       graph.moduleConfigList.map((t) => t.name),
       ['app', 'app2', 'bar', 'foo'],
     );
+  });
+
+  it('should resolve dependencies from proto name candidates only', () => {
+    const graph = new GlobalGraph({ strict: true });
+    const injectObject: InjectObjectDescriptor = {
+      refName: 'target',
+      objName: 'target',
+      qualifiers: [],
+    };
+    const consumer = createProtoDescriptor({
+      name: 'consumer',
+      injectObjects: [injectObject],
+    });
+    const target = createProtoDescriptor({ name: 'target' });
+    const unrelated = createProtoDescriptor({ name: 'unrelated' });
+
+    const moduleNode = new GlobalModuleNode({
+      name: 'app',
+      unitPath: '/fixtures/app',
+      optional: false,
+    });
+    moduleNode.addProto(consumer);
+    moduleNode.addProto(target);
+    moduleNode.addProto(unrelated);
+    graph.addModuleNode(moduleNode);
+
+    const unrelatedNode = Array.from(graph.protoGraph.nodes.values()).find((node) => node.val.proto === unrelated);
+    assert(unrelatedNode);
+    unrelatedNode.val.selectProto = () => {
+      throw new Error('unrelated proto should not be scanned');
+    };
+
+    graph.build();
+    assert.equal(graph.findInjectProto(consumer, injectObject), target);
   });
 
   it('should sort extends class success', async () => {


### PR DESCRIPTION
## Summary

- Maintain a `protoNameNodeMap` as module protos are added to `GlobalGraph`.
- Use the name index as the candidate set for dependency resolution, while still applying the existing `selectProto()` qualifier/access checks.
- Add a regression test that fails if dependency resolution scans unrelated proto names.

## Why

`GlobalGraph.build()` resolves each inject object by scanning every proto node and then checking name, qualifiers, and access level. Large TEGG apps can have thousands of protos, so narrowing candidates by proto name avoids repeated full graph scans without changing selection semantics.

This complements the graph traversal optimization in #6024 and can be reviewed independently.

## Benchmark Data

Local synthetic benchmark was measured on Node.js `v22.18.0` with 28 modules, 1,513 protos, and 560 inject objects. The `legacy-full-scan` row uses the same graph shape with the candidate lookup forced to iterate all proto nodes, matching the behavior before this index.

| Metric | legacy-full-scan | indexed | Change |
| --- | ---: | ---: | ---: |
| `GlobalGraph.build()` median | 49.34ms | 0.16ms | 305.4x faster |
| min | 48.30ms | 0.14ms | - |
| max | 51.60ms | 0.31ms | - |
| `selectProto()` calls | 847,280 | 560 | -99.93% |

Command shape:

```bash
cd tegg/core/metadata
ut run bench:proto-name-index
```

## Validation

- `utx vitest run tegg/core/metadata/test/GlobalGraph.test.ts --bail 1 --testTimeout 20000 --hookTimeout 20000`
- `cd tegg/core/metadata && ut run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution so the app now picks the correct matching prototype more reliably.
  * Reduced unnecessary scanning of unrelated candidates, which may improve lookup consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->