### PR TITLE
fix(dal): skip transaction hook without datasource

### DIFF
--- a/tegg/plugin/dal/src/lib/TransactionPrototypeHook.ts
+++ b/tegg/plugin/dal/src/lib/TransactionPrototypeHook.ts
@@ -26,10 +26,14 @@ export class TransactionPrototypeHook implements LifecycleHook<EggPrototypeLifec
       return;
     }
     const moduleName = ctx.loadUnit.name;
+    const datasourceConfigs = (this.moduleConfigs[moduleName]?.config as any)?.dataSource || {};
+    const dataSources = Object.keys(datasourceConfigs);
+    if (dataSources.length === 0) {
+      return;
+    }
+
     for (const transactionMetadata of transactionMetadataList) {
       const clazzName = `${moduleName}.${ctx.clazz.name}.${String(transactionMetadata.method)}`;
-      const datasourceConfigs = (this.moduleConfigs[moduleName]?.config as any)?.dataSource || {};
-
       let datasourceName: string;
       if (transactionMetadata.datasourceName) {
         assert(
@@ -39,7 +43,6 @@ export class TransactionPrototypeHook implements LifecycleHook<EggPrototypeLifec
         datasourceName = transactionMetadata.datasourceName;
         this.logger.info(`use datasource [${transactionMetadata.datasourceName}] for class ${clazzName}`);
       } else {
-        const dataSources = Object.keys(datasourceConfigs);
         if (dataSources.length === 1) {
           datasourceName = dataSources[0];
         } else {

--- a/tegg/plugin/dal/test/TransactionPrototypeHook.test.ts
+++ b/tegg/plugin/dal/test/TransactionPrototypeHook.test.ts
@@ -1,0 +1,64 @@
+import { Transactional } from '@eggjs/transaction-decorator';
+import { describe, expect, it } from 'vitest';
+
+import { TransactionPrototypeHook } from '../src/lib/TransactionPrototypeHook.ts';
+
+describe('plugin/dal/test/TransactionPrototypeHook.test.ts', () => {
+  const logger = {
+    info() {},
+  } as any;
+
+  it('should skip transaction hook when module has no dataSource config', async () => {
+    class FooService {
+      @Transactional()
+      async doSomething() {}
+    }
+
+    const hook = new TransactionPrototypeHook(
+      {
+        foo: {
+          config: {},
+        },
+      } as any,
+      logger,
+    );
+
+    await expect(
+      hook.preCreate({
+        clazz: FooService,
+        loadUnit: {
+          name: 'foo',
+        },
+      } as any),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should skip transaction hook when module has empty dataSource config', async () => {
+    class BarService {
+      @Transactional({
+        datasourceName: 'foo',
+      })
+      async doSomething() {}
+    }
+
+    const hook = new TransactionPrototypeHook(
+      {
+        bar: {
+          config: {
+            dataSource: {},
+          },
+        },
+      } as any,
+      logger,
+    );
+
+    await expect(
+      hook.preCreate({
+        clazz: BarService,
+        loadUnit: {
+          name: 'bar',
+        },
+      } as any),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
### What changed

`TransactionPrototypeHook` now skips transactional methods when the module has no `config.dataSource` entries. This mirrors `DalModuleLoadUnitHook`, which already returns early when no DAL datasource is configured.

### Why

When another DAL implementation owns datasource creation, `@eggjs/dal-plugin` currently sees an empty datasource map and throws `module ... has multi datasource` for every `@Transactional()` method. With no configured datasource, this hook cannot safely install a transaction AOP, so it should no-op instead of failing module bootstrap.

This is one of the patches currently carried by yuyanbff during the Egg 4 / Chair 3 migration.

### Verification

- `./node_modules/.bin/vitest run --project @eggjs/dal-plugin tegg/plugin/dal/test/TransactionPrototypeHook.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p tegg/plugin/dal/tsconfig.json`
- `./node_modules/.bin/oxlint tegg/plugin/dal/src/lib/TransactionPrototypeHook.ts tegg/plugin/dal/test/TransactionPrototypeHook.test.ts --type-aware --type-check --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction hook behavior for modules with missing or empty datasource settings.
  * Prevents unnecessary transaction metadata processing when datasource configuration is absent.
* **Tests**
  * Added automated coverage to verify the hook is skipped when module `dataSource` is not provided or is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->