### PR TITLE
fix(security): escape shell arg single quotes

### DIFF
--- a/plugins/security/README.md
+++ b/plugins/security/README.md
@@ -440,7 +440,9 @@ cp.exec('bash /home/admin/ali-knowledge-graph-backend/initrun.sh ' + ctx.helper.
 
 ### .escapeShellArg()
 
-Escape command line arguments. Add single quotes around a string and quotes/escapes any existing single quotes allowing you to pass a string directly to a shell function and having it be treated as a single safe argument.
+Escape POSIX shell command line arguments. Add single quotes around a string and quotes/escapes any existing single quotes allowing you to pass a string directly to a shell function and having it be treated as a single safe argument.
+
+Prefer `child_process.execFile()` or `child_process.spawn()` with an arguments array when possible. This helper is for a single argument in a POSIX shell command string, and is not a Windows `cmd.exe` or PowerShell escaping helper.
 
 ```js
 const ip = '127.0.0.1 && cat /etc/passwd';

--- a/plugins/security/README.zh-CN.md
+++ b/plugins/security/README.zh-CN.md
@@ -358,7 +358,9 @@ cp.exec('bash /home/admin/ali-knowledge-graph-backend/initrun.sh ' + this.helper
 
 ### .escapeShellArg()
 
-命令行参数转义。给字符串增加一对单引号并且能引用或者转码任何已经存在的单引号， 这样以确保能够直接将一个字符串传入 shell 函数，并且还是确保安全的。
+POSIX shell 命令行参数转义。给字符串增加一对单引号并且能引用或者转码任何已经存在的单引号， 这样以确保能够直接将一个字符串传入 shell 函数，并且还是确保安全的。
+
+如果可以，优先使用 `child_process.execFile()` 或 `child_process.spawn()` 的参数数组。这个 helper 只用于 POSIX shell 命令字符串里的单个参数，不适用于 Windows `cmd.exe` 或 PowerShell 转义。
 
 ```js
 const ip = '127.0.0.1 && cat /etc/passwd';

--- a/plugins/security/src/lib/helper/escapeShellArg.ts
+++ b/plugins/security/src/lib/helper/escapeShellArg.ts
@@ -1,4 +1,4 @@
 export default function escapeShellArg(text: string): string {
   const str = '' + text;
-  return "'" + str.replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
+  return "'" + str.replace(/'/g, "'\\''") + "'";
 }

--- a/plugins/security/test/app/extends/escapeShellArg.test.ts
+++ b/plugins/security/test/app/extends/escapeShellArg.test.ts
@@ -1,7 +1,14 @@
-import { mm, type MockApplication } from '@eggjs/mock';
-import { beforeAll, afterAll, describe, it } from 'vitest';
+import { exec as childProcessExec } from 'node:child_process';
+import { promisify } from 'node:util';
 
+import { mm, type MockApplication } from '@eggjs/mock';
+import { beforeAll, afterAll, describe, expect, it } from 'vitest';
+
+import escapeShellArg from '../../../src/lib/helper/escapeShellArg.ts';
 import { getFixtures } from '../../utils.ts';
+
+const exec = promisify(childProcessExec);
+const itOnPosix = process.platform === 'win32' ? it.skip : it;
 
 describe('test/app/extends/escapeShellArg.test.ts', () => {
   let app: MockApplication;
@@ -25,6 +32,13 @@ describe('test/app/extends/escapeShellArg.test.ts', () => {
 
     it('should not affect normal arg', () => {
       return app.httpRequest().get('/escapeShellArg-3').expect(200).expect('true');
+    });
+
+    itOnPosix('should keep single quotes inside one shell argument', async () => {
+      const payload = "'; echo EGG_SECURITY_INJECTED; #";
+      const { stdout } = await exec(`printf 'ARG:%s\\n' ${escapeShellArg(payload)}`);
+
+      expect(stdout).toBe("ARG:'; echo EGG_SECURITY_INJECTED; #\n");
     });
   });
 });

--- a/plugins/security/test/fixtures/apps/helper-escapeShellArg-app/app/router.js
+++ b/plugins/security/test/fixtures/apps/helper-escapeShellArg-app/app/router.js
@@ -10,7 +10,7 @@ module.exports = (app) => {
     const port = "8889'|chmod 777 /tmp/muma.sh;echo \\";
     this.body =
       `cp.exec('./start.sh '+${this.helper.escapeShellArg(port)})` ===
-      "cp.exec('./start.sh '+'8889\\'|chmod 777 /tmp/muma.sh;echo \\\\')";
+      "cp.exec('./start.sh '+'8889'\\''|chmod 777 /tmp/muma.sh;echo \\')";
   });
 
   app.get('/escapeShellArg-3', async function () {


### PR DESCRIPTION
## Summary

Fix `@eggjs/security`'s `escapeShellArg` helper so embedded single quotes use the POSIX-safe `'\''` quoting pattern instead of `\'`, which does not escape single quotes inside POSIX shell single-quoted strings.

## Why

The previous output could terminate the quoted argument and allow a following shell metacharacter sequence to execute when callers used the documented `child_process.exec()` string-concatenation pattern.

## Changes

- Replace the single quote escaping logic with the POSIX standard `'\''` sequence.
- Add a POSIX shell regression test that verifies a payload containing `'; echo ...; #` remains one argument.
- Update the helper docs to clarify that this is POSIX shell single-argument escaping and recommend `execFile()` / `spawn()` argument arrays where possible.

## Validation

- `./node_modules/.bin/oxfmt plugins/security/src/lib/helper/escapeShellArg.ts plugins/security/test/app/extends/escapeShellArg.test.ts plugins/security/test/fixtures/apps/helper-escapeShellArg-app/app/router.js plugins/security/README.md plugins/security/README.zh-CN.md`
- `git diff --check`
- Manual shell regression with Node + `child_process.exec`: payload `'; echo EGG_SECURITY_INJECTED; #` is printed as one argument and does not execute the injected `echo`.

Note: local `vitest run plugins/security/test/app/extends/escapeShellArg.test.ts` could not start in this checkout because `@oxc-node/core` is missing from `node_modules`; CI should run with a hydrated install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shell argument escaping for POSIX environments, including arguments containing single quotes and shell metacharacters.
  - Preserved argument contents more reliably when executed through a shell.

- **Documentation**
  - Clarified POSIX shell behavior and limitations.
  - Added guidance to prefer process APIs with argument arrays for safer command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->