### PR TITLE
fix(scripts): use file URL for ESM sourcemap preload

### DIFF
--- a/tools/scripts/src/commands/start.ts
+++ b/tools/scripts/src/commands/start.ts
@@ -2,6 +2,7 @@ import { spawn, type SpawnOptions, type ChildProcess, execFile as _execFile } fr
 import { mkdir, rename, stat, open } from 'node:fs/promises';
 import path from 'node:path';
 import { scheduler } from 'node:timers/promises';
+import { pathToFileURL } from 'node:url';
 import { debuglog, promisify } from 'node:util';
 
 import { getFrameworkPath, importResolve } from '@eggjs/utils';
@@ -308,7 +309,7 @@ export default class Start<T extends typeof Start> extends BaseCommand<T> {
       });
       const sourceMapSupport = path.join(path.dirname(sourceMapSupportPkgPath), 'register.js');
       if (this.isESM) {
-        execArgv.push('--import', sourceMapSupport);
+        execArgv.push('--import', pathToFileURL(sourceMapSupport).href);
       } else {
         execArgv.push('--require', sourceMapSupport);
       }

--- a/tools/scripts/test/start-unit.test.ts
+++ b/tools/scripts/test/start-unit.test.ts
@@ -20,7 +20,7 @@ class TestStart extends (Start as any) {
     return '/fake/framework';
   }
   async getServerBin() {
-    return '/fake/scripts/start-cluster.cjs';
+    return `/fake/scripts/start-cluster.${this.isESM ? 'mjs' : 'cjs'}`;
   }
 }
 
@@ -67,6 +67,34 @@ describe('test/start-unit.test.ts', () => {
     // not a snapshot boot
     expect(args).not.toContain('--snapshot-blob');
     expect(options.env.NODE_ENV).toBe('production');
+  });
+
+  it('preloads source-map-support with a file URL for ESM apps', async () => {
+    const esmBaseDir = path.join(homeDir, 'esm-typescript-app');
+    await fs.mkdir(esmBaseDir);
+    await fs.writeFile(
+      path.join(esmBaseDir, 'package.json'),
+      JSON.stringify({ name: 'esm-typescript-app', type: 'module', egg: { typescript: true } }),
+    );
+    spawnMock.mockImplementation(() => ({
+      once: vi.fn().mockReturnThis(),
+      on: vi.fn().mockReturnThis(),
+      unref: vi.fn(),
+      disconnect: vi.fn(),
+      kill: vi.fn(),
+      pid: 1112,
+    }));
+
+    await TestStart.run(['--workers=1', esmBaseDir]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).toContain('/fake/scripts/start-cluster.mjs');
+    const importIndex = args.indexOf('--import');
+    expect(importIndex).toBeGreaterThan(-1);
+    // A Windows drive path such as D:\app\register.js is parsed as the
+    // unsupported `d:` URL scheme by Node's ESM loader unless it is a file URL.
+    expect(args[importIndex + 1]).toMatch(/^file:/);
   });
 
   it('daemon mode backgrounds once the child reports egg-ready over IPC', async () => {


### PR DESCRIPTION
## Motivation

On Windows, egg-scripts passes the resolved source-map-support path directly to Node.js --import for ESM applications. A drive-letter path such as D:\app\node_modules\source-map-support\register.js is parsed as the unsupported d: URL scheme, causing ERR_UNSUPPORTED_ESM_URL_SCHEME during production startup.

Fixes #6041.

## Changes

- convert the internally resolved source-map-support path to a file URL before passing it to --import
- keep the CommonJS --require path unchanged
- add regression coverage for an ESM application with egg.typescript enabled

## Testing

- cd tools/scripts && ut run test -- test/start-unit.test.ts (3 passed)
- cd tools/scripts && ut run test (24 passed, 38 skipped)
- cd tools/scripts && ut run typecheck
- oxfmt --check on the changed files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed startup for ESM TypeScript applications by ensuring source maps load correctly.
  * ESM applications now launch with the appropriate module format and file URL configuration.
  * CommonJS startup behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->