### PR TITLE
chore(release): align next with beta.23 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/monorepo",
-  "version": "4.1.2-beta.21",
+  "version": "4.1.2-beta.22",
   "private": true,
   "description": "Eggjs framework monorepo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/monorepo",
-  "version": "4.1.2-beta.22",
+  "version": "4.1.2-beta.23",
   "private": true,
   "description": "Eggjs framework monorepo",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/monorepo",
-  "version": "4.1.2-beta.20",
+  "version": "4.1.2-beta.21",
   "private": true,
   "description": "Eggjs framework monorepo",
   "license": "MIT",

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cluster",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "cluster manager for egg",
   "keywords": [
     "cluster",

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cluster",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "cluster manager for egg",
   "keywords": [
     "cluster",

--- a/packages/cluster/package.json
+++ b/packages/cluster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cluster",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "cluster manager for egg",
   "keywords": [
     "cluster",

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cookies",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "cookies module for egg",
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/cookies",
   "license": "MIT",

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cookies",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "cookies module for egg",
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/cookies",
   "license": "MIT",

--- a/packages/cookies/package.json
+++ b/packages/cookies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/cookies",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "cookies module for egg",
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/cookies",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core",
-  "version": "7.0.2-beta.21",
+  "version": "7.0.2-beta.22",
   "description": "A core plugin framework based on @eggjs/koa",
   "keywords": [
     "egg",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core",
-  "version": "7.0.2-beta.20",
+  "version": "7.0.2-beta.21",
   "description": "A core plugin framework based on @eggjs/koa",
   "keywords": [
     "egg",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core",
-  "version": "7.0.2-beta.22",
+  "version": "7.0.2-beta.23",
   "description": "A core plugin framework based on @eggjs/koa",
   "keywords": [
     "egg",

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg",
-  "version": "4.1.2-beta.21",
+  "version": "4.1.2-beta.22",
   "description": "A web application framework for Node.js",
   "keywords": [
     "app",

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg",
-  "version": "4.1.2-beta.20",
+  "version": "4.1.2-beta.21",
   "description": "A web application framework for Node.js",
   "keywords": [
     "app",

--- a/packages/egg/package.json
+++ b/packages/egg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg",
-  "version": "4.1.2-beta.22",
+  "version": "4.1.2-beta.23",
   "description": "A web application framework for Node.js",
   "keywords": [
     "app",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/errors",
-  "version": "3.0.2-beta.21",
+  "version": "3.0.2-beta.22",
   "description": "@eggjs/errors provide two kinds of errors that is Error and Exception.",
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/errors",
   "bugs": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/errors",
-  "version": "3.0.2-beta.20",
+  "version": "3.0.2-beta.21",
   "description": "@eggjs/errors provide two kinds of errors that is Error and Exception.",
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/errors",
   "bugs": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/errors",
-  "version": "3.0.2-beta.22",
+  "version": "3.0.2-beta.23",
   "description": "@eggjs/errors provide two kinds of errors that is Error and Exception.",
   "homepage": "https://github.com/eggjs/egg/tree/next/packages/errors",
   "bugs": {

--- a/packages/extend2/package.json
+++ b/packages/extend2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/extend2",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "Port of jQuery.extend for Node.js",
   "keywords": [
     "clone",

--- a/packages/extend2/package.json
+++ b/packages/extend2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/extend2",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "Port of jQuery.extend for Node.js",
   "keywords": [
     "clone",

--- a/packages/extend2/package.json
+++ b/packages/extend2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/extend2",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "Port of jQuery.extend for Node.js",
   "keywords": [
     "clone",

--- a/packages/koa-static-cache/package.json
+++ b/packages/koa-static-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/koa-static-cache",
-  "version": "7.0.2-beta.20",
+  "version": "7.0.2-beta.21",
   "description": "Static cache middleware for koa",
   "keywords": [
     "cache",

--- a/packages/koa-static-cache/package.json
+++ b/packages/koa-static-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/koa-static-cache",
-  "version": "7.0.2-beta.21",
+  "version": "7.0.2-beta.22",
   "description": "Static cache middleware for koa",
   "keywords": [
     "cache",

--- a/packages/koa-static-cache/package.json
+++ b/packages/koa-static-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/koa-static-cache",
-  "version": "7.0.2-beta.22",
+  "version": "7.0.2-beta.23",
   "description": "Static cache middleware for koa",
   "keywords": [
     "cache",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/koa",
-  "version": "3.1.2-beta.20",
+  "version": "3.1.2-beta.21",
   "description": "Koa web app framework for https://eggjs.org",
   "keywords": [
     "app",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/koa",
-  "version": "3.1.2-beta.22",
+  "version": "3.1.2-beta.23",
   "description": "Koa web app framework for https://eggjs.org",
   "keywords": [
     "app",

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/koa",
-  "version": "3.1.2-beta.21",
+  "version": "3.1.2-beta.22",
   "description": "Koa web app framework for https://eggjs.org",
   "keywords": [
     "app",

--- a/packages/loader-fs/package.json
+++ b/packages/loader-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/loader-fs",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "description": "Loader-facing filesystem abstraction for Egg",
   "keywords": [
     "egg",

--- a/packages/loader-fs/package.json
+++ b/packages/loader-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/loader-fs",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "description": "Loader-facing filesystem abstraction for Egg",
   "keywords": [
     "egg",

--- a/packages/loader-fs/package.json
+++ b/packages/loader-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/loader-fs",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "description": "Loader-facing filesystem abstraction for Egg",
   "keywords": [
     "egg",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/logger",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "egg logger",
   "keywords": [
     "egg",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/logger",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "egg logger",
   "keywords": [
     "egg",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/logger",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "egg logger",
   "keywords": [
     "egg",

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/path-matching",
-  "version": "3.0.2-beta.21",
+  "version": "3.0.2-beta.22",
   "description": "match or ignore url path",
   "keywords": [
     "ignore",

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/path-matching",
-  "version": "3.0.2-beta.20",
+  "version": "3.0.2-beta.21",
   "description": "match or ignore url path",
   "keywords": [
     "ignore",

--- a/packages/path-matching/package.json
+++ b/packages/path-matching/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/path-matching",
-  "version": "3.0.2-beta.22",
+  "version": "3.0.2-beta.23",
   "description": "match or ignore url path",
   "keywords": [
     "ignore",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/router",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "Router middleware for egg/koa. Provides RESTful resource routing.",
   "keywords": [
     "koa",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/router",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "Router middleware for egg/koa. Provides RESTful resource routing.",
   "keywords": [
     "koa",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/router",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "Router middleware for egg/koa. Provides RESTful resource routing.",
   "keywords": [
     "koa",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/skills",
-  "version": "4.1.2-beta.22",
+  "version": "4.1.2-beta.23",
   "description": "agent skills for egg",
   "keywords": [
     "egg",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/skills",
-  "version": "4.1.2-beta.20",
+  "version": "4.1.2-beta.21",
   "description": "agent skills for egg",
   "keywords": [
     "egg",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/skills",
-  "version": "4.1.2-beta.21",
+  "version": "4.1.2-beta.22",
   "description": "agent skills for egg",
   "keywords": [
     "egg",

--- a/packages/supertest/package.json
+++ b/packages/supertest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/supertest",
-  "version": "9.0.2-beta.21",
+  "version": "9.0.2-beta.22",
   "description": "SuperAgent driven library for testing HTTP servers",
   "keywords": [
     "bdd",

--- a/packages/supertest/package.json
+++ b/packages/supertest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/supertest",
-  "version": "9.0.2-beta.22",
+  "version": "9.0.2-beta.23",
   "description": "SuperAgent driven library for testing HTTP servers",
   "keywords": [
     "bdd",

--- a/packages/supertest/package.json
+++ b/packages/supertest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/supertest",
-  "version": "9.0.2-beta.20",
+  "version": "9.0.2-beta.21",
   "description": "SuperAgent driven library for testing HTTP servers",
   "keywords": [
     "bdd",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tsconfig",
-  "version": "3.1.2-beta.22",
+  "version": "3.1.2-beta.23",
   "description": "Base tsconfig for egg ts project",
   "keywords": [
     "egg",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tsconfig",
-  "version": "3.1.2-beta.20",
+  "version": "3.1.2-beta.21",
   "description": "Base tsconfig for egg ts project",
   "keywords": [
     "egg",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tsconfig",
-  "version": "3.1.2-beta.21",
+  "version": "3.1.2-beta.22",
   "description": "Base tsconfig for egg ts project",
   "keywords": [
     "egg",

--- a/packages/typings/package.json
+++ b/packages/typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/typings",
-  "version": "4.1.2-beta.20",
+  "version": "4.1.2-beta.21",
   "description": "Shared typings for egg projects",
   "keywords": [
     "egg",

--- a/packages/typings/package.json
+++ b/packages/typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/typings",
-  "version": "4.1.2-beta.22",
+  "version": "4.1.2-beta.23",
   "description": "Shared typings for egg projects",
   "keywords": [
     "egg",

--- a/packages/typings/package.json
+++ b/packages/typings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/typings",
-  "version": "4.1.2-beta.21",
+  "version": "4.1.2-beta.22",
   "description": "Shared typings for egg projects",
   "keywords": [
     "egg",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/utils",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "Utils for all egg projects",
   "keywords": [
     "egg",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/utils",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "Utils for all egg projects",
   "keywords": [
     "egg",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/utils",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "Utils for all egg projects",
   "keywords": [
     "egg",

--- a/plugins/development/package.json
+++ b/plugins/development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/development",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "development tool for egg",
   "keywords": [
     "egg",

--- a/plugins/development/package.json
+++ b/plugins/development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/development",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "development tool for egg",
   "keywords": [
     "egg",

--- a/plugins/development/package.json
+++ b/plugins/development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/development",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "development tool for egg",
   "keywords": [
     "egg",

--- a/plugins/i18n/package.json
+++ b/plugins/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/i18n",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "i18n plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/i18n/package.json
+++ b/plugins/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/i18n",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "i18n plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/i18n/package.json
+++ b/plugins/i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/i18n",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "i18n plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/jsonp",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "jsonp support for egg",
   "keywords": [
     "egg",

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/jsonp",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "jsonp support for egg",
   "keywords": [
     "egg",

--- a/plugins/jsonp/package.json
+++ b/plugins/jsonp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/jsonp",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "jsonp support for egg",
   "keywords": [
     "egg",

--- a/plugins/logrotator/package.json
+++ b/plugins/logrotator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/logrotator",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "logrotator for egg",
   "keywords": [
     "egg",

--- a/plugins/logrotator/package.json
+++ b/plugins/logrotator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/logrotator",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "logrotator for egg",
   "keywords": [
     "egg",

--- a/plugins/logrotator/package.json
+++ b/plugins/logrotator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/logrotator",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "logrotator for egg",
   "keywords": [
     "egg",

--- a/plugins/mock/package.json
+++ b/plugins/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mock",
-  "version": "7.0.2-beta.20",
+  "version": "7.0.2-beta.21",
   "description": "mock server plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/mock/package.json
+++ b/plugins/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mock",
-  "version": "7.0.2-beta.22",
+  "version": "7.0.2-beta.23",
   "description": "mock server plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/mock/package.json
+++ b/plugins/mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mock",
-  "version": "7.0.2-beta.21",
+  "version": "7.0.2-beta.22",
   "description": "mock server plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/multipart",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "Multipart plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/multipart",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "Multipart plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/multipart/package.json
+++ b/plugins/multipart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/multipart",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "Multipart plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/onerror",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "error handler for egg",
   "keywords": [
     "egg",

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/onerror",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "error handler for egg",
   "keywords": [
     "egg",

--- a/plugins/onerror/package.json
+++ b/plugins/onerror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/onerror",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "error handler for egg",
   "keywords": [
     "egg",

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/redis",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "Valkey / Redis plugin for egg",
   "keywords": [
     "Valkey",

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/redis",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "Valkey / Redis plugin for egg",
   "keywords": [
     "Valkey",

--- a/plugins/redis/package.json
+++ b/plugins/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/redis",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "Valkey / Redis plugin for egg",
   "keywords": [
     "Valkey",

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule",
-  "version": "6.0.2-beta.20",
+  "version": "6.0.2-beta.21",
   "description": "schedule plugin for egg, support corn job.",
   "keywords": [
     "cron",

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule",
-  "version": "6.0.2-beta.21",
+  "version": "6.0.2-beta.22",
   "description": "schedule plugin for egg, support corn job.",
   "keywords": [
     "cron",

--- a/plugins/schedule/package.json
+++ b/plugins/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule",
-  "version": "6.0.2-beta.22",
+  "version": "6.0.2-beta.23",
   "description": "schedule plugin for egg, support corn job.",
   "keywords": [
     "cron",

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/security",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "security plugin in egg framework",
   "keywords": [
     "egg",

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/security",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "security plugin in egg framework",
   "keywords": [
     "egg",

--- a/plugins/security/package.json
+++ b/plugins/security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/security",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "security plugin in egg framework",
   "keywords": [
     "egg",

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/session",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "session plugin for egg",
   "keywords": [
     "cookie",

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/session",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "session plugin for egg",
   "keywords": [
     "cookie",

--- a/plugins/session/package.json
+++ b/plugins/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/session",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "session plugin for egg",
   "keywords": [
     "cookie",

--- a/plugins/static/package.json
+++ b/plugins/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/static",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "static server plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/static/package.json
+++ b/plugins/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/static",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "static server plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/static/package.json
+++ b/plugins/static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/static",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "static server plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/tracer/package.json
+++ b/plugins/tracer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tracer",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tracer for egg",
   "keywords": [
     "egg",

--- a/plugins/tracer/package.json
+++ b/plugins/tracer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tracer",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tracer for egg",
   "keywords": [
     "egg",

--- a/plugins/tracer/package.json
+++ b/plugins/tracer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tracer",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tracer for egg",
   "keywords": [
     "egg",

--- a/plugins/typebox-validate/package.json
+++ b/plugins/typebox-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/typebox-validate",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "another validate for typescript egg projects",
   "keywords": [
     "ajv",

--- a/plugins/typebox-validate/package.json
+++ b/plugins/typebox-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/typebox-validate",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "another validate for typescript egg projects",
   "keywords": [
     "ajv",

--- a/plugins/typebox-validate/package.json
+++ b/plugins/typebox-validate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/typebox-validate",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "another validate for typescript egg projects",
   "keywords": [
     "ajv",

--- a/plugins/view-nunjucks/package.json
+++ b/plugins/view-nunjucks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/view-nunjucks",
-  "version": "3.0.2-beta.21",
+  "version": "3.0.2-beta.22",
   "description": "nunjucks view plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/view-nunjucks/package.json
+++ b/plugins/view-nunjucks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/view-nunjucks",
-  "version": "3.0.2-beta.20",
+  "version": "3.0.2-beta.21",
   "description": "nunjucks view plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/view-nunjucks/package.json
+++ b/plugins/view-nunjucks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/view-nunjucks",
-  "version": "3.0.2-beta.22",
+  "version": "3.0.2-beta.23",
   "description": "nunjucks view plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/view/package.json
+++ b/plugins/view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/view",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "Base view plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/view/package.json
+++ b/plugins/view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/view",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "Base view plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/view/package.json
+++ b/plugins/view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/view",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "Base view plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/watcher",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "file watcher plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/watcher",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "file watcher plugin for egg",
   "keywords": [
     "egg",

--- a/plugins/watcher/package.json
+++ b/plugins/watcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/watcher",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "file watcher plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/core/agent-runtime/package.json
+++ b/tegg/core/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/agent-runtime",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "Agent runtime with store abstraction for Egg.js tegg",
   "keywords": [
     "agent",

--- a/tegg/core/agent-runtime/package.json
+++ b/tegg/core/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/agent-runtime",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "Agent runtime with store abstraction for Egg.js tegg",
   "keywords": [
     "agent",

--- a/tegg/core/agent-runtime/package.json
+++ b/tegg/core/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/agent-runtime",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "Agent runtime with store abstraction for Egg.js tegg",
   "keywords": [
     "agent",

--- a/tegg/core/ajv-decorator/package.json
+++ b/tegg/core/ajv-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/ajv-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg ajv decorator",
   "keywords": [
     "ajv",

--- a/tegg/core/ajv-decorator/package.json
+++ b/tegg/core/ajv-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/ajv-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg ajv decorator",
   "keywords": [
     "ajv",

--- a/tegg/core/ajv-decorator/package.json
+++ b/tegg/core/ajv-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/ajv-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg ajv decorator",
   "keywords": [
     "ajv",

--- a/tegg/core/aop-decorator/package.json
+++ b/tegg/core/aop-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg aop decorator",
   "keywords": [
     "aop",

--- a/tegg/core/aop-decorator/package.json
+++ b/tegg/core/aop-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg aop decorator",
   "keywords": [
     "aop",

--- a/tegg/core/aop-decorator/package.json
+++ b/tegg/core/aop-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg aop decorator",
   "keywords": [
     "aop",

--- a/tegg/core/aop-runtime/package.json
+++ b/tegg/core/aop-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-runtime",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg aop runtime",
   "keywords": [
     "aop",

--- a/tegg/core/aop-runtime/package.json
+++ b/tegg/core/aop-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-runtime",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg aop runtime",
   "keywords": [
     "aop",

--- a/tegg/core/aop-runtime/package.json
+++ b/tegg/core/aop-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-runtime",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg aop runtime",
   "keywords": [
     "aop",

--- a/tegg/core/background-task/package.json
+++ b/tegg/core/background-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/background-task",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "background task util for tegg",
   "keywords": [
     "async",

--- a/tegg/core/background-task/package.json
+++ b/tegg/core/background-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/background-task",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "background task util for tegg",
   "keywords": [
     "async",

--- a/tegg/core/background-task/package.json
+++ b/tegg/core/background-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/background-task",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "background task util for tegg",
   "keywords": [
     "async",

--- a/tegg/core/common-util/package.json
+++ b/tegg/core/common-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-common-util",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "common util for tegg",
   "keywords": [
     "collection",

--- a/tegg/core/common-util/package.json
+++ b/tegg/core/common-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-common-util",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "common util for tegg",
   "keywords": [
     "collection",

--- a/tegg/core/common-util/package.json
+++ b/tegg/core/common-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-common-util",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "common util for tegg",
   "keywords": [
     "collection",

--- a/tegg/core/controller-decorator/package.json
+++ b/tegg/core/controller-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/controller-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg controller decorator",
   "keywords": [
     "controller",

--- a/tegg/core/controller-decorator/package.json
+++ b/tegg/core/controller-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/controller-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg controller decorator",
   "keywords": [
     "controller",

--- a/tegg/core/controller-decorator/package.json
+++ b/tegg/core/controller-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/controller-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg controller decorator",
   "keywords": [
     "controller",

--- a/tegg/core/core-decorator/package.json
+++ b/tegg/core/core-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg core decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/core-decorator/package.json
+++ b/tegg/core/core-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg core decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/core-decorator/package.json
+++ b/tegg/core/core-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/core-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg core decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/dal-decorator/package.json
+++ b/tegg/core/dal-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg dal decorator",
   "keywords": [
     "dal",

--- a/tegg/core/dal-decorator/package.json
+++ b/tegg/core/dal-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg dal decorator",
   "keywords": [
     "dal",

--- a/tegg/core/dal-decorator/package.json
+++ b/tegg/core/dal-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg dal decorator",
   "keywords": [
     "dal",

--- a/tegg/core/dal-runtime/package.json
+++ b/tegg/core/dal-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-runtime",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg dal runtime",
   "keywords": [
     "dal",

--- a/tegg/core/dal-runtime/package.json
+++ b/tegg/core/dal-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-runtime",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg dal runtime",
   "keywords": [
     "dal",

--- a/tegg/core/dal-runtime/package.json
+++ b/tegg/core/dal-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-runtime",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg dal runtime",
   "keywords": [
     "dal",

--- a/tegg/core/dynamic-inject-runtime/package.json
+++ b/tegg/core/dynamic-inject-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dynamic-inject-runtime",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg dynamic inject runtime",
   "keywords": [
     "egg",

--- a/tegg/core/dynamic-inject-runtime/package.json
+++ b/tegg/core/dynamic-inject-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dynamic-inject-runtime",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg dynamic inject runtime",
   "keywords": [
     "egg",

--- a/tegg/core/dynamic-inject-runtime/package.json
+++ b/tegg/core/dynamic-inject-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dynamic-inject-runtime",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg dynamic inject runtime",
   "keywords": [
     "egg",

--- a/tegg/core/dynamic-inject/package.json
+++ b/tegg/core/dynamic-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dynamic-inject",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg dynamic inject decorator",
   "keywords": [
     "egg",

--- a/tegg/core/dynamic-inject/package.json
+++ b/tegg/core/dynamic-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dynamic-inject",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg dynamic inject decorator",
   "keywords": [
     "egg",

--- a/tegg/core/dynamic-inject/package.json
+++ b/tegg/core/dynamic-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dynamic-inject",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg dynamic inject decorator",
   "keywords": [
     "egg",

--- a/tegg/core/eventbus-decorator/package.json
+++ b/tegg/core/eventbus-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg eventbus decorator",
   "keywords": [
     "egg",

--- a/tegg/core/eventbus-decorator/package.json
+++ b/tegg/core/eventbus-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg eventbus decorator",
   "keywords": [
     "egg",

--- a/tegg/core/eventbus-decorator/package.json
+++ b/tegg/core/eventbus-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg eventbus decorator",
   "keywords": [
     "egg",

--- a/tegg/core/eventbus-runtime/package.json
+++ b/tegg/core/eventbus-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-runtime",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg eventbus runtime",
   "keywords": [
     "egg",

--- a/tegg/core/eventbus-runtime/package.json
+++ b/tegg/core/eventbus-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-runtime",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg eventbus runtime",
   "keywords": [
     "egg",

--- a/tegg/core/eventbus-runtime/package.json
+++ b/tegg/core/eventbus-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-runtime",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg eventbus runtime",
   "keywords": [
     "egg",

--- a/tegg/core/langchain-decorator/package.json
+++ b/tegg/core/langchain-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/langchain-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg langchain decorator",
   "keywords": [
     "egg",

--- a/tegg/core/langchain-decorator/package.json
+++ b/tegg/core/langchain-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/langchain-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg langchain decorator",
   "keywords": [
     "egg",

--- a/tegg/core/langchain-decorator/package.json
+++ b/tegg/core/langchain-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/langchain-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg langchain decorator",
   "keywords": [
     "egg",

--- a/tegg/core/lifecycle/package.json
+++ b/tegg/core/lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/lifecycle",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg lifecycle definition and decorators",
   "keywords": [
     "egg",

--- a/tegg/core/lifecycle/package.json
+++ b/tegg/core/lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/lifecycle",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg lifecycle definition and decorators",
   "keywords": [
     "egg",

--- a/tegg/core/lifecycle/package.json
+++ b/tegg/core/lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/lifecycle",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg lifecycle definition and decorators",
   "keywords": [
     "egg",

--- a/tegg/core/loader/package.json
+++ b/tegg/core/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-loader",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg default loader implement",
   "keywords": [
     "egg",

--- a/tegg/core/loader/package.json
+++ b/tegg/core/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-loader",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.20",
   "description": "tegg default loader implement",
   "keywords": [
     "egg",

--- a/tegg/core/loader/package.json
+++ b/tegg/core/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-loader",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg default loader implement",
   "keywords": [
     "egg",

--- a/tegg/core/loader/package.json
+++ b/tegg/core/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-loader",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg default loader implement",
   "keywords": [
     "egg",

--- a/tegg/core/mcp-client/package.json
+++ b/tegg/core/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-client",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg mcp client",
   "keywords": [
     "egg",

--- a/tegg/core/mcp-client/package.json
+++ b/tegg/core/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-client",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg mcp client",
   "keywords": [
     "egg",

--- a/tegg/core/mcp-client/package.json
+++ b/tegg/core/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-client",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg mcp client",
   "keywords": [
     "egg",

--- a/tegg/core/metadata/package.json
+++ b/tegg/core/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/metadata",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg metadata",
   "keywords": [
     "egg",

--- a/tegg/core/metadata/package.json
+++ b/tegg/core/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/metadata",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg metadata",
   "keywords": [
     "egg",

--- a/tegg/core/metadata/package.json
+++ b/tegg/core/metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/metadata",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg metadata",
   "keywords": [
     "egg",

--- a/tegg/core/orm-decorator/package.json
+++ b/tegg/core/orm-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/orm-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg orm decorator",
   "keywords": [
     "egg",

--- a/tegg/core/orm-decorator/package.json
+++ b/tegg/core/orm-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/orm-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg orm decorator",
   "keywords": [
     "egg",

--- a/tegg/core/orm-decorator/package.json
+++ b/tegg/core/orm-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/orm-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg orm decorator",
   "keywords": [
     "egg",

--- a/tegg/core/runtime/package.json
+++ b/tegg/core/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-runtime",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg runtime",
   "keywords": [
     "egg",

--- a/tegg/core/runtime/package.json
+++ b/tegg/core/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-runtime",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg runtime",
   "keywords": [
     "egg",

--- a/tegg/core/runtime/package.json
+++ b/tegg/core/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-runtime",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg runtime",
   "keywords": [
     "egg",

--- a/tegg/core/schedule-decorator/package.json
+++ b/tegg/core/schedule-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg schedule decorator",
   "keywords": [
     "egg",

--- a/tegg/core/schedule-decorator/package.json
+++ b/tegg/core/schedule-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg schedule decorator",
   "keywords": [
     "egg",

--- a/tegg/core/schedule-decorator/package.json
+++ b/tegg/core/schedule-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg schedule decorator",
   "keywords": [
     "egg",

--- a/tegg/core/standalone-decorator/package.json
+++ b/tegg/core/standalone-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/standalone-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg standalone decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/standalone-decorator/package.json
+++ b/tegg/core/standalone-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/standalone-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg standalone decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/standalone-decorator/package.json
+++ b/tegg/core/standalone-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/standalone-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg standalone decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/tegg/package.json
+++ b/tegg/core/tegg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg decorator packages",
   "keywords": [
     "egg",

--- a/tegg/core/tegg/package.json
+++ b/tegg/core/tegg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg decorator packages",
   "keywords": [
     "egg",

--- a/tegg/core/tegg/package.json
+++ b/tegg/core/tegg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg decorator packages",
   "keywords": [
     "egg",

--- a/tegg/core/transaction-decorator/package.json
+++ b/tegg/core/transaction-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/transaction-decorator",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg transaction decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/transaction-decorator/package.json
+++ b/tegg/core/transaction-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/transaction-decorator",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg transaction decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/transaction-decorator/package.json
+++ b/tegg/core/transaction-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/transaction-decorator",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg transaction decorator",
   "keywords": [
     "decorator",

--- a/tegg/core/types/package.json
+++ b/tegg/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-types",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg types",
   "keywords": [
     "egg",

--- a/tegg/core/types/package.json
+++ b/tegg/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-types",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg types",
   "keywords": [
     "egg",

--- a/tegg/core/types/package.json
+++ b/tegg/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-types",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg types",
   "keywords": [
     "egg",

--- a/tegg/core/vitest/package.json
+++ b/tegg/core/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-vitest",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "Vitest adapter for tegg context injection",
   "keywords": [
     "adapter",

--- a/tegg/core/vitest/package.json
+++ b/tegg/core/vitest/package.json
@@ -30,6 +30,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./runner": "./src/runner.ts",
+    "./setup": "./src/setup.ts",
     "./shared": "./src/shared.ts",
     "./package.json": "./package.json"
   },
@@ -38,6 +39,7 @@
     "exports": {
       ".": "./dist/index.js",
       "./runner": "./dist/runner.js",
+      "./setup": "./dist/setup.js",
       "./shared": "./dist/shared.js",
       "./package.json": "./package.json"
     }

--- a/tegg/core/vitest/package.json
+++ b/tegg/core/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-vitest",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.20",
   "description": "Vitest adapter for tegg context injection",
   "keywords": [
     "adapter",

--- a/tegg/core/vitest/package.json
+++ b/tegg/core/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-vitest",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "Vitest adapter for tegg context injection",
   "keywords": [
     "adapter",

--- a/tegg/core/vitest/package.json
+++ b/tegg/core/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-vitest",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "Vitest adapter for tegg context injection",
   "keywords": [
     "adapter",

--- a/tegg/core/vitest/src/runner.ts
+++ b/tegg/core/vitest/src/runner.ts
@@ -87,12 +87,6 @@ export default class TeggVitestRunner extends VitestTestRunner {
 
   constructor(config: ConstructorParameters<typeof VitestTestRunner>[0]) {
     super(config);
-    // TEGG discovers prototype files while the Egg app is booting. Route those
-    // imports through Vitest's module graph so application loading and test
-    // imports resolve to the same class instances.
-    // `setup` imports intentionally invalidate Vitest's module cache. Use the
-    // regular collection path here so an already imported prototype is reused.
-    globalThis.__EGG_MODULE_IMPORTER__ = async (filepath: string) => super.importFile(filepath, 'collect');
     // When isolate: false, all test files share the same worker and module cache.
     // The app must not be closed between files — only after all files finish.
     this.sharedMode = !config.isolate;

--- a/tegg/core/vitest/src/runner.ts
+++ b/tegg/core/vitest/src/runner.ts
@@ -87,6 +87,12 @@ export default class TeggVitestRunner extends VitestTestRunner {
 
   constructor(config: ConstructorParameters<typeof VitestTestRunner>[0]) {
     super(config);
+    // TEGG discovers prototype files while the Egg app is booting. Route those
+    // imports through Vitest's module graph so application loading and test
+    // imports resolve to the same class instances.
+    // `setup` imports intentionally invalidate Vitest's module cache. Use the
+    // regular collection path here so an already imported prototype is reused.
+    globalThis.__EGG_MODULE_IMPORTER__ = async (filepath: string) => super.importFile(filepath, 'collect');
     // When isolate: false, all test files share the same worker and module cache.
     // The app must not be closed between files — only after all files finish.
     this.sharedMode = !config.isolate;

--- a/tegg/core/vitest/src/setup.ts
+++ b/tegg/core/vitest/src/setup.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const nodeRequire = createRequire(import.meta.url);
+const esmDirectoryCache = new Map<string, boolean>();
+
+function isEsmFile(filePath: string): boolean {
+  if (filePath.endsWith('.mjs')) return true;
+  if (filePath.endsWith('.cjs')) return false;
+
+  let directory = path.dirname(filePath);
+  const visited: string[] = [];
+  while (directory !== path.dirname(directory)) {
+    const cached = esmDirectoryCache.get(directory);
+    if (cached !== undefined) {
+      for (const item of visited) esmDirectoryCache.set(item, cached);
+      return cached;
+    }
+
+    visited.push(directory);
+    const packageFile = path.join(directory, 'package.json');
+    if (fs.existsSync(packageFile)) {
+      let isEsm = false;
+      try {
+        isEsm = JSON.parse(fs.readFileSync(packageFile, 'utf8')).type === 'module';
+      } catch {
+        // Invalid package metadata follows Node's CommonJS-compatible fallback.
+      }
+      for (const item of visited) esmDirectoryCache.set(item, isEsm);
+      return isEsm;
+    }
+    directory = path.dirname(directory);
+  }
+  return false;
+}
+
+// This setup file runs inside the test ViteVM. CJS files must use Node's
+// require cache, while ESM files stay in Vitest's transformed import graph.
+globalThis.__EGG_MODULE_IMPORTER__ = async (filePath: string) => {
+  if (isEsmFile(filePath)) return import(pathToFileURL(filePath).href);
+  return nodeRequire(filePath);
+};

--- a/tegg/core/vitest/test/fixture_app.test.ts
+++ b/tegg/core/vitest/test/fixture_app.test.ts
@@ -33,6 +33,11 @@ describe('fixture demo app', () => {
   });
 
   it('injects ctx and getEggObject', async () => {
+    const loadedModule = (await globalThis.__EGG_MODULE_IMPORTER__?.(
+      path.join(__dirname, 'fixtures/apps/demo-app/modules/demo-module/HelloService.ts'),
+    )) as { HelloService: typeof HelloService };
+    assert.strictEqual(loadedModule.HelloService, HelloService);
+
     const ctx = app.ctxStorage.getStore();
     assert(ctx);
     const helloService = (await ctx.getEggObject(HelloService)) as any;

--- a/tegg/core/vitest/vitest.config.ts
+++ b/tegg/core/vitest/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     environment: 'node',
     include: ['test/**/*.test.ts'],
     // Register TS loader (ts-node) before tests so Egg can load .ts via Module._extensions.
-    setupFiles: ['test/setup.ts'],
+    setupFiles: ['./src/setup.ts', 'test/setup.ts'],
     // Custom runner for tegg context injection via enterWith + held beginModuleScope.
     runner: './src/runner.ts',
   },

--- a/tegg/plugin/ajv/package.json
+++ b/tegg/plugin/ajv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/ajv-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "ajv plugin for egg and tegg",
   "keywords": [
     "ajv",

--- a/tegg/plugin/ajv/package.json
+++ b/tegg/plugin/ajv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/ajv-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "ajv plugin for egg and tegg",
   "keywords": [
     "ajv",

--- a/tegg/plugin/ajv/package.json
+++ b/tegg/plugin/ajv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/ajv-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "ajv plugin for egg and tegg",
   "keywords": [
     "ajv",

--- a/tegg/plugin/aop/package.json
+++ b/tegg/plugin/aop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg aop plugin",
   "keywords": [
     "aop",

--- a/tegg/plugin/aop/package.json
+++ b/tegg/plugin/aop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg aop plugin",
   "keywords": [
     "aop",

--- a/tegg/plugin/aop/package.json
+++ b/tegg/plugin/aop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/aop-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg aop plugin",
   "keywords": [
     "aop",

--- a/tegg/plugin/common/package.json
+++ b/tegg/plugin/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/module-common",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "common module",
   "keywords": [
     "common",

--- a/tegg/plugin/common/package.json
+++ b/tegg/plugin/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/module-common",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "common module",
   "keywords": [
     "common",

--- a/tegg/plugin/common/package.json
+++ b/tegg/plugin/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/module-common",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "common module",
   "keywords": [
     "common",

--- a/tegg/plugin/config/package.json
+++ b/tegg/plugin/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-config",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "module config plugin for egg",
   "keywords": [
     "config",

--- a/tegg/plugin/config/package.json
+++ b/tegg/plugin/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-config",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "module config plugin for egg",
   "keywords": [
     "config",

--- a/tegg/plugin/config/package.json
+++ b/tegg/plugin/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-config",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "module config plugin for egg",
   "keywords": [
     "config",

--- a/tegg/plugin/controller/package.json
+++ b/tegg/plugin/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/controller-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "controller decorator plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/controller/package.json
+++ b/tegg/plugin/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/controller-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "controller decorator plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/controller/package.json
+++ b/tegg/plugin/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/controller-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "controller decorator plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/dal/package.json
+++ b/tegg/plugin/dal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "dal plugin for egg",
   "keywords": [
     "dal",

--- a/tegg/plugin/dal/package.json
+++ b/tegg/plugin/dal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "dal plugin for egg",
   "keywords": [
     "dal",

--- a/tegg/plugin/dal/package.json
+++ b/tegg/plugin/dal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dal-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "dal plugin for egg",
   "keywords": [
     "dal",

--- a/tegg/plugin/dal/src/lib/TransactionPrototypeHook.ts
+++ b/tegg/plugin/dal/src/lib/TransactionPrototypeHook.ts
@@ -26,10 +26,14 @@ export class TransactionPrototypeHook implements LifecycleHook<EggPrototypeLifec
       return;
     }
     const moduleName = ctx.loadUnit.name;
+    const datasourceConfigs = (this.moduleConfigs[moduleName]?.config as any)?.dataSource || {};
+    const dataSources = Object.keys(datasourceConfigs);
+    if (dataSources.length === 0) {
+      return;
+    }
+
     for (const transactionMetadata of transactionMetadataList) {
       const clazzName = `${moduleName}.${ctx.clazz.name}.${String(transactionMetadata.method)}`;
-      const datasourceConfigs = (this.moduleConfigs[moduleName]?.config as any)?.dataSource || {};
-
       let datasourceName: string;
       if (transactionMetadata.datasourceName) {
         assert(
@@ -39,7 +43,6 @@ export class TransactionPrototypeHook implements LifecycleHook<EggPrototypeLifec
         datasourceName = transactionMetadata.datasourceName;
         this.logger.info(`use datasource [${transactionMetadata.datasourceName}] for class ${clazzName}`);
       } else {
-        const dataSources = Object.keys(datasourceConfigs);
         if (dataSources.length === 1) {
           datasourceName = dataSources[0];
         } else {

--- a/tegg/plugin/dal/test/TransactionPrototypeHook.test.ts
+++ b/tegg/plugin/dal/test/TransactionPrototypeHook.test.ts
@@ -1,0 +1,64 @@
+import { Transactional } from '@eggjs/transaction-decorator';
+import { describe, expect, it } from 'vitest';
+
+import { TransactionPrototypeHook } from '../src/lib/TransactionPrototypeHook.ts';
+
+describe('plugin/dal/test/TransactionPrototypeHook.test.ts', () => {
+  const logger = {
+    info() {},
+  } as any;
+
+  it('should skip transaction hook when module has no dataSource config', async () => {
+    class FooService {
+      @Transactional()
+      async doSomething() {}
+    }
+
+    const hook = new TransactionPrototypeHook(
+      {
+        foo: {
+          config: {},
+        },
+      } as any,
+      logger,
+    );
+
+    await expect(
+      hook.preCreate({
+        clazz: FooService,
+        loadUnit: {
+          name: 'foo',
+        },
+      } as any),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should skip transaction hook when module has empty dataSource config', async () => {
+    class BarService {
+      @Transactional({
+        datasourceName: 'foo',
+      })
+      async doSomething() {}
+    }
+
+    const hook = new TransactionPrototypeHook(
+      {
+        bar: {
+          config: {
+            dataSource: {},
+          },
+        },
+      } as any,
+      logger,
+    );
+
+    await expect(
+      hook.preCreate({
+        clazz: BarService,
+        loadUnit: {
+          name: 'bar',
+        },
+      } as any),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tegg/plugin/dns-cache/package.json
+++ b/tegg/plugin/dns-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dns-cache-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg dns cache plugin",
   "keywords": [
     "cache",

--- a/tegg/plugin/dns-cache/package.json
+++ b/tegg/plugin/dns-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dns-cache-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg dns cache plugin",
   "keywords": [
     "cache",

--- a/tegg/plugin/dns-cache/package.json
+++ b/tegg/plugin/dns-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/dns-cache-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg dns cache plugin",
   "keywords": [
     "cache",

--- a/tegg/plugin/eventbus/package.json
+++ b/tegg/plugin/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg event plugin",
   "keywords": [
     "decorator",

--- a/tegg/plugin/eventbus/package.json
+++ b/tegg/plugin/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg event plugin",
   "keywords": [
     "decorator",

--- a/tegg/plugin/eventbus/package.json
+++ b/tegg/plugin/eventbus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/eventbus-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg event plugin",
   "keywords": [
     "decorator",

--- a/tegg/plugin/langchain/package.json
+++ b/tegg/plugin/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/langchain-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "langchain for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/langchain/package.json
+++ b/tegg/plugin/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/langchain-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "langchain for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/langchain/package.json
+++ b/tegg/plugin/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/langchain-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "langchain for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/mcp-client/package.json
+++ b/tegg/plugin/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-client-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "mcp client for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/mcp-client/package.json
+++ b/tegg/plugin/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-client-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "mcp client for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/mcp-client/package.json
+++ b/tegg/plugin/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-client-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "mcp client for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/mcp-proxy/package.json
+++ b/tegg/plugin/mcp-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-proxy-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg mcp proxy plugin",
   "keywords": [
     "egg",

--- a/tegg/plugin/mcp-proxy/package.json
+++ b/tegg/plugin/mcp-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-proxy-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg mcp proxy plugin",
   "keywords": [
     "egg",

--- a/tegg/plugin/mcp-proxy/package.json
+++ b/tegg/plugin/mcp-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mcp-proxy-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg mcp proxy plugin",
   "keywords": [
     "egg",

--- a/tegg/plugin/orm/package.json
+++ b/tegg/plugin/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/orm-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "orm decorator for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/orm/package.json
+++ b/tegg/plugin/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/orm-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "orm decorator for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/orm/package.json
+++ b/tegg/plugin/orm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/orm-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "orm decorator for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/schedule/package.json
+++ b/tegg/plugin/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "schedule decorator plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/schedule/package.json
+++ b/tegg/plugin/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "schedule decorator plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/schedule/package.json
+++ b/tegg/plugin/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/schedule-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "schedule decorator plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/tegg/package.json
+++ b/tegg/plugin/tegg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-plugin",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "module plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/tegg/package.json
+++ b/tegg/plugin/tegg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-plugin",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "module plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/plugin/tegg/package.json
+++ b/tegg/plugin/tegg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/tegg-plugin",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "module plugin for egg",
   "keywords": [
     "egg",

--- a/tegg/standalone/standalone/package.json
+++ b/tegg/standalone/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/standalone",
-  "version": "4.0.2-beta.20",
+  "version": "4.0.2-beta.21",
   "description": "tegg standalone",
   "keywords": [
     "async",

--- a/tegg/standalone/standalone/package.json
+++ b/tegg/standalone/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/standalone",
-  "version": "4.0.2-beta.22",
+  "version": "4.0.2-beta.23",
   "description": "tegg standalone",
   "keywords": [
     "async",

--- a/tegg/standalone/standalone/package.json
+++ b/tegg/standalone/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/standalone",
-  "version": "4.0.2-beta.21",
+  "version": "4.0.2-beta.22",
   "description": "tegg standalone",
   "keywords": [
     "async",

--- a/tools/create-egg/package.json
+++ b/tools/create-egg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-egg",
-  "version": "4.1.2-beta.21",
+  "version": "4.1.2-beta.22",
   "description": "Scaffolding Your First Egg.js Project",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/create-egg",
   "bugs": {

--- a/tools/create-egg/package.json
+++ b/tools/create-egg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-egg",
-  "version": "4.1.2-beta.22",
+  "version": "4.1.2-beta.23",
   "description": "Scaffolding Your First Egg.js Project",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/create-egg",
   "bugs": {

--- a/tools/create-egg/package.json
+++ b/tools/create-egg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-egg",
-  "version": "4.1.2-beta.20",
+  "version": "4.1.2-beta.21",
   "description": "Scaffolding Your First Egg.js Project",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/create-egg",
   "bugs": {

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/bin",
-  "version": "8.0.2-beta.22",
+  "version": "8.0.2-beta.23",
   "description": "egg developer tool",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bin",
   "bugs": {

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/bin",
-  "version": "8.0.2-beta.20",
+  "version": "8.0.2-beta.21",
   "description": "egg developer tool",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bin",
   "bugs": {

--- a/tools/egg-bin/package.json
+++ b/tools/egg-bin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/bin",
-  "version": "8.0.2-beta.21",
+  "version": "8.0.2-beta.22",
   "description": "egg developer tool",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bin",
   "bugs": {

--- a/tools/egg-bin/src/commands/test.ts
+++ b/tools/egg-bin/src/commands/test.ts
@@ -252,6 +252,12 @@ export default class Test<T extends typeof Test> extends BaseCommand<T> {
     }
     if (!runner) {
       debug('skip @eggjs/tegg-vitest/runner: self-test fixture or not resolvable');
+    } else {
+      const teggSetup = importResolve('@eggjs/tegg-vitest/setup', {
+        paths: [flags.base, import.meta.dirname],
+      });
+      setupFiles.unshift(teggSetup);
+      debug('auto add @eggjs/tegg-vitest/setup: %o', teggSetup);
     }
 
     return {

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/egg-bundler",
-  "version": "0.0.1-beta.10",
+  "version": "0.0.1-beta.11",
   "description": "Bundle an Egg.js application into a deployable artifact using @utoo/pack",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bundler",
   "bugs": {

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/egg-bundler",
-  "version": "0.0.1-beta.11",
+  "version": "0.0.1-beta.12",
   "description": "Bundle an Egg.js application into a deployable artifact using @utoo/pack",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bundler",
   "bugs": {

--- a/tools/egg-bundler/package.json
+++ b/tools/egg-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/egg-bundler",
-  "version": "0.0.1-beta.12",
+  "version": "0.0.1-beta.13",
   "description": "Bundle an Egg.js application into a deployable artifact using @utoo/pack",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/egg-bundler",
   "bugs": {

--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/scripts",
-  "version": "5.0.2-beta.20",
+  "version": "5.0.2-beta.21",
   "description": "deploy tool for egg project",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/scripts",
   "bugs": {

--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/scripts",
-  "version": "5.0.2-beta.22",
+  "version": "5.0.2-beta.23",
   "description": "deploy tool for egg project",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/scripts",
   "bugs": {

--- a/tools/scripts/package.json
+++ b/tools/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/scripts",
-  "version": "5.0.2-beta.21",
+  "version": "5.0.2-beta.22",
   "description": "deploy tool for egg project",
   "homepage": "https://github.com/eggjs/egg/tree/next/tools/scripts",
   "bugs": {


### PR DESCRIPTION
## What

Bring the branch that was used to publish `v4.1.2-beta.23` back into `next` so the source baseline matches the npm beta release.

This includes:

- the beta.21, beta.22, and beta.23 release version commits
- the tegg vitest module-importer setup change used by the published beta
- the dal transaction hook guard used by the published beta

## Why

The successful manual release run checked out `codex/release-beta22-module-importer` even though the Actions run page shows `headBranch=next`. As a result, npm beta packages advanced to `4.1.2-beta.23`, but `next` stayed behind at `4.1.2-beta.20`.

Merging this PR first realigns `next` with the already-published beta line before any further beta release is cut.

## Validation

- Confirmed `v4.1.2-beta.23` points at `origin/codex/release-beta22-module-importer`
- Confirmed Git can auto-merge `origin/next` with `origin/codex/release-beta22-module-importer` using `git merge-tree --write-tree`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Vitest setup support for dynamic module loading and automatic test initialization.
  - Exposed the new Vitest setup entry for easier test configuration.

- **Bug Fixes**
  - Improved transaction hook handling when no data source is configured.
  - Prevented unnecessary transaction setup in unsupported configurations.

- **Chores**
  - Published updated beta releases across the project’s packages and tools, advancing versions to the latest beta iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->