### PR TITLE
fix(dal-runtime): package codegen templates

### DIFF
--- a/tegg/core/dal-runtime/test/CodeGenerator.test.ts
+++ b/tegg/core/dal-runtime/test/CodeGenerator.test.ts
@@ -15,6 +15,16 @@ import { MultiPrimaryKey } from './fixtures/modules/generate_codes/MultiPrimaryK
 const execFileAsync = promisify(execFile);
 
 describe('test/CodeGenerator.test.ts', () => {
+  it('should configure templates as build assets', async () => {
+    const config = (await import('../tsdown.config.ts')).default as any;
+    assert.deepEqual(config.copy, [
+      {
+        from: 'src/templates',
+        to: 'dist/templates',
+      },
+    ]);
+  });
+
   it('should load templates under native ESM runtime', async () => {
     const repoDir = path.resolve(__dirname, '../../../..');
     const moduleDir = path.join(__dirname, './fixtures/modules/generate_codes');

--- a/tegg/core/dal-runtime/tsdown.config.ts
+++ b/tegg/core/dal-runtime/tsdown.config.ts
@@ -4,4 +4,10 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
   },
+  copy: [
+    {
+      from: 'src/templates',
+      to: 'dist/templates',
+    },
+  ],
 });


### PR DESCRIPTION
### What changed

Copy `src/templates` into `dist/templates` through the package tsdown configuration.

### Why

`@eggjs/dal-runtime` publishes only `dist`, but its Nunjucks templates were not copied by the build. A clean consumer install therefore fails DAL generation with `template not found` and currently requires Chair-bin to copy three files into node_modules during postinstall.

### Verification

- `vitest run --project @eggjs/dal-runtime tegg/core/dal-runtime/test/CodeGenerator.test.ts`
- 5 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured required templates are included in the build output, preventing missing template files at runtime.

* **Tests**
  * Added coverage to verify that templates are copied to the expected distribution directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->