### PR TITLE
fix(tegg-loader): include mjs and cjs extensions

### DIFF
--- a/tegg/core/loader/src/LoaderUtil.ts
+++ b/tegg/core/loader/src/LoaderUtil.ts
@@ -28,6 +28,11 @@ export class LoaderUtil {
 
   static supportExtensions(): string[] {
     const extensions = Object.keys((Module as any)._extensions);
+    // ESM-only packages and explicit CommonJS entry files are valid Node.js
+    // module files, but they are not guaranteed to appear in Module._extensions.
+    for (const ext of ['.mjs', '.cjs']) {
+      if (!extensions.includes(ext)) extensions.push(ext);
+    }
     // TypeScript loaders such as tsx and Node's native type stripping register
     // via ESM loader hooks rather than `Module._extensions`, so `_extensions`
     // may not list `.ts` even when TS files are loadable (e.g. during manifest

--- a/tegg/core/loader/test/LoaderUtil.test.ts
+++ b/tegg/core/loader/test/LoaderUtil.test.ts
@@ -29,6 +29,13 @@ describe('core/loader/test/LoaderUtil.test.ts', () => {
   }
 
   describe('supportExtensions()', () => {
+    it('should include .mjs/.cjs as first-class module extensions', () => {
+      process.env.EGG_TS_ENABLE = 'false';
+      const extensions = LoaderUtil.supportExtensions();
+      assert(extensions.includes('.mjs'));
+      assert(extensions.includes('.cjs'));
+    });
+
     it('should not include TypeScript extensions when EGG_TS_ENABLE=false', () => {
       process.env.EGG_TS_ENABLE = 'false';
       const extensions = LoaderUtil.supportExtensions();
@@ -45,6 +52,16 @@ describe('core/loader/test/LoaderUtil.test.ts', () => {
       assert(extensions.includes('.ts'));
       assert(extensions.includes('.mts'));
       assert(extensions.includes('.cts'));
+    });
+  });
+
+  describe('filePattern()', () => {
+    it('should discover .mjs/.cjs files even when TypeScript loading is disabled', () => {
+      process.env.EGG_TS_ENABLE = 'false';
+      const patterns = LoaderUtil.filePattern();
+      const positivePattern = patterns[0];
+      assert(positivePattern.includes('mjs'));
+      assert(positivePattern.includes('cjs'));
     });
   });
 });


### PR DESCRIPTION
## Summary

- Always include `.mjs` and `.cjs` in `LoaderUtil.supportExtensions()` even when they are not present in `Module._extensions`.
- Keep TypeScript extension gating unchanged, including `EGG_TS_ENABLE=false` behavior.
- Add coverage for extension discovery and `filePattern()` generation.

## Why

TEGG module loading discovers files from `LoaderUtil.filePattern()`. ESM-only packages can expose `.mjs` egg modules, but `.mjs` is not guaranteed to appear in Node CJS `Module._extensions`, so those modules can be skipped during scanning.

This is independent from the core FileLoader `.mjs/.cjs` support in #6023; it covers the TEGG loader path.

## Validation

- `utx vitest run tegg/core/loader/test/LoaderUtil.test.ts --bail 1 --testTimeout 20000 --hookTimeout 20000`
- `cd tegg/core/loader && ut run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module file detection so additional valid Node.js module formats are recognized in environments where TypeScript loading is disabled.
  * Updated file discovery to include these module formats consistently, helping reduce missed imports and loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->