### PR TITLE
perf(tegg-loader): dedupe concurrent module loads

### DIFF
--- a/tegg/core/loader/src/impl/ModuleLoader.ts
+++ b/tegg/core/loader/src/impl/ModuleLoader.ts
@@ -19,6 +19,7 @@ export interface ModuleLoaderOptions {
 export class ModuleLoader implements Loader {
   private readonly moduleDir: string;
   private protoClazzList: EggProtoImplClass[];
+  private loadPromise?: Promise<EggProtoImplClass[]>;
   private readonly precomputedFiles?: string[];
   private readonly loaderFS: LoaderFS;
 
@@ -33,6 +34,22 @@ export class ModuleLoader implements Loader {
     if (this.protoClazzList) {
       return this.protoClazzList;
     }
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+
+    const loadPromise = this.loadOnce();
+    this.loadPromise = loadPromise;
+    try {
+      return await loadPromise;
+    } finally {
+      if (this.loadPromise === loadPromise) {
+        this.loadPromise = undefined;
+      }
+    }
+  }
+
+  private async loadOnce(): Promise<EggProtoImplClass[]> {
     const protoClassList: EggProtoImplClass[] = [];
 
     let files: string[];

--- a/tegg/core/loader/test/ModuleLoaderManifest.test.ts
+++ b/tegg/core/loader/test/ModuleLoaderManifest.test.ts
@@ -2,13 +2,18 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 
 import { EggLoadUnitType } from '@eggjs/metadata';
-import { describe, it } from 'vitest';
+import { afterEach, describe, it, vi } from 'vitest';
 
 import { ModuleLoader } from '../src/impl/ModuleLoader.ts';
 import { LoaderFactory } from '../src/index.ts';
+import { LoaderUtil } from '../src/LoaderUtil.ts';
 
 describe('core/loader/test/ModuleLoaderManifest.test.ts', () => {
   const repoModulePath = path.join(__dirname, './fixtures/modules/module-for-loader');
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   it('should load only precomputed files when provided', async () => {
     const loader = new ModuleLoader(repoModulePath, { precomputedFiles: ['AppRepo.ts'] });
@@ -48,5 +53,42 @@ describe('core/loader/test/ModuleLoaderManifest.test.ts', () => {
     const first = await loader.load();
     const second = await loader.load();
     assert.strictEqual(first, second);
+  });
+
+  it('should share an in-flight load between concurrent callers', async () => {
+    const originalLoadFile = LoaderUtil.loadFile;
+    let release: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const loadFile = vi.spyOn(LoaderUtil, 'loadFile').mockImplementation(async (filePath) => {
+      await gate;
+      return originalLoadFile.call(LoaderUtil, filePath);
+    });
+    const loader = new ModuleLoader(repoModulePath, { precomputedFiles: ['AppRepo.ts'] });
+
+    const firstLoad = loader.load();
+    const secondLoad = loader.load();
+    assert.equal(loadFile.mock.calls.length, 1);
+    release!();
+
+    const [first, second] = await Promise.all([firstLoad, secondLoad]);
+    assert.strictEqual(first, second);
+    assert.equal(loadFile.mock.calls.length, 1);
+  });
+
+  it('should allow retry after an in-flight load fails', async () => {
+    const originalLoadFile = LoaderUtil.loadFile;
+    const loadFile = vi
+      .spyOn(LoaderUtil, 'loadFile')
+      .mockRejectedValueOnce(new Error('load failed'))
+      .mockImplementation((filePath) => originalLoadFile.call(LoaderUtil, filePath));
+    const loader = new ModuleLoader(repoModulePath, { precomputedFiles: ['AppRepo.ts'] });
+
+    await assert.rejects(loader.load(), /load failed/);
+    const prototypes = await loader.load();
+
+    assert.equal(prototypes.length, 2);
+    assert.equal(loadFile.mock.calls.length, 2);
   });
 });


### PR DESCRIPTION
## Summary

- share an in-flight `ModuleLoader.load()` promise between concurrent callers
- clear the in-flight promise after completion so failed loads remain retryable
- add regression coverage for concurrent deduplication and retry-after-failure

## Motivation

`protoClazzList` only caches completed loads. When multiple startup paths call `load()` before the first call finishes, each caller performs the same file loading and module imports. Keeping a per-loader in-flight promise avoids duplicate work while preserving the existing completed-result cache.

## Test

```text
utx vitest run tegg/core/loader/test/ModuleLoaderManifest.test.ts
6 tests passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading so simultaneous requests share one in-progress operation, preventing duplicate loading work.
  * Module loading now retries correctly after a failed attempt.

* **Tests**
  * Added coverage for concurrent loading and retry behavior.
  * Improved test isolation by restoring mocks after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->