### PR TITLE
fix: update setup-utoo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup utoo
-        uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # main
+        uses: utooland/setup-utoo@e7aa4d726a17f79f68aed736476ea5bd68f8ba52 # main
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
@@ -174,7 +174,7 @@ jobs:
           & mysql -uroot -e "CREATE DATABASE IF NOT EXISTS test;"
 
       - name: Setup utoo
-        uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # main
+        uses: utooland/setup-utoo@e7aa4d726a17f79f68aed736476ea5bd68f8ba52 # main
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
@@ -268,7 +268,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup utoo
-        uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # main
+        uses: utooland/setup-utoo@e7aa4d726a17f79f68aed736476ea5bd68f8ba52 # main
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
@@ -349,7 +349,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Setup utoo
-        uses: utooland/setup-utoo@3a51006d0b66afcc32d1b9177a4b200b74f4a8cb # main
+        uses: utooland/setup-utoo@e7aa4d726a17f79f68aed736476ea5bd68f8ba52 # main
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6


### PR DESCRIPTION
## Summary

- update all CI `utooland/setup-utoo` pins to `e7aa4d726a17f79f68aed736476ea5bd68f8ba52`
- pick up the setup-utoo fix that caches Windows npm command shims and validates the restored `utoo` command

## Why

The previous pinned setup-utoo commit could restore a Windows utoo cache that contained the package metadata but missed the npm-generated `ut`/`utoo` command shims. That let the action report a cache hit, then the next CI step failed with `ut is not recognized`.

The newer setup-utoo commit moves the cache key/schema forward, includes Windows shim extensions, and verifies `utoo --version` before accepting a restored cache.

## Validation

- `git diff --check`

No project tests were run because this only updates a GitHub Actions pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the revision used by automated validation workflows to improve consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->