### PR TITLE
test(egg-bin): prevent dependency install scripts

### DIFF
--- a/tools/egg-bin/README.md
+++ b/tools/egg-bin/README.md
@@ -25,6 +25,9 @@ egg developer tool, base on [oclif](https://oclif.io/).
 npm i @eggjs/bin --save-dev
 ```
 
+`@eggjs/bin` does not define dependency install scripts. You do not need to add
+it to an install-script allowlist.
+
 ## Usage
 
 Add `egg-bin` to `package.json` scripts:

--- a/tools/egg-bin/test/egg-bin.test.ts
+++ b/tools/egg-bin/test/egg-bin.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { describe, it } from 'vitest';
@@ -8,6 +9,13 @@ import { getRootDirname, getFixtures } from './helper.js';
 describe('test/egg-bin.test.ts', () => {
   const eggBin = path.join(getRootDirname(), 'bin/run.js');
   const cwd = getFixtures('test-files-egg-bin');
+
+  it('should not define dependency install scripts', async () => {
+    const pkg = JSON.parse(await fs.readFile(path.join(getRootDirname(), 'package.json'), 'utf8'));
+    for (const name of ['preinstall', 'install', 'postinstall']) {
+      expect(pkg.scripts).not.toHaveProperty(name);
+    }
+  });
 
   describe('global options', () => {
     it('should show version', () => {


### PR DESCRIPTION
`@eggjs/bin` does not define dependency install scripts. This change documents that behavior. It also adds a regression test for `preinstall`, `install`, and `postinstall`.

Package managers do not need an install-script allowlist entry for `@eggjs/bin`.

The focused test and the full `@eggjs/bin` test suite pass.

Closes eggjs/bin#294.
