### PR TITLE
Fix createAnonymousContext query parameter loss

### DIFF
--- a/lib/egg.js
+++ b/lib/egg.js
@@ -1,5 +1,6 @@
 const { performance } = require('perf_hooks');
 const path = require('path');
+const querystring = require('querystring');
 const fs = require('fs');
 const ms = require('ms');
 const http = require('http');
@@ -587,6 +588,16 @@ class EggApplication extends EggCore {
           request[key] = req[key];
         }
       }
+    }
+    // Koa reads querystring from req.url, so normalize mocked query values.
+    if (req && Object.prototype.hasOwnProperty.call(req, 'url')) {
+      // An explicitly supplied URL takes precedence.
+    } else if (request.querystring) {
+      const requestPath = request.path || '/';
+      const separator = requestPath.includes('?') ? '&' : '?';
+      request.url = `${requestPath}${separator}${request.querystring}`;
+    } else if (req && req.query && Object.keys(req.query).length) {
+      request.url = `${request.path || '/'}?${querystring.stringify(req.query)}`;
     }
     const response = new http.ServerResponse(request);
     return this.createContext(request, response);

--- a/test/lib/egg.test.js
+++ b/test/lib/egg.test.js
@@ -481,6 +481,22 @@ describe('test/lib/egg.test.js', () => {
       ctx = app.agent.createAnonymousContext();
       assert(ctx);
     });
+
+    it('should apply mocked querystring and query', () => {
+      let ctx = app.createAnonymousContext({ querystring: 'page=1&size=10' });
+      assert(ctx.url === '/?page=1&size=10');
+      assert.deepEqual(ctx.query, { page: '1', size: '10' });
+
+      ctx = app.createAnonymousContext({ query: { page: 1 } });
+      assert(ctx.url === '/?page=1');
+      assert.deepEqual(ctx.query, { page: '1' });
+    });
+
+    it('should keep an explicitly supplied URL', () => {
+      const ctx = app.createAnonymousContext({ url: '/users?from=url', query: { page: 1 } });
+      assert(ctx.url === '/users?from=url');
+      assert.deepEqual(ctx.query, { from: 'url' });
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`app.createAnonymousContext(req)` documents that callers can mock request values such as `querystring`, but Koa reads the query string from `req.url`. As a result, mocked `query` and `querystring` values were silently ignored.

```js
const ctx = app.createAnonymousContext({ querystring: 'page=1&size=10' });
ctx.query;
// => {}
```

## Fix

Normalize a supplied `querystring` or `query` object into the mocked request URL before creating the context. An explicitly supplied `url` remains authoritative.

## Tests

Added regression coverage for:

- `querystring` values
- `query` object values
- explicit URL precedence

The focused `createAnonymousContext` tests pass with 3 passing cases.
