### PR TITLE
chore: migrate egg-cors into monorepo

### DIFF
--- a/plugins/cors/LICENSE
+++ b/plugins/cors/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Alibaba Group Holding Limited and other contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/cors/README.md
+++ b/plugins/cors/README.md
@@ -1,0 +1,44 @@
+# @eggjs/cors
+
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) plugin for Egg,
+based on [@koa/cors](https://github.com/koajs/cors).
+
+## Install
+
+```bash
+npm install @eggjs/cors
+```
+
+## Usage
+
+```ts
+// config/plugin.ts
+import corsPlugin from '@eggjs/cors';
+
+export default {
+  ...corsPlugin(),
+};
+```
+
+When no custom `origin` is configured, the plugin uses the Security plugin's
+`domainWhiteList`. Without the Security plugin, the request origin is allowed.
+
+## Configuration
+
+All [@koa/cors options](https://github.com/koajs/cors#corsoptions) are supported.
+
+```ts
+// config/config.default.ts
+export default {
+  cors: {
+    origin: 'https://example.com',
+    credentials: true,
+  },
+};
+```
+
+A custom `origin` takes precedence over `security.domainWhiteList`.
+
+## License
+
+[MIT](LICENSE)

--- a/plugins/cors/package.json
+++ b/plugins/cors/package.json
@@ -48,12 +48,12 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@koa/cors": "catalog:"
+    "@koa/cors": "catalog:",
+    "@types/koa__cors": "catalog:"
   },
   "devDependencies": {
     "@eggjs/mock": "workspace:*",
     "@eggjs/tsconfig": "workspace:*",
-    "@types/koa__cors": "catalog:",
     "@types/node": "catalog:",
     "egg": "workspace:*",
     "typescript": "catalog:"

--- a/plugins/cors/package.json
+++ b/plugins/cors/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@eggjs/cors",
+  "version": "4.0.0-beta.26",
+  "description": "CORS plugin for Egg",
+  "keywords": [
+    "cors",
+    "egg",
+    "egg-plugin"
+  ],
+  "homepage": "https://github.com/eggjs/egg/tree/next/plugins/cors",
+  "bugs": {
+    "url": "https://github.com/eggjs/egg/issues"
+  },
+  "license": "MIT",
+  "author": "dead_horse",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eggjs/egg.git",
+    "directory": "plugins/cors"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./app": "./src/app.ts",
+    "./app/middleware/cors": "./src/app/middleware/cors.ts",
+    "./config/config.default": "./src/config/config.default.ts",
+    "./types": "./src/types.ts",
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": "./dist/index.js",
+      "./app": "./dist/app.js",
+      "./app/middleware/cors": "./dist/app/middleware/cors.js",
+      "./config/config.default": "./dist/config/config.default.js",
+      "./types": "./dist/types.js",
+      "./package.json": "./package.json"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@koa/cors": "catalog:"
+  },
+  "devDependencies": {
+    "@eggjs/mock": "workspace:*",
+    "@eggjs/tsconfig": "workspace:*",
+    "@types/koa__cors": "catalog:",
+    "@types/node": "catalog:",
+    "egg": "workspace:*",
+    "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "egg": "workspace:*"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  }
+}

--- a/plugins/cors/src/app.ts
+++ b/plugins/cors/src/app.ts
@@ -1,0 +1,36 @@
+import type { Application, Context, ILifecycleBoot } from 'egg';
+import type { Context as KoaContext } from 'koa';
+
+export default class AppBoot implements ILifecycleBoot {
+  #app: Application;
+
+  constructor(app: Application) {
+    this.#app = app;
+  }
+
+  configWillLoad(): void {
+    const { config } = this.#app;
+    config.coreMiddleware.unshift('cors');
+
+    config.cors.hasCustomOriginHandler = Boolean(config.cors.origin);
+    config.cors.origin ??= function corsOrigin(ctx: KoaContext): string {
+      const origin = ctx.get('origin');
+      if (!origin) return '';
+
+      const eggContext = ctx as unknown as Context;
+      if (typeof eggContext.isSafeDomain !== 'function') return origin;
+
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(origin);
+      } catch {
+        return '';
+      }
+
+      if (eggContext.isSafeDomain(parsedUrl.hostname) || eggContext.isSafeDomain(origin)) {
+        return origin;
+      }
+      return '';
+    };
+  }
+}

--- a/plugins/cors/src/app.ts
+++ b/plugins/cors/src/app.ts
@@ -10,7 +10,11 @@ export default class AppBoot implements ILifecycleBoot {
 
   configWillLoad(): void {
     const { config } = this.#app;
-    config.coreMiddleware.unshift('cors');
+    const coreMiddleware = config.coreMiddleware;
+    for (let index = coreMiddleware.lastIndexOf('cors'); index >= 0; index = coreMiddleware.lastIndexOf('cors')) {
+      coreMiddleware.splice(index, 1);
+    }
+    coreMiddleware.unshift('cors');
 
     config.cors.hasCustomOriginHandler = Boolean(config.cors.origin);
     config.cors.origin ??= function corsOrigin(ctx: KoaContext): string {

--- a/plugins/cors/src/app/middleware/cors.ts
+++ b/plugins/cors/src/app/middleware/cors.ts
@@ -1,0 +1,3 @@
+import cors from '@koa/cors';
+
+export default cors;

--- a/plugins/cors/src/config/config.default.ts
+++ b/plugins/cors/src/config/config.default.ts
@@ -1,0 +1,10 @@
+import type { Options as KoaCorsOptions } from '@koa/cors';
+
+export interface CorsConfig extends KoaCorsOptions {
+  /** Whether the application supplied its own origin handler. */
+  hasCustomOriginHandler?: boolean;
+}
+
+export default {
+  cors: {} as CorsConfig,
+};

--- a/plugins/cors/src/index.ts
+++ b/plugins/cors/src/index.ts
@@ -1,0 +1,14 @@
+import './types.ts';
+import { definePluginFactory, type EggPluginFactory } from 'egg';
+
+/**
+ * CORS plugin.
+ *
+ * @since 4.1.0
+ */
+export default definePluginFactory({
+  name: 'cors',
+  enable: true,
+  path: import.meta.dirname,
+  optionalDependencies: ['security'],
+}) as EggPluginFactory;

--- a/plugins/cors/src/types.ts
+++ b/plugins/cors/src/types.ts
@@ -1,0 +1,7 @@
+import type { CorsConfig } from './config/config.default.ts';
+
+declare module 'egg' {
+  interface EggAppConfig {
+    cors: CorsConfig;
+  }
+}

--- a/plugins/cors/test/cors.test.ts
+++ b/plugins/cors/test/cors.test.ts
@@ -1,0 +1,125 @@
+import { strict as assert } from 'node:assert';
+import path from 'node:path';
+
+import { mm, type MockApplication } from '@eggjs/mock';
+import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
+
+function createApp(name: string): MockApplication {
+  return mm.app({
+    baseDir: path.join(import.meta.dirname, 'fixtures', 'apps', name),
+  });
+}
+
+describe('@eggjs/cors', () => {
+  let app: MockApplication;
+
+  beforeAll(async () => {
+    app = createApp('cors');
+    await app.ready();
+  });
+  afterAll(() => app.close());
+  afterEach(() => mm.restore());
+
+  it('does not set an origin header when the request has no origin', async () => {
+    await app
+      .httpRequest()
+      .get('/')
+      .expect({ foo: 'bar' })
+      .expect((res) => assert.equal(res.headers['access-control-allow-origin'], undefined))
+      .expect(200);
+  });
+
+  it('allows origins in the security domain whitelist', async () => {
+    await app
+      .httpRequest()
+      .get('/')
+      .set('Origin', 'http://test.eggjs.org')
+      .expect('Access-Control-Allow-Origin', 'http://test.eggjs.org')
+      .expect('Access-Control-Allow-Credentials', 'true')
+      .expect(200);
+
+    await app
+      .httpRequest()
+      .get('/')
+      .set('Origin', 'https://b.com:1234')
+      .expect('Access-Control-Allow-Origin', 'https://b.com:1234')
+      .expect(200);
+  });
+
+  it('rejects origins outside the security domain whitelist', async () => {
+    await app
+      .httpRequest()
+      .get('/')
+      .set('Origin', 'http://eggjs.org!.evil.com')
+      .expect((res) => {
+        assert.equal(res.headers['access-control-allow-origin'], undefined);
+        assert.equal(res.headers['access-control-allow-credentials'], undefined);
+      })
+      .expect(200);
+  });
+});
+
+describe('@eggjs/cors with a string origin', () => {
+  let app: MockApplication;
+
+  beforeAll(async () => {
+    app = createApp('cors-origin');
+    await app.ready();
+  });
+  afterAll(() => app.close());
+  afterEach(() => mm.restore());
+
+  it('uses the configured origin instead of the whitelist', async () => {
+    await app
+      .httpRequest()
+      .get('/')
+      .set('Origin', 'http://not-in-the-whitelist.example')
+      .expect('Access-Control-Allow-Origin', 'eggjs.org')
+      .expect('Access-Control-Allow-Credentials', 'true')
+      .expect(200);
+  });
+});
+
+describe('@eggjs/cors with an origin function', () => {
+  let app: MockApplication;
+
+  beforeAll(async () => {
+    app = createApp('cors-origin-function');
+    await app.ready();
+  });
+  afterAll(() => app.close());
+  afterEach(() => mm.restore());
+
+  it('marks and invokes the custom origin handler', async () => {
+    await app.httpRequest().get('/config').expect({ hasCustomOriginHandler: true }).expect(200);
+    await app
+      .httpRequest()
+      .get('/')
+      .set('Origin', 'http://example.com')
+      .expect('Access-Control-Allow-Origin', 'eggjs.org')
+      .expect(200);
+  });
+});
+
+describe('@eggjs/cors private network access', () => {
+  let app: MockApplication;
+
+  beforeAll(async () => {
+    app = createApp('cors-private-network');
+    await app.ready();
+  });
+  afterAll(() => app.close());
+  afterEach(() => mm.restore());
+
+  it('sets the private network header on a preflight request', async () => {
+    await app
+      .httpRequest()
+      .options('/')
+      .set('Origin', 'https://eggjs.org')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Private-Network', 'true')
+      .expect('Access-Control-Allow-Origin', 'https://eggjs.org')
+      .expect('Access-Control-Allow-Private-Network', 'true')
+      .expect(204);
+  });
+});

--- a/plugins/cors/test/cors.test.ts
+++ b/plugins/cors/test/cors.test.ts
@@ -2,7 +2,10 @@ import { strict as assert } from 'node:assert';
 import path from 'node:path';
 
 import { mm, type MockApplication } from '@eggjs/mock';
+import type { Application } from 'egg';
 import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
+
+import AppBoot from '../src/app.ts';
 
 function createApp(name: string): MockApplication {
   return mm.app({
@@ -56,6 +59,22 @@ describe('@eggjs/cors', () => {
         assert.equal(res.headers['access-control-allow-credentials'], undefined);
       })
       .expect(200);
+  });
+});
+
+describe('@eggjs/cors middleware registration', () => {
+  it('moves an existing cors middleware to the front without duplicating it', () => {
+    const coreMiddleware = ['bodyParser', 'cors', 'overrideMethod', 'cors'];
+    const app = {
+      config: {
+        coreMiddleware,
+        cors: {},
+      },
+    } as unknown as Application;
+
+    new AppBoot(app).configWillLoad();
+
+    assert.deepEqual(coreMiddleware, ['cors', 'bodyParser', 'overrideMethod']);
   });
 });
 

--- a/plugins/cors/test/fixtures/apps/cors-origin-function/app/router.js
+++ b/plugins/cors/test/fixtures/apps/cors-origin-function/app/router.js
@@ -1,0 +1,10 @@
+module.exports = (app) => {
+  app.get('/', async (ctx) => {
+    ctx.body = { foo: 'bar' };
+  });
+  app.get('/config', async (ctx) => {
+    ctx.body = {
+      hasCustomOriginHandler: ctx.app.config.cors.hasCustomOriginHandler,
+    };
+  });
+};

--- a/plugins/cors/test/fixtures/apps/cors-origin-function/config/config.default.js
+++ b/plugins/cors/test/fixtures/apps/cors-origin-function/config/config.default.js
@@ -1,0 +1,8 @@
+exports.keys = 'cors-origin-function-test';
+exports.cors = {
+  async origin(ctx) {
+    if (!ctx.get('origin')) return '';
+    return 'eggjs.org';
+  },
+  credentials: true,
+};

--- a/plugins/cors/test/fixtures/apps/cors-origin-function/config/plugin.js
+++ b/plugins/cors/test/fixtures/apps/cors-origin-function/config/plugin.js
@@ -1,0 +1,5 @@
+import corsPlugin from '../../../../../src/index.ts';
+
+module.exports = {
+  ...corsPlugin(),
+};

--- a/plugins/cors/test/fixtures/apps/cors-origin-function/package.json
+++ b/plugins/cors/test/fixtures/apps/cors-origin-function/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "cors-origin-function-test"
+}

--- a/plugins/cors/test/fixtures/apps/cors-origin/app/router.js
+++ b/plugins/cors/test/fixtures/apps/cors-origin/app/router.js
@@ -1,0 +1,5 @@
+module.exports = (app) => {
+  app.get('/', async (ctx) => {
+    ctx.body = { foo: 'bar' };
+  });
+};

--- a/plugins/cors/test/fixtures/apps/cors-origin/config/config.default.js
+++ b/plugins/cors/test/fixtures/apps/cors-origin/config/config.default.js
@@ -1,0 +1,8 @@
+exports.keys = 'cors-origin-test';
+exports.cors = {
+  origin: 'eggjs.org',
+  credentials: true,
+};
+exports.security = {
+  domainWhiteList: ['eggjs-white.org'],
+};

--- a/plugins/cors/test/fixtures/apps/cors-origin/config/plugin.js
+++ b/plugins/cors/test/fixtures/apps/cors-origin/config/plugin.js
@@ -1,0 +1,5 @@
+import corsPlugin from '../../../../../src/index.ts';
+
+module.exports = {
+  ...corsPlugin(),
+};

--- a/plugins/cors/test/fixtures/apps/cors-origin/package.json
+++ b/plugins/cors/test/fixtures/apps/cors-origin/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "cors-origin-test"
+}

--- a/plugins/cors/test/fixtures/apps/cors-private-network/app/router.js
+++ b/plugins/cors/test/fixtures/apps/cors-private-network/app/router.js
@@ -1,0 +1,5 @@
+module.exports = (app) => {
+  app.get('/', async (ctx) => {
+    ctx.body = { foo: 'bar' };
+  });
+};

--- a/plugins/cors/test/fixtures/apps/cors-private-network/config/config.default.js
+++ b/plugins/cors/test/fixtures/apps/cors-private-network/config/config.default.js
@@ -1,0 +1,6 @@
+exports.keys = 'cors-private-network-test';
+exports.cors = { privateNetworkAccess: true };
+exports.security = {
+  csrf: false,
+  domainWhiteList: ['.eggjs.org'],
+};

--- a/plugins/cors/test/fixtures/apps/cors-private-network/config/plugin.js
+++ b/plugins/cors/test/fixtures/apps/cors-private-network/config/plugin.js
@@ -1,0 +1,5 @@
+import corsPlugin from '../../../../../src/index.ts';
+
+module.exports = {
+  ...corsPlugin(),
+};

--- a/plugins/cors/test/fixtures/apps/cors-private-network/package.json
+++ b/plugins/cors/test/fixtures/apps/cors-private-network/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "cors-private-network-test"
+}

--- a/plugins/cors/test/fixtures/apps/cors/app/router.js
+++ b/plugins/cors/test/fixtures/apps/cors/app/router.js
@@ -1,0 +1,5 @@
+module.exports = (app) => {
+  app.get('/', async (ctx) => {
+    ctx.body = { foo: 'bar' };
+  });
+};

--- a/plugins/cors/test/fixtures/apps/cors/config/config.default.js
+++ b/plugins/cors/test/fixtures/apps/cors/config/config.default.js
@@ -1,0 +1,5 @@
+exports.keys = 'cors-test';
+exports.cors = { credentials: true };
+exports.security = {
+  domainWhiteList: ['.eggjs.org', 'https://b.com:1234'],
+};

--- a/plugins/cors/test/fixtures/apps/cors/config/plugin.js
+++ b/plugins/cors/test/fixtures/apps/cors/config/plugin.js
@@ -1,0 +1,5 @@
+import corsPlugin from '../../../../../src/index.ts';
+
+module.exports = {
+  ...corsPlugin(),
+};

--- a/plugins/cors/test/fixtures/apps/cors/package.json
+++ b/plugins/cors/test/fixtures/apps/cors/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "cors-test"
+}

--- a/plugins/cors/tsconfig.json
+++ b/plugins/cors/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/plugins/cors/vitest.config.ts
+++ b/plugins/cors/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineProject } from 'vitest/config';
+
+export default defineProject({});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ packages:
   - tegg/standalone/*
 
 catalog:
+  '@koa/cors': ^5.0.0
   '@clack/prompts': ^0.11.0
   '@eggjs/compressible': ^3.0.0
   '@eggjs/cookies': ^3.1.0
@@ -42,6 +43,7 @@ catalog:
   '@types/js-beautify': ^1.14.3
   '@types/js-yaml': ^4.0.9
   '@types/koa-bodyparser': ^4.3.12
+  '@types/koa__cors': ^5.0.1
   '@types/koa-compose': ^3.2.8
   '@types/koa-range': ^0.3.5
   '@types/lodash': ^4.17.20

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -66,6 +66,9 @@
       "path": "./plugins/jsonp"
     },
     {
+      "path": "./plugins/cors"
+    },
+    {
       "path": "./plugins/watcher"
     },
     {

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -25,6 +25,7 @@ Read this file before exploring raw sources.
 ## Packages
 
 - [Core Package](./packages/core.md) - Loader, lifecycle, and application core primitives used by Egg runtime packages.
+- [CORS Plugin](./packages/cors.md) - Applies @koa/cors with optional Security domain checks.
 - [Egg Bundler](./packages/egg-bundler.md) - Bundles Egg applications for Node startup snapshots and tegg standalone service workers.
 - [Loader FS Package](./packages/loader-fs.md) - Shared loader-facing filesystem boundary for Egg loaders and future bundled runtimes.
 - [Onerror Plugin](./packages/onerror.md) - Default Egg error-handling plugin and configurable response negotiation layer.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -2,6 +2,12 @@
 
 Dates use the workspace-local Asia/Shanghai calendar date.
 
+## [2026-08-27] package | migrate egg-cors into the monorepo
+
+- sources touched: `plugins/cors`
+- pages updated: `wiki/index.md`, `wiki/log.md`, `wiki/packages/cors.md`
+- note: Added the scoped `@eggjs/cors` plugin with the existing Security whitelist fallback, typed @koa/cors configuration, modern plugin metadata, and Vitest coverage.
+
 ## [2026-08-06] fix | restore standalone public dynamic injection
 
 - sources touched: `tegg/standalone/{standalone,service-worker-runtime}`

--- a/wiki/packages/cors.md
+++ b/wiki/packages/cors.md
@@ -1,0 +1,21 @@
+---
+title: CORS Plugin
+type: package
+summary: Egg plugin that applies @koa/cors with optional Security domain checks.
+source_files:
+  - plugins/cors/src/index.ts
+  - plugins/cors/src/app.ts
+  - plugins/cors/src/config/config.default.ts
+updated_at: 2026-08-27
+status: active
+---
+
+# CORS Plugin
+
+`@eggjs/cors` installs `@koa/cors` at the front of Egg's core middleware list.
+Applications can use the full upstream CORS option surface.
+
+When an application does not configure `cors.origin`, the plugin consults the
+optional Security plugin's `ctx.isSafeDomain()` check. If Security is not
+enabled, it permits the request origin. A custom origin string or function
+takes precedence and is recorded by `cors.hasCustomOriginHandler`.


### PR DESCRIPTION
## Summary

- add the scoped @eggjs/cors plugin to the Egg monorepo
- preserve the Security safe-domain fallback and custom origin behavior
- expose the @koa/cors option types and plugin config augmentation
- cover default, custom-origin, rejected-origin, and private-network behavior
- add package documentation and wiki records

Closes #5799

## Validation

- 6 targeted Vitest tests pass
- targeted oxlint and oxfmt checks pass
- package build passes
- git diff --check passes

The repository-wide TypeScript check still reports the existing tegg/plugin/orm AbstractDriver.DataType and unused @ts-expect-error errors; the new CORS files do not add type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `@eggjs/cors` plugin for configurable Cross-Origin Resource Sharing.
  * Supports custom origins, credentials, private network access, and standard CORS options.
  * Automatically validates request origins against the Security domain allowlist when no custom origin is configured.

* **Documentation**
  * Added installation, configuration, licensing, and usage documentation.

* **Tests**
  * Added coverage for origin validation, custom handlers, missing origins, and private network preflight requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->