### PR TITLE
docs: acknowledge Y4tacker security report

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,11 @@ These versions are currently being supported with security updates.
 
 To report a security vulnerability, please do not open an issue, as this notifies attackers of the vulnerability.
 Instead, please email [fengmk2](mailto:fengmk2+eggjs-security@gmail.com) to disclose.
+
+## Security Acknowledgements
+
+We thank the following security researchers for responsibly disclosing vulnerabilities and helping make Egg.js more secure.
+
+| Researcher | Vulnerability | Fixes |
+| ---------- | ------------- | ----- |
+| Y4tacker | Command injection via `escapeShellArg` in `@eggjs/security` | [4.x](https://github.com/eggjs/security/pull/106), [3.x](https://github.com/eggjs/security/pull/107) |


### PR DESCRIPTION
## Summary

Add a Security Acknowledgements section to `SECURITY.md` and credit Y4tacker for responsibly reporting the command injection vulnerability in `@eggjs/security`'s `escapeShellArg` helper.

## References

- 4.x fix: https://github.com/eggjs/security/pull/106
- 3.x fix: https://github.com/eggjs/security/pull/107

## Validation

Documentation-only change; verified the acknowledgement and fix links in the rendered Markdown structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Security Acknowledgements section recognizing a researcher for responsibly reporting a command injection issue.
  * Included references to the relevant fixes across supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->