### PR TITLE
perf(ajv): lazy load runtime dependencies

### DIFF
--- a/tegg/plugin/ajv/src/lib/Ajv.ts
+++ b/tegg/plugin/ajv/src/lib/Ajv.ts
@@ -1,24 +1,54 @@
-import { type Ajv as IAjv, AjvInvalidParamError } from '@eggjs/ajv-decorator';
-import addFormats from '@eggjs/ajv-formats';
-import keyWords from '@eggjs/ajv-keywords';
+import type { Ajv as IAjv } from '@eggjs/ajv-decorator';
 import { SingletonProto, AccessLevel } from '@eggjs/core-decorator';
 import { LifecycleInit } from '@eggjs/lifecycle';
-import { type Schema, Ajv2019 } from 'ajv/dist/2019.js';
+import type { Schema, Ajv2019 as IAjv2019 } from 'ajv/dist/2019.js';
+
+type AjvInvalidParamErrorClass = typeof import('@eggjs/ajv-decorator').AjvInvalidParamError;
+type Ajv2019Class = typeof import('ajv/dist/2019.js').Ajv2019;
+
+let AjvInvalidParamError: AjvInvalidParamErrorClass;
+let addFormats: any;
+let keyWords: any;
+let Ajv2019: Ajv2019Class;
+let loadAjvDepsPromise: Promise<void> | undefined;
+
+async function loadAjvDeps(): Promise<void> {
+  if (Ajv2019) {
+    return;
+  }
+  loadAjvDepsPromise ??= Promise.all([
+    import('@eggjs/ajv-decorator'),
+    import('@eggjs/ajv-formats'),
+    import('@eggjs/ajv-keywords'),
+    import('ajv/dist/2019.js'),
+  ])
+    .then(([decorator, formats, keywords, ajv2019]) => {
+      AjvInvalidParamError = decorator.AjvInvalidParamError;
+      addFormats = (formats as any).default ?? formats;
+      keyWords = (keywords as any).default ?? keywords;
+      Ajv2019 = ajv2019.Ajv2019;
+    })
+    .catch((err) => {
+      loadAjvDepsPromise = undefined;
+      throw err;
+    });
+  await loadAjvDepsPromise;
+}
 
 @SingletonProto({
   accessLevel: AccessLevel.PUBLIC,
 })
 export class Ajv implements IAjv {
-  static InvalidParamErrorClass: typeof AjvInvalidParamError = AjvInvalidParamError;
+  static InvalidParamErrorClass: AjvInvalidParamErrorClass;
 
-  #ajvInstance: Ajv2019;
+  #ajvInstance!: IAjv2019;
 
   @LifecycleInit()
-  protected _init(): void {
+  protected async _init(): Promise<void> {
+    await loadAjvDeps();
+    Ajv.InvalidParamErrorClass ??= AjvInvalidParamError;
     this.#ajvInstance = new Ajv2019();
-    // @ts-expect-error ajv-keywords is not typed
     keyWords(this.#ajvInstance, 'transform');
-    // @ts-expect-error ajv-formats is not typed
     addFormats(this.#ajvInstance, [
       'date-time',
       'time',


### PR DESCRIPTION
### What changed

`@eggjs/ajv-plugin` now keeps only type imports at module evaluation time and dynamically loads `@eggjs/ajv-decorator`, `@eggjs/ajv-formats`, `@eggjs/ajv-keywords`, and `ajv/dist/2019.js` during `LifecycleInit`.

### Why

TEGG scans module files during boot. Loading the Ajv plugin file currently pulls the full Ajv/formats/keywords dependency graph even before an Ajv instance is initialized. Deferring those runtime dependencies keeps prototype discovery cheap while preserving the existing lifecycle behavior: the Ajv instance is still ready after `LifecycleInit`.

This corresponds to one of the temporary yuyanbff Egg 4 / Chair 3 migration patches.

### Verification

- `./node_modules/.bin/vitest run --project @eggjs/ajv-plugin tegg/plugin/ajv/test/ajv.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p tegg/plugin/ajv/tsconfig.json`
- `./node_modules/.bin/oxlint tegg/plugin/ajv/src/lib/Ajv.ts --type-aware --type-check --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated validation setup to load required validation components only when the validator is first initialized.
  * Made validator initialization asynchronous to improve responsiveness and reduce upfront work.
  * Added promise-based caching so subsequent uses reuse the loaded validation logic, with safe handling if loading fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->