### PR TITLE
fix(tegg-loader): ignore non-runtime module files

### DIFF
--- a/tegg/core/loader/src/LoaderUtil.ts
+++ b/tegg/core/loader/src/LoaderUtil.ts
@@ -81,6 +81,10 @@ export class LoaderUtil {
       '!**/node_modules',
       // node load type definitions
       '!**/*.d.ts',
+      '!**/*.d.mts',
+      '!**/*.d.cts',
+      // test runner configuration is not an application module
+      '!**/vitest.config.*',
       // not load test/coverage files
       '!**/test',
       '!**/coverage',

--- a/tegg/core/loader/test/Loader.test.ts
+++ b/tegg/core/loader/test/Loader.test.ts
@@ -16,6 +16,14 @@ describe('core/loader/test/Loader.test.ts', () => {
   });
 
   describe('module loader', () => {
+    it('should exclude declarations and test runner configuration', () => {
+      const patterns = LoaderUtil.filePattern();
+      assert(patterns.includes('!**/*.d.ts'));
+      assert(patterns.includes('!**/*.d.mts'));
+      assert(patterns.includes('!**/*.d.cts'));
+      assert(patterns.includes('!**/vitest.config.*'));
+    });
+
     it('should load module', async () => {
       const repoModulePath = path.join(__dirname, './fixtures/modules/module-for-loader');
       const loader = LoaderFactory.createLoader(repoModulePath, EggLoadUnitType.MODULE);


### PR DESCRIPTION
### What changed

Exclude TypeScript declaration variants (`.d.mts`, `.d.cts`) and `vitest.config.*` from TEGG runtime module discovery.

### Why

The extension-aware glob includes `.mts`/`.cts`/`.mjs`, so declaration files and package-local Vitest config can otherwise be imported as application modules. This currently requires a Chair-bin postinstall patch and can fail when a published TEGG module contains `vitest.config.mjs`.

### Verification

- `vitest run --project @eggjs/tegg-loader tegg/core/loader/test/Loader.test.ts`
- 11 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading to ignore TypeScript declaration entrypoints and Vitest configuration files, preventing them from being treated as application modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->