### PR TITLE
fix(cluster): harden worker thread lifecycle

### DIFF
--- a/packages/cluster/src/utils/mode/impl/worker_threads/agent.ts
+++ b/packages/cluster/src/utils/mode/impl/worker_threads/agent.ts
@@ -1,6 +1,9 @@
+import { once } from 'node:events';
+import { setTimeout as sleep } from 'node:timers/promises';
 import workerThreads, { type Worker } from 'node:worker_threads';
 
 import { ClusterAgentWorkerError } from '../../../../error/ClusterAgentWorkerError.ts';
+import { WORKER_THREAD_GRACEFUL_EXIT } from '../../../../worker_protocol/worker-thread.ts';
 import type { MessageBody } from '../../../messenger.ts';
 import { BaseAgentUtils, BaseAgentWorker } from '../../base/agent.ts';
 
@@ -69,11 +72,19 @@ export class AgentThreadUtils extends BaseAgentUtils {
     this.#worker.removeAllListeners();
   }
 
-  async kill(): Promise<void> {
+  async kill(timeout: number): Promise<void> {
     if (this.#worker) {
-      this.log(`[master] kill agent worker#${this.#id} (worker_threads) by worker.terminate()`);
+      this.log(`[master] gracefully close agent worker#${this.#id} (worker_threads)`);
       this.clean();
-      await this.#worker.terminate();
+      const exited = once(this.#worker, 'exit').then(
+        () => true,
+        () => false,
+      );
+      this.#worker.postMessage(WORKER_THREAD_GRACEFUL_EXIT);
+      if (!(await Promise.race([exited, sleep(timeout).then(() => false)]))) {
+        this.log(`[master] terminate agent worker#${this.#id} after ${timeout}ms timeout`);
+        await this.#worker.terminate();
+      }
     }
   }
 }

--- a/packages/cluster/src/utils/mode/impl/worker_threads/agent.ts
+++ b/packages/cluster/src/utils/mode/impl/worker_threads/agent.ts
@@ -78,7 +78,10 @@ export class AgentThreadUtils extends BaseAgentUtils {
       this.clean();
       const exited = once(this.#worker, 'exit').then(
         () => true,
-        () => false,
+        (err) => {
+          this.logger.error('[master] agent worker#%s error during graceful shutdown: ', this.#id, err);
+          return false;
+        },
       );
       this.#worker.postMessage(WORKER_THREAD_GRACEFUL_EXIT);
       if (!(await Promise.race([exited, sleep(timeout).then(() => false)]))) {

--- a/packages/cluster/src/utils/mode/impl/worker_threads/app.ts
+++ b/packages/cluster/src/utils/mode/impl/worker_threads/app.ts
@@ -1,6 +1,8 @@
+import { once } from 'node:events';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { Worker as ThreadWorker, type WorkerOptions } from 'node:worker_threads';
 
+import { WORKER_THREAD_GRACEFUL_EXIT } from '../../../../worker_protocol/worker-thread.ts';
 import type { MessageBody } from '../../../messenger.ts';
 import { BaseAppWorker, BaseAppUtils } from '../../base/app.ts';
 
@@ -139,12 +141,22 @@ export class AppThreadUtils extends BaseAppUtils {
     return this;
   }
 
-  async kill(): Promise<void> {
-    for (const worker of this.#workers) {
-      const id = Reflect.get(worker, 'id');
-      this.log(`[master] kill app worker#${id} (worker_threads) by worker.terminate()`);
-      worker.removeAllListeners();
-      worker.terminate();
-    }
+  async kill(timeout: number): Promise<void> {
+    await Promise.all(
+      this.#workers.map(async (worker) => {
+        const id = Reflect.get(worker, 'id');
+        this.log(`[master] gracefully close app worker#${id} (worker_threads)`);
+        worker.removeAllListeners();
+        const exited = once(worker, 'exit').then(
+          () => true,
+          () => false,
+        );
+        worker.postMessage(WORKER_THREAD_GRACEFUL_EXIT);
+        if (!(await Promise.race([exited, sleep(timeout).then(() => false)]))) {
+          this.log(`[master] terminate app worker#${id} after ${timeout}ms timeout`);
+          await worker.terminate();
+        }
+      }),
+    );
   }
 }

--- a/packages/cluster/src/utils/mode/impl/worker_threads/app.ts
+++ b/packages/cluster/src/utils/mode/impl/worker_threads/app.ts
@@ -50,15 +50,15 @@ export class AppThreadWorker extends BaseAppWorker<ThreadWorker> {
 }
 
 export class AppThreadUtils extends BaseAppUtils {
-  #workers: ThreadWorker[] = [];
+  #workers: AppThreadWorker[] = [];
 
   #forkSingle(appPath: string, options: WorkerOptions, id: number): void {
     // start app worker
     const worker = new ThreadWorker(appPath, options);
-    this.#workers.push(worker);
 
     // wrap app worker
     const appWorker = new AppThreadWorker(worker, id);
+    this.#workers.push(appWorker);
     this.emit('worker_forked', appWorker);
     appWorker.disableRefork = true;
     worker.on('message', (msg: MessageBody) => {
@@ -143,8 +143,8 @@ export class AppThreadUtils extends BaseAppUtils {
 
   async kill(timeout: number): Promise<void> {
     await Promise.all(
-      this.#workers.map(async (worker) => {
-        const id = Reflect.get(worker, 'id');
+      this.#workers.map(async (appWorker) => {
+        const { id, instance: worker } = appWorker;
         this.log(`[master] gracefully close app worker#${id} (worker_threads)`);
         worker.removeAllListeners();
         const exited = once(worker, 'exit').then(

--- a/packages/cluster/src/utils/mode/impl/worker_threads/app.ts
+++ b/packages/cluster/src/utils/mode/impl/worker_threads/app.ts
@@ -149,7 +149,10 @@ export class AppThreadUtils extends BaseAppUtils {
         worker.removeAllListeners();
         const exited = once(worker, 'exit').then(
           () => true,
-          () => false,
+          (err) => {
+            this.logger.error('[master] app worker#%s error during graceful shutdown: ', id, err);
+            return false;
+          },
         );
         worker.postMessage(WORKER_THREAD_GRACEFUL_EXIT);
         if (!(await Promise.race([exited, sleep(timeout).then(() => false)]))) {

--- a/packages/cluster/src/utils/options.ts
+++ b/packages/cluster/src/utils/options.ts
@@ -202,6 +202,11 @@ export async function parseOptions(options?: ClusterOptions): Promise<ParsedClus
     assert(fs.existsSync(options[optionName]), `options.${optionName} file should exist: ${options[optionName]}`);
     assert(options.startMode !== 'worker_threads', `options.${optionName} only supports startMode "process"`);
   }
+  assert(
+    !(options.sticky && options.startMode === 'worker_threads'),
+    'options.sticky only supports startMode "process"',
+  );
+
   // don't print deprecated message in production env.
   // it will print to stderr.
   if (process.env.NODE_ENV === 'production') {

--- a/packages/cluster/src/worker_protocol/app.ts
+++ b/packages/cluster/src/worker_protocol/app.ts
@@ -77,6 +77,10 @@ export function startAppWorker(
       ...clusterConfig.https,
       ...options.https,
     };
+    // A master-level port of 0 means that the application listen config still
+    // decides the worker port. This is required by reusePort workers, which
+    // must all bind the same configured port rather than separate ephemeral
+    // ports.
     const port = (app.options.port = options.port || listenConfig.port);
     const debugPort = options.debugPort;
     const protocol = httpsOptions.key && httpsOptions.cert ? 'https' : 'http';

--- a/packages/cluster/src/worker_protocol/worker-thread.ts
+++ b/packages/cluster/src/worker_protocol/worker-thread.ts
@@ -5,6 +5,8 @@ import type { Options as GracefulExitOptions } from 'graceful-process';
 import type { MessageBody } from '../utils/messenger.ts';
 import type { AppWorkerIO } from './app.ts';
 
+export const WORKER_THREAD_GRACEFUL_EXIT = '@eggjs/cluster:graceful-exit';
+
 /**
  * Worker-thread-backed transport shared by the standard worker entries and
  * generated bundle entries.
@@ -30,11 +32,19 @@ export function createWorkerThreadIO(): AppWorkerIO {
     },
     gracefulExit(options: GracefulExitOptions): void {
       const { beforeExit } = options;
-      process.on('exit', async (code) => {
-        if (typeof beforeExit === 'function') {
-          await beforeExit();
+      let closing = false;
+      port.on('message', async (message: unknown) => {
+        if (message !== WORKER_THREAD_GRACEFUL_EXIT || closing) return;
+        closing = true;
+        try {
+          if (typeof beforeExit === 'function') {
+            await beforeExit();
+          }
+          process.exit(0);
+        } catch (err) {
+          options.logger?.error('[worker_thread] graceful exit failed: %s', err);
+          process.exit(1);
         }
-        process.exit(code);
       });
     },
   };

--- a/packages/cluster/src/worker_protocol/worker-thread.ts
+++ b/packages/cluster/src/worker_protocol/worker-thread.ts
@@ -42,7 +42,7 @@ export function createWorkerThreadIO(): AppWorkerIO {
           }
           process.exit(0);
         } catch (err) {
-          options.logger?.error('[worker_thread] graceful exit failed: %s', err);
+          options.logger?.error('[worker_thread] graceful exit failed:', err);
           process.exit(1);
         }
       });

--- a/packages/cluster/test/fixtures/worker-thread-io.mjs
+++ b/packages/cluster/test/fixtures/worker-thread-io.mjs
@@ -8,4 +8,11 @@ io.on('message', (message) => {
   }
 });
 
+io.gracefulExit({
+  async beforeExit() {
+    await Promise.resolve();
+    io.send({ action: 'closed' });
+  },
+});
+
 io.send({ action: 'ready' });

--- a/packages/cluster/test/options.test.ts
+++ b/packages/cluster/test/options.test.ts
@@ -209,6 +209,13 @@ describe('test/options.test.ts', () => {
         assert.equal(options[optionName], undefined);
       });
     }
+
+    it('should reject sticky mode with worker_threads', async () => {
+      await assert.rejects(
+        parseOptions({ baseDir, sticky: true, startMode: 'worker_threads' }),
+        /options\.sticky only supports startMode "process"/,
+      );
+    });
   });
 
   // TODO: flaky test on windows, Hook timed out in 20000ms

--- a/packages/cluster/test/worker-protocol-io.test.ts
+++ b/packages/cluster/test/worker-protocol-io.test.ts
@@ -125,14 +125,15 @@ describe('test/worker-protocol-io.test.ts', () => {
   it('exits a worker thread with code 1 when graceful cleanup fails', async () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
     const logger = { error: vi.fn() };
+    const closeError = new Error('close failed');
     const io = createWorkerThreadIO();
-    io.gracefulExit({ beforeExit: () => Promise.reject(new Error('close failed')), logger } as any);
+    io.gracefulExit({ beforeExit: () => Promise.reject(closeError), logger } as any);
     const gracefulListener = mocks.parentPort!.on.mock.calls[0][1] as (message: unknown) => Promise<void>;
 
     await gracefulListener(WORKER_THREAD_GRACEFUL_EXIT);
 
     assert.deepEqual(exit.mock.calls, [[1]]);
-    assert.equal(logger.error.mock.calls.length, 1);
+    assert.deepEqual(logger.error.mock.calls, [['[worker_thread] graceful exit failed:', closeError]]);
   });
 
   it('rejects worker-thread IO outside a worker', () => {

--- a/packages/cluster/test/worker-protocol-io.test.ts
+++ b/packages/cluster/test/worker-protocol-io.test.ts
@@ -24,7 +24,7 @@ vi.mock('node:worker_threads', async (importOriginal) => ({
 }));
 
 import { createProcessWorkerIO } from '../src/worker_protocol/process.ts';
-import { createWorkerThreadIO } from '../src/worker_protocol/worker-thread.ts';
+import { createWorkerThreadIO, WORKER_THREAD_GRACEFUL_EXIT } from '../src/worker_protocol/worker-thread.ts';
 
 describe('test/worker-protocol-io.test.ts', () => {
   const originalSendDescriptor = Object.getOwnPropertyDescriptor(process, 'send');
@@ -90,7 +90,7 @@ describe('test/worker-protocol-io.test.ts', () => {
     assert.equal(processSend.mock.calls.length, 0);
   });
 
-  it('adapts worker-thread messaging, events, and kill', () => {
+  it('adapts worker-thread messaging, events, kill, and graceful exit', async () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
     const io = createWorkerThreadIO();
 
@@ -106,6 +106,33 @@ describe('test/worker-protocol-io.test.ts', () => {
 
     io.kill();
     assert.deepEqual(exit.mock.calls, [[1]]);
+
+    const beforeExit = vi.fn().mockResolvedValue(undefined);
+    io.gracefulExit({ beforeExit } as any);
+    const gracefulListener = mocks.parentPort!.on.mock.calls.at(-1)?.[1] as
+      | ((message: unknown) => Promise<void>)
+      | undefined;
+    assert.ok(gracefulListener);
+    await gracefulListener('unrelated-message');
+    assert.equal(beforeExit.mock.calls.length, 0);
+    await gracefulListener(WORKER_THREAD_GRACEFUL_EXIT);
+    assert.equal(beforeExit.mock.calls.length, 1);
+    assert.deepEqual(exit.mock.calls, [[1], [0]]);
+    await gracefulListener(WORKER_THREAD_GRACEFUL_EXIT);
+    assert.equal(beforeExit.mock.calls.length, 1);
+  });
+
+  it('exits a worker thread with code 1 when graceful cleanup fails', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const logger = { error: vi.fn() };
+    const io = createWorkerThreadIO();
+    io.gracefulExit({ beforeExit: () => Promise.reject(new Error('close failed')), logger } as any);
+    const gracefulListener = mocks.parentPort!.on.mock.calls[0][1] as (message: unknown) => Promise<void>;
+
+    await gracefulListener(WORKER_THREAD_GRACEFUL_EXIT);
+
+    assert.deepEqual(exit.mock.calls, [[1]]);
+    assert.equal(logger.error.mock.calls.length, 1);
   });
 
   it('rejects worker-thread IO outside a worker', () => {

--- a/packages/cluster/test/worker-protocol.test.ts
+++ b/packages/cluster/test/worker-protocol.test.ts
@@ -8,6 +8,7 @@ import { describe, it, vi } from 'vitest';
 
 import { startAgentWorker } from '../src/worker_protocol/agent.ts';
 import { startAppWorker } from '../src/worker_protocol/app.ts';
+import { WORKER_THREAD_GRACEFUL_EXIT } from '../src/worker_protocol/worker-thread.ts';
 
 vi.mock('node:http', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:http')>();
@@ -47,6 +48,19 @@ describe('test/worker-protocol.test.ts', () => {
     worker.postMessage('kill');
     const [exitCode] = await once(worker, 'exit');
     assert.equal(exitCode, 1);
+  });
+
+  it('awaits worker-thread cleanup before exiting', async () => {
+    const worker = new Worker(new URL('./fixtures/worker-thread-io.mjs', import.meta.url));
+    await once(worker, 'message');
+
+    const exitPromise = once(worker, 'exit');
+    worker.postMessage(WORKER_THREAD_GRACEFUL_EXIT);
+    const [message] = await once(worker, 'message');
+    const [exitCode] = await exitPromise;
+
+    assert.equal(message.action, 'closed');
+    assert.equal(exitCode, 0);
   });
 
   it('removes the startup error listener from an already-ready agent', () => {

--- a/packages/cluster/test/worker-protocol.test.ts
+++ b/packages/cluster/test/worker-protocol.test.ts
@@ -156,6 +156,43 @@ describe('test/worker-protocol.test.ts', () => {
     });
   });
 
+  it('uses the configured port when the master port is zero', async () => {
+    const app = new EventEmitter() as any;
+    app.config = { cluster: { listen: { port: 7001 } } };
+    app.options = {};
+    app.ready = (callback: (err?: Error) => void) => callback();
+    app.callback = () => (_request: unknown, response: { end(): void }) => response.end();
+    app.close = () => {};
+
+    let server: Server | undefined;
+    app.once('server', (value: Server) => {
+      server = value;
+    });
+    const messages: any[] = [];
+    startAppWorker(
+      app,
+      { port: 0 },
+      {
+        workerId: 1,
+        send(message) {
+          messages.push(message);
+        },
+        kill() {
+          assert.fail('configured-port app should not be killed');
+        },
+        gracefulExit() {},
+        on() {},
+      },
+    );
+    await Promise.resolve();
+
+    assert.equal(app.options.port, 7001);
+    assert.equal(messages[0].action, 'realport');
+    assert.equal(messages[0].data.port, 7001);
+    assert.ok(server);
+    server.close();
+  });
+
   it('kills an app that fails or times out during startup', () => {
     const readyError = new Error('app start failed');
     const failedApp = new EventEmitter() as any;
@@ -256,7 +293,7 @@ describe('test/worker-protocol.test.ts', () => {
   it('reports reusePort startup to the master', async () => {
     vi.spyOn(os, 'platform').mockReturnValue('linux');
     const app = new EventEmitter() as any;
-    app.config = { cluster: { listen: { port: 7001, reusePort: true } } };
+    app.config = { cluster: { listen: { port: 7001, hostname: '127.0.0.1', reusePort: true } } };
     app.options = {};
     app.ready = (callback: (err?: Error) => void) => callback();
     app.callback = () => (_request: unknown, response: { end(): void }) => response.end();
@@ -354,6 +391,42 @@ describe('test/worker-protocol.test.ts', () => {
     assert.equal(kill.mock.calls.length, 1);
     assert.equal(logger.error.mock.calls.length, 1);
     assert.match(logger.error.mock.calls[0][0], /port should be number/);
+  });
+
+  it('kills an app when a path-listening server emits an error', () => {
+    const app = new EventEmitter() as any;
+    app.config = { cluster: { listen: { path: '/tmp/egg-worker-protocol.sock' } } };
+    app.options = {};
+    app.ready = (callback: (err?: Error) => void) => callback();
+    app.callback = () => (_request: unknown, response: { end(): void }) => response.end();
+    app.close = () => {};
+
+    let server: Server | undefined;
+    app.once('server', (value: Server) => {
+      server = value;
+    });
+    const kill = vi.fn();
+    const logger = { error: vi.fn() } as any;
+    startAppWorker(
+      app,
+      {},
+      {
+        workerId: 1,
+        send() {},
+        kill,
+        gracefulExit() {},
+        on() {},
+      },
+      logger,
+    );
+
+    assert.ok(server);
+    server.emit('error', Object.assign(new Error('listen failed'), { code: 'EADDRINUSE' }));
+    assert.equal(kill.mock.calls.length, 1);
+    assert.deepEqual(logger.error.mock.calls, [
+      ['[app_worker] server got error: %s, code: %s', 'listen failed', 'EADDRINUSE'],
+    ]);
+    server.close();
   });
 
   it('closes the app during graceful exit', () => {

--- a/packages/cluster/test/worker-thread-utils.test.ts
+++ b/packages/cluster/test/worker-thread-utils.test.ts
@@ -105,6 +105,13 @@ describe('test/worker-thread-utils.test.ts', () => {
       assert.deepEqual(worker.postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
       assert.equal(worker.terminate.mock.calls.length, 0);
     }
+    const shutdownLogs = dependencies.log.mock.calls
+      .map(([message]) => message)
+      .filter((message) => String(message).includes('gracefully close app worker'));
+    assert.deepEqual(shutdownLogs, [
+      '[master] gracefully close app worker#1 (worker_threads)',
+      '[master] gracefully close app worker#2 (worker_threads)',
+    ]);
   });
 
   it('terminates every app worker after the graceful-exit timeout', async () => {

--- a/packages/cluster/test/worker-thread-utils.test.ts
+++ b/packages/cluster/test/worker-thread-utils.test.ts
@@ -1,0 +1,110 @@
+import { strict as assert } from 'node:assert';
+
+import { beforeEach, describe, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  exitOnGracefulMessage: true,
+  nextThreadId: 1,
+  workers: [] as Array<{
+    postMessage: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock('node:worker_threads', async () => {
+  const { EventEmitter } = await import('node:events');
+
+  class Worker extends EventEmitter {
+    threadId = mocks.nextThreadId++;
+    postMessage = vi.fn(() => {
+      if (mocks.exitOnGracefulMessage) {
+        this.emit('exit', 0);
+      }
+    });
+    terminate = vi.fn().mockResolvedValue(0);
+
+    constructor() {
+      super();
+      mocks.workers.push(this);
+    }
+  }
+
+  return {
+    default: { Worker },
+    Worker,
+  };
+});
+
+import { AgentThreadUtils } from '../src/utils/mode/impl/worker_threads/agent.ts';
+import { AppThreadUtils } from '../src/utils/mode/impl/worker_threads/app.ts';
+import { WORKER_THREAD_GRACEFUL_EXIT } from '../src/worker_protocol/worker-thread.ts';
+
+describe('test/worker-thread-utils.test.ts', () => {
+  const dependencies = {
+    isProduction: false,
+    log: vi.fn(),
+    logger: { error: vi.fn() },
+    messenger: { send: vi.fn() },
+  };
+
+  beforeEach(() => {
+    mocks.exitOnGracefulMessage = true;
+    mocks.nextThreadId = 1;
+    mocks.workers.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('lets the agent worker exit gracefully before the timeout', async () => {
+    const utils = new AgentThreadUtils({ agentWorkerFile: 'agent.js' } as any, dependencies as any);
+    utils.fork();
+
+    await utils.kill(10);
+
+    assert.deepEqual(mocks.workers[0].postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
+    assert.equal(mocks.workers[0].terminate.mock.calls.length, 0);
+  });
+
+  it('terminates the agent worker after the graceful-exit timeout', async () => {
+    mocks.exitOnGracefulMessage = false;
+    const utils = new AgentThreadUtils({ agentWorkerFile: 'agent.js' } as any, dependencies as any);
+    utils.fork();
+
+    await utils.kill(0);
+
+    assert.deepEqual(mocks.workers[0].postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
+    assert.equal(mocks.workers[0].terminate.mock.calls.length, 1);
+  });
+
+  it('lets every app worker exit gracefully before the timeout', async () => {
+    const utils = new AppThreadUtils(
+      { appWorkerFile: 'app.js', port: 7001, reusePort: true, workers: 2 } as any,
+      dependencies as any,
+    );
+    utils.fork();
+
+    await utils.kill(10);
+
+    assert.equal(mocks.workers.length, 2);
+    for (const worker of mocks.workers) {
+      assert.deepEqual(worker.postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
+      assert.equal(worker.terminate.mock.calls.length, 0);
+    }
+  });
+
+  it('terminates every app worker after the graceful-exit timeout', async () => {
+    mocks.exitOnGracefulMessage = false;
+    const utils = new AppThreadUtils(
+      { appWorkerFile: 'app.js', port: 7001, reusePort: true, workers: 2 } as any,
+      dependencies as any,
+    );
+    utils.fork();
+
+    await utils.kill(0);
+
+    assert.equal(mocks.workers.length, 2);
+    for (const worker of mocks.workers) {
+      assert.deepEqual(worker.postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
+      assert.equal(worker.terminate.mock.calls.length, 1);
+    }
+  });
+});

--- a/packages/cluster/test/worker-thread-utils.test.ts
+++ b/packages/cluster/test/worker-thread-utils.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 import { beforeEach, describe, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+  errorOnGracefulMessage: false,
   exitOnGracefulMessage: true,
   nextThreadId: 1,
   workers: [] as Array<{
@@ -17,7 +18,9 @@ vi.mock('node:worker_threads', async () => {
   class Worker extends EventEmitter {
     threadId = mocks.nextThreadId++;
     postMessage = vi.fn(() => {
-      if (mocks.exitOnGracefulMessage) {
+      if (mocks.errorOnGracefulMessage) {
+        this.emit('error', new Error('graceful shutdown failed'));
+      } else if (mocks.exitOnGracefulMessage) {
         this.emit('exit', 0);
       }
     });
@@ -48,6 +51,7 @@ describe('test/worker-thread-utils.test.ts', () => {
   };
 
   beforeEach(() => {
+    mocks.errorOnGracefulMessage = false;
     mocks.exitOnGracefulMessage = true;
     mocks.nextThreadId = 1;
     mocks.workers.length = 0;
@@ -73,6 +77,18 @@ describe('test/worker-thread-utils.test.ts', () => {
 
     assert.deepEqual(mocks.workers[0].postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
     assert.equal(mocks.workers[0].terminate.mock.calls.length, 1);
+  });
+
+  it('logs and terminates when the agent worker errors during graceful exit', async () => {
+    mocks.errorOnGracefulMessage = true;
+    const utils = new AgentThreadUtils({ agentWorkerFile: 'agent.js' } as any, dependencies as any);
+    utils.fork();
+
+    await utils.kill(10);
+
+    assert.equal(mocks.workers[0].terminate.mock.calls.length, 1);
+    assert.equal(dependencies.logger.error.mock.calls.length, 1);
+    assert.match(String(dependencies.logger.error.mock.calls[0].at(-1)), /graceful shutdown failed/);
   });
 
   it('lets every app worker exit gracefully before the timeout', async () => {
@@ -105,6 +121,25 @@ describe('test/worker-thread-utils.test.ts', () => {
     for (const worker of mocks.workers) {
       assert.deepEqual(worker.postMessage.mock.calls, [[WORKER_THREAD_GRACEFUL_EXIT]]);
       assert.equal(worker.terminate.mock.calls.length, 1);
+    }
+  });
+
+  it('logs and terminates when app workers error during graceful exit', async () => {
+    mocks.errorOnGracefulMessage = true;
+    const utils = new AppThreadUtils(
+      { appWorkerFile: 'app.js', port: 7001, reusePort: true, workers: 2 } as any,
+      dependencies as any,
+    );
+    utils.fork();
+
+    await utils.kill(10);
+
+    assert.equal(dependencies.logger.error.mock.calls.length, 2);
+    for (const worker of mocks.workers) {
+      assert.equal(worker.terminate.mock.calls.length, 1);
+    }
+    for (const call of dependencies.logger.error.mock.calls) {
+      assert.match(String(call.at(-1)), /graceful shutdown failed/);
     }
   });
 });

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -24,7 +24,7 @@ Dates use the workspace-local Asia/Shanghai calendar date.
 
 - sources touched: `packages/cluster/src/{worker_protocol,utils/mode}`, `tools/egg-bin/src/commands/snapshot.ts`, `tools/scripts/src/commands/start.ts`, `tools/egg-bundler/src/lib/prelude.ts`, related tests and user docs
 - pages updated: `wiki/log.md`, `wiki/packages/egg-bundler.md`
-- note: Blank worker paths normalize before launch. Snapshot builds reject colliding role blob paths, remove stale outputs before validating the current build, and reject bootstrap modules that would otherwise be silently ignored. Lazy-external call-result proxies now memoize their first resolved object so mutations persist after restore.
+- note: Worker-thread shutdown now uses an explicit master-to-worker close message and awaits app/agent cleanup before falling back to termination. Invalid sticky/thread combinations and blank worker paths fail or normalize before launch. Snapshot builds reject colliding role blob paths, remove stale outputs before validating the current build, and reject bootstrap modules that would otherwise be silently ignored. Lazy-external call-result proxies now memoize their first resolved object so mutations persist after restore.
 
 ## [2026-08-03] fix | preserve authoritative manifest discovery in Tegg loaders
 

--- a/wiki/packages/egg-bundler.md
+++ b/wiki/packages/egg-bundler.md
@@ -102,7 +102,11 @@ constraint is why worker output always needs a thin ESM wrapper.
   self-contained, so no common runtime chunk is emitted between the two files.
   Custom V8 snapshot blobs remain process-only because Node does not expose a
   per-Worker snapshot-blob API; option parsing rejects that combination before
-  creating a worker thread.
+  creating a worker thread. Sticky-session mode is also process-only because its
+  socket handoff uses process IPC. Worker-thread shutdown is an explicit protocol:
+  the master requests graceful exit, the worker awaits `app.close()` or
+  `agent.close()`, and the master falls back to `Worker.terminate()` after the
+  configured close timeout.
 - `egg-bin bundle --cluster` is the ordinary cluster-bundle producer. It selects
   the bundler's `cluster` target and writes `app_worker.js`, `agent_worker.js`,
   and the bundle manifest without constructing snapshot blobs. Its output can


### PR DESCRIPTION
## Summary

Hardens the `worker_threads` cluster lifecycle on top of the bundle and startup-snapshot support merged in #6042:

- add an explicit master-to-worker graceful-exit message instead of attempting asynchronous cleanup from the worker `exit` event;
- wait for app/agent cleanup and fall back to `Worker.terminate()` after the configured timeout;
- consume and log worker `error` events during graceful shutdown, then continue with the termination fallback without exposing an unhandled EventEmitter error;
- reject `sticky: true` with `startMode: worker_threads`, because sticky socket handoff requires process IPC;
- preserve the existing master-port and `reusePort` listen semantics, with focused server-error and hostname regression coverage.

## Why

A worker thread's `exit` event is emitted after the thread has already stopped, so cleanup cannot reliably be initiated from that event. The new protocol asks the worker to close while it is still alive and keeps forced termination as a bounded fallback.

Sticky mode is rejected explicitly because its socket handoff mechanism is only available to process workers.

## Validation

- `ut run test --workspace @eggjs/cluster -- test/worker-thread-utils.test.ts test/worker-protocol.test.ts test/worker-protocol-io.test.ts` — 24 passed
- `vitest run test/options.test.ts -t 'should reject sticky mode with worker_threads'` — 1 passed
- `ut run typecheck --workspace @eggjs/cluster` — passed

The full cross-platform suite is covered by CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker threads now shut down gracefully, allowing application and agent cleanup to complete before termination.
  * Shutdown automatically falls back to forced termination when the configured timeout is exceeded.
  * Added clear handling and logging for shutdown failures.

* **Bug Fixes**
  * Sticky-session mode now rejects unsupported worker-thread startup configurations.
  * Improved worker port handling when the master port is set to zero.

* **Documentation**
  * Documented worker-thread shutdown behavior and supported startup configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->